### PR TITLE
Change license to Apache-2.0

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,13 @@
+Copyright 2020 Equinor ASA
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Witsml Explorer is a data management tool used for browsing and editing data dir
 ## Contributing
 Please see our [contributing.md](/CONTRIBUTING.md).
 
-## License (Soon)
-Witsml Explorer is expected to soon get the Apache 2 License
+## License
+Witsml Explorer has the Apache-2.0 license.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/equinor/witsml-explorer.git"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "workspaces": [
     "Src/WitsmlExplorer.Frontend"
   ],


### PR DESCRIPTION
#Request Template Witsml Explorer
Fixes #8 and #4 

## Description
Update license to Apache-2.0, and run a compatibility check for project dependencies.

Running `npx license-compatibility-checker` ([link](https://github.com/HansHammel/license-compatibility-checker)) gives a list of possible incompatible libraries. Most of them are because the checker is not able to recognize custom text in the licenses, like `(BSD-2-Clause OR MIT OR Apache-2.0)`, but those are in reality OK. One dependency (rework) is listed with  `No license`. But having a closer look at the[ github page](https://github.com/reworkcss/rework) for that project shows that the license is actually `MIT`.

## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Impacted Areas in Application
Change of project license.


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
