### PR TITLE
[PH] Fix #100 Add dataVersion in GetCap request

### DIFF
--- a/Src/Witsml/ServiceReference/WitsmlService.cs
+++ b/Src/Witsml/ServiceReference/WitsmlService.cs
@@ -204,17 +204,34 @@ namespace Witsml.ServiceReference
     public partial class WMLS_GetCapRequest
     {
         
-        [System.ServiceModel.MessageBodyMemberAttribute(Namespace="", Order=0)]
-        public string OptionsIn;
+        [System.ServiceModel.MessageBodyMemberAttribute(Namespace="", Order=0, Name="OptionsIn")]
+        private string optionsIn;
         
         public WMLS_GetCapRequest()
         {
         }
         
-        public WMLS_GetCapRequest(string OptionsIn)
+        public WMLS_GetCapRequest(string OptionsIn )
         {
-            this.OptionsIn = OptionsIn;
+            this.OptionsIn = OptionsIn ;
         }
+
+        /// <summary>
+        /// Quoting the specification : "'dataVersion' is a required optionsIn parameter to be passed as part of the WMLS_GetCap(). 
+        ///                             Not doing so would result in the server returning a -424- error status code"
+        /// The OptionsIn setter method enforce such rule by adding automatically the "dataVersion" parameter if not provided.
+        /// It is to be noted that the data version is fixed to 1.4.1.1 by default and might need to be passed as argument in future 
+        /// if there is a requirement to support a different WITSML version by default.
+        /// </summary>
+        public string OptionsIn {
+            get { return optionsIn ; }
+            set { 
+                optionsIn = value ;
+                if ( ! optionsIn.Contains ("dataVersion") ) 
+                    optionsIn += ";dataVersion=1.4.1.1" ;
+                }
+        }
+
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]


### PR DESCRIPTION
#Request Template Witsml Explorer
Fixes # (100)

## Description
As per WITSML API specifications, 'dataVersion' is a required optionsIn parameter to be passed as part of the WMLS_GetCap() . Not doing so would result in the server returning a -424- error status code.

In order to be compliant, the WMLS_GetCapRequest as been modified so that a dataVersion attribute is always specified as part of the OptionIns parameter.

By default, the value 'dataVersion=1.4.1.1' is being used, unless the optionsIn parameter used to initialize the WMLS_GetCapRequest already contains a 'dataVersion' attribute value.

In order to do that, the previously public OptionsIn property of teh WMLS_GetCapRequest class has been made private and a property setter/getter be implemented (the setter taking care of providing the default value = 1.4.1.1)

...


## Type of change

- [x] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

*


# Checklist:

- [x] PR is related to an issue
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ x I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments
N/A
