### PR TITLE
Rename master -> main in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build and Test
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   backend:


### PR DESCRIPTION
Fixes #41 

## Description
Trigger CI job when a PR targets `main` and not `master`


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [X] Bugfix

# Checklist:
_Put an x in the boxes that are fulfilled._

- [X] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
