### PR TITLE
Allows bypass ssl cert authn

### DIFF
--- a/Src/Witsml/ServiceReference/WitsmlService.cs
+++ b/Src/Witsml/ServiceReference/WitsmlService.cs
@@ -204,17 +204,34 @@ namespace Witsml.ServiceReference
     public partial class WMLS_GetCapRequest
     {
         
-        [System.ServiceModel.MessageBodyMemberAttribute(Namespace="", Order=0)]
-        public string OptionsIn;
+        [System.ServiceModel.MessageBodyMemberAttribute(Namespace="", Order=0, Name="OptionsIn")]
+        private string optionsIn;
         
         public WMLS_GetCapRequest()
         {
         }
         
-        public WMLS_GetCapRequest(string OptionsIn)
+        public WMLS_GetCapRequest(string OptionsIn )
         {
-            this.OptionsIn = OptionsIn;
+            this.OptionsIn = OptionsIn ;
         }
+
+        /// <summary>
+        /// Quoting the specification : "'dataVersion' is a required optionsIn parameter to be passed as part of the WMLS_GetCap(). 
+        ///                             Not doing so would result in the server returning a -424- error status code"
+        /// The OptionsIn setter method enforce such rule by adding automatically the "dataVersion" parameter if not provided.
+        /// It is to be noted that the data version is fixed to 1.4.1.1 by default and might need to be passed as argument in future 
+        /// if there is a requirement to support a different WITSML version by default.
+        /// </summary>
+        public string OptionsIn {
+            get { return optionsIn ; }
+            set { 
+                optionsIn = value ;
+                if ( ! optionsIn.Contains ("dataVersion") ) 
+                    optionsIn += ";dataVersion=1.4.1.1" ;
+                }
+        }
+
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -64,7 +64,7 @@ namespace WitsmlExplorer.Api.Services
         private async Task VerifyCredentials(Uri serverUrl, Credentials credentials)
         {
             var witsmlClient = new WitsmlClient(serverUrl.ToString(), credentials.Username, credentials.Password,
-                StringHelpers.ToBoolean(configuration["LogQueries"]));
+                StringHelpers.ToBoolean(configuration["LogQueries"]),StringHelpers.ToBoolean(configuration["sslCertAuthN"]));
             await witsmlClient.TestConnectionAsync();
         }
     }

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -39,12 +39,13 @@ namespace WitsmlExplorer.Api.Services
             if (!isEncrypted) return;
 
             var logQueries = StringHelpers.ToBoolean(configuration["LogQueries"]);
-            witsmlClient = new WitsmlClient(serverUrl, credentials[0].Username, credentialsService.Decrypt(credentials[0]), logQueries);
+            var sslCertAuthN = StringHelpers.ToBoolean(configuration["sslCertAuthN"]);
+            witsmlClient = new WitsmlClient(serverUrl, credentials[0].Username, credentialsService.Decrypt(credentials[0]), logQueries, sslCertAuthN);
 
             var sourceServerUrl = headers[WitsmlSourceServerUrlHeader];
 
             if (string.IsNullOrEmpty(sourceServerUrl) && credentials.Count == 1) return;
-            witsmlSourceClient = new WitsmlClient(sourceServerUrl, credentials[1].Username, credentialsService.Decrypt(credentials[1]), logQueries);
+            witsmlSourceClient = new WitsmlClient(sourceServerUrl, credentials[1].Username, credentialsService.Decrypt(credentials[1]), logQueries, sslCertAuthN);
         }
 
         private static List<Credentials> ExtractCredentialsFromHeader(IHeaderDictionary headers)


### PR DESCRIPTION
#Request Template Witsml Explorer
Fixes #189 

## Description
During development it is not uncommon to have to perform integration & regression tests against WITSML development servers. These development servers do not have necessarily a fully CA root certificate.  As WE enforce SSL certificate authenticate, it can't be used against WITSML development servers.

The purpose of teh present PullRequest is to allow such development server to be used as part of WE tests. For that below changes are made:

- Settings : Add support for an extra 'sslCertAuthN' property in teh setting JSON configuration file. By default (if not specified) the SSL certificate authentication is set to TRUE to maintain strong security check. Bypass it is an explicit action developer has to do by modifying his/her mysettings.json file. Example below

{
  "LogQueries": true,
  "AllowedHosts": "*",
  "Host": "http://localhost", 
  "MongoDb": {
    "Name": "witsml-explorer-db",
    "ConnectionString": "mongodb://<user>:<pwd>@localhost"
  },
  "sslCertAuthN" : false
}

- The SSL certificate setting is being passed as initialization parameter when a 'WitsmlClient' is being created.
   If the value is False (e.g. Do not perform SSL certificate authentication) then the verification is bypassed


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* None


# Checklist:
_Put an x in the boxes that are fulfilled._

- [ ] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Further comments

Tested against InterACT production and development servers, and & Kongsberg provided server. Test covering 2 cases : 
- sslCertAuthN set to false --> Can login to allservers
- sslCertAuthN set to true --> Unable to login to development server, can login to InterACT prod & & Kongsberg
- sslCertAuthN not specified in setting file --> Unable login to development server, can login to InterACT & Kongsberg