### PR TITLE
Adding Windows compatible command for running dotnet-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "Src/WitsmlExplorer.Frontend"
   ],
   "scripts": {
-    "dotnet-format": "dotnet-format --check",
-    "dotnet-format:fix": "dotnet-format",
+    "dotnet-format": "dotnet tool run dotnet-format --check",
+    "dotnet-format:fix": "dotnet tool run dotnet-format",
     "eslint": "eslint . --cache",
     "eslint:fix": "eslint . --cache --fix"
   },
   "lint-staged": {
     "*.{cs,vb}": [
-      "dotnet-format --check --include"
+      "dotnet tool run dotnet-format --check --include"
     ],
     "*.{ts,tsx}": [
       "eslint",


### PR DESCRIPTION
#Request Template Witsml Explorer
Fixes # 

## Description
`dotnet-format` is not being run on Windows without going through `dotnet tools run dotnet-format` 
This pull request updates package.json to fix this issue. Other platform can run both commands.

## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
`dotnet toolset`

# Checklist:

- [ ] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments
Configuration change. Documentation will be updated to reflect this.