### PR TITLE
Fix the issue #105 : Initialize CapabilitiesIn to empty string by default

### DIFF
--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -79,7 +79,8 @@ namespace Witsml
                 {
                     WMLtypeIn = query.TypeName,
                     OptionsIn = optionsIn.GetName(),
-                    QueryIn = XmlHelper.Serialize(query)
+                    QueryIn = XmlHelper.Serialize(query),
+                    CapabilitiesIn = ""
                 };
 
                 var response = await client.WMLS_GetFromStoreAsync(request);


### PR DESCRIPTION
#Request Template Witsml Explorer
Fixes # (105)

## Description
As per teh WITSML 1.4.1.1 API specification, the CapabilitiesIn parameter is marked as a _required_ parameter to WMLS_GetFromStore.

Below are the specification sections discussing the case :
6.1.6: "While all parameters have to be specified in each function, certain parameters MAY be specified with an
empty value to indicate that a value was not given. This case generally applies to the OptionsIn and
CapabilitiesIn parameters but is explicitly documented where applicable."

6.6 : WMLS_GetFromStore Function 
**CapabilitiesIn** : 
- Input string. The client’s Capabilities Object (capClient) to be sent to the server. Formore information, see section 4.2.2, page 28.
- The server MUST interpret an empty string to mean that no value was given.

...


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
All GetFromStore requests.

*


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments
- No change to documentation required
- No new names introduced
