### PR TITLE
[PH] Ignore  launch settings in Integration tests

### DIFF
--- a/Tests/WitsmlExplorer.IntegrationTests/.gitignore
+++ b/Tests/WitsmlExplorer.IntegrationTests/.gitignore
@@ -1,1 +1,2 @@
 secrets.json
+Properties\launchSettings.json


### PR DESCRIPTION
#Request Template Witsml Explorer
No issue fixed. 

## Description
Add launch setting configuration file in the Git ignore list for integration test. Settings are generally locally customized and not necessarily useful to be shared. launchSettings.json file is only used within the local development machine.



## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application

* None


# Checklist:
_Put an x in the boxes that are fulfilled._

- [ ] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

If later it appears that the settings can be beneficial across different developers, then can look at removing the launchSettings.json from the ignore list and organize the configurations sections.