### PR TITLE
Visualise Active Well and Wellbore

### DIFF
--- a/Src/Witsml/Data/WitsmlWellbore.cs
+++ b/Src/Witsml/Data/WitsmlWellbore.cs
@@ -13,5 +13,7 @@ namespace Witsml.Data
         [XmlElement("purposeWellbore")] public string PurposeWellbore { get; set; }
         [XmlElement("typeWellbore")] public string TypeWellbore { get; set; }
         [XmlElement("commonData")] public WitsmlCommonData CommonData { get; set; }
+        [XmlElement("isActive")] public string IsActive { get; set; }
+
     }
 }

--- a/Src/Witsml/Query/WellboreQueries.cs
+++ b/Src/Witsml/Query/WellboreQueries.cs
@@ -17,7 +17,9 @@ namespace Witsml.Query
                     NameWell = "",
                     TypeWellbore = "",
                     StatusWellbore = "",
+                    IsActive = "",
                     CommonData = new WitsmlCommonData()
+
                 }.AsSingletonList()
             };
         }

--- a/Src/Witsml/Query/WellboreQueries.cs
+++ b/Src/Witsml/Query/WellboreQueries.cs
@@ -19,7 +19,6 @@ namespace Witsml.Query
                     StatusWellbore = "",
                     IsActive = "",
                     CommonData = new WitsmlCommonData()
-
                 }.AsSingletonList()
             };
         }

--- a/Src/WitsmlExplorer.Api/Models/Wellbore.cs
+++ b/Src/WitsmlExplorer.Api/Models/Wellbore.cs
@@ -6,13 +6,14 @@ namespace WitsmlExplorer.Api.Models
     {
         public string Uid { get; set; }
         public string Name { get; set; }
-        public string WellUid { get;set; }
+        public string WellUid { get; set; }
         public string WellName { get; set; }
         public string WellborePurpose { get; set; }
         public string WellboreParentUid { get; set; }
         public string WellboreParentName { get; set; }
         public string WellStatus { get; set; }
         public string WellType { get; set; }
+        public string IsActive { get; set; }
         public DateTime? DateTimeCreation { get; set; }
         public DateTime? DateTimeLastChange { get; set; }
         public string ItemState { get; set; }

--- a/Src/WitsmlExplorer.Api/Services/WellboreService.cs
+++ b/Src/WitsmlExplorer.Api/Services/WellboreService.cs
@@ -58,6 +58,7 @@ namespace WitsmlExplorer.Api.Services
                         WellName = witsmlWellbore.NameWell,
                         WellStatus = witsmlWellbore.StatusWellbore,
                         WellType = witsmlWellbore.TypeWellbore,
+                        IsActive = witsmlWellbore.IsActive,
                         DateTimeLastChange = StringHelpers.ToDateTime(witsmlWellbore.CommonData.DTimLastChange)
                     })
                 .OrderBy(wellbore => wellbore.Name).ToList();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellContextMenu.tsx
@@ -45,6 +45,7 @@ const WellContextMenu = (props: WellContextMenuProps): React.ReactElement => {
       wellName: well.name,
       wellStatus: "",
       wellType: "",
+      isActive: "",
       wellboreParentUid: "",
       wellboreParentName: "",
       wellborePurpose: "unknown"

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -71,6 +71,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
       wellName: wellbore.wellName,
       wellStatus: "",
       wellType: "",
+      isActive: "",
       wellboreParentUid: wellbore.uid,
       wellboreParentName: wellbore.name,
       wellborePurpose: "unknown"

--- a/Src/WitsmlExplorer.Frontend/components/Icons/IsActiveIcon.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Icons/IsActiveIcon.tsx
@@ -1,0 +1,9 @@
+﻿import * as React from "react";
+
+export function IsActiveIcon(): React.ReactElement {
+  return (
+    <>
+      <img src="/assets/icons/trendingUp.svg" alt="Is Active" />
+    </>
+  );
+}

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/TreeItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/TreeItem.tsx
@@ -7,14 +7,16 @@ import { useTheme } from "@material-ui/core/styles";
 import NavigationContext from "../../contexts/navigationContext";
 import { ToggleTreeNodeAction } from "../../contexts/navigationStateReducer";
 import NavigationType from "../../contexts/navigationType";
+import { IsActiveIcon } from "../Icons/IsActiveIcon";
 
 interface StyledTreeItemProps extends TreeItemProps {
   labelText: string;
   selected?: boolean;
+  isActive?: boolean;
 }
 
 const StyledTreeItem = (props: StyledTreeItemProps): React.ReactElement => {
-  const { labelText, selected, ...other } = props; // eslint-disable-line
+  const { labelText, selected, isActive, ...other } = props; // eslint-disable-line
   const { dispatchNavigation } = useContext(NavigationContext);
   const isCompactMode = useTheme().props.MuiCheckbox.size === "small";
 
@@ -28,6 +30,7 @@ const StyledTreeItem = (props: StyledTreeItemProps): React.ReactElement => {
       onIconClick={() => toggleTreeNode(props)}
       label={
         <Label>
+          {isActive && <IsActiveIcon />}
           <NavigationDrawer selected={selected} compactMode={isCompactMode}>
             {labelText}
           </NavigationDrawer>

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
@@ -40,7 +40,7 @@ const WellItem = (props: WellItemProps): React.ReactElement => {
       labelText={well.name}
       nodeId={well.uid}
       onLabelClick={() => onSelectWell(well)}
-      isActive={well.wellbores.some((wellbore) => wellbore.isActive === "true")}
+      isActive={well.wellbores.some((wellbore) => wellbore.isActive === "true" || wellbore.isActive === "1")}
     >
       {well &&
         well.wellbores &&

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
@@ -40,6 +40,7 @@ const WellItem = (props: WellItemProps): React.ReactElement => {
       labelText={well.name}
       nodeId={well.uid}
       onLabelClick={() => onSelectWell(well)}
+      isActive={well.wellbores.some((wellbore) => wellbore.isActive === "true")}
     >
       {well &&
         well.wellbores &&

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -118,6 +118,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
       labelText={wellbore.name}
       onLabelClick={onLabelClick}
       onIconClick={onIconClick}
+      isActive={wellbore.isActive === "true"}
     >
       <TreeItem
         nodeId={logGroupId}

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -118,7 +118,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
       labelText={wellbore.name}
       onLabelClick={onLabelClick}
       onIconClick={onIconClick}
-      isActive={wellbore.isActive === "true"}
+      isActive={wellbore.isActive === "true" || wellbore.isActive === "1"}
     >
       <TreeItem
         nodeId={logGroupId}

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -679,9 +679,9 @@ it("Should collapse child nodes when toggling an expanded parent node", () => {
 
 const SERVER_1 = { id: "1", name: "WITSML server", url: "http://example.com", description: "Witsml server" };
 const SERVER_2 = { id: "2", name: "WITSML server 2", url: "http://example2.com", description: "Witsml server 2" };
-const WELLBORE_1: Wellbore = { uid: "wellbore1", wellUid: "well1", name: "Wellbore 1", logs: [], rigs: [], trajectories: [], wellStatus: "", wellType: "" };
-const WELLBORE_2: Wellbore = { uid: "wellbore2", wellUid: "well2", name: "Wellbore 2", logs: [], rigs: [], trajectories: [], wellStatus: "", wellType: "" };
-const WELLBORE_3: Wellbore = { uid: "wellbore3", wellUid: "well3", name: "Wellbore 3", logs: [], rigs: [], trajectories: [], wellStatus: "", wellType: "" };
+const WELLBORE_1: Wellbore = { uid: "wellbore1", wellUid: "well1", name: "Wellbore 1", logs: [], rigs: [], trajectories: [], wellStatus: "", wellType: "", isActive: "" };
+const WELLBORE_2: Wellbore = { uid: "wellbore2", wellUid: "well2", name: "Wellbore 2", logs: [], rigs: [], trajectories: [], wellStatus: "", wellType: "", isActive: "" };
+const WELLBORE_3: Wellbore = { uid: "wellbore3", wellUid: "well3", name: "Wellbore 3", logs: [], rigs: [], trajectories: [], wellStatus: "", wellType: "", isActive: "" };
 const WELL_1: Well = { uid: "well1", name: "Well 1", wellbores: [WELLBORE_1], field: "", operator: "", country: "" };
 const WELL_2: Well = { uid: "well2", name: "Well 2", wellbores: [WELLBORE_2], field: "", operator: "", country: "" };
 const WELL_3: Well = { uid: "well3", name: "Well 3", wellbores: [WELLBORE_3], field: "", operator: "", country: "" };

--- a/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
@@ -10,6 +10,7 @@ export default interface Wellbore {
   wellName?: string;
   wellStatus: string;
   wellType: string;
+  isActive: string;
   wellboreParentUid?: string;
   wellboreParentName?: string;
   wellborePurpose?: string;
@@ -29,6 +30,7 @@ export function emptyWellbore(): Wellbore {
     wellName: "",
     wellStatus: "",
     wellType: "",
+    isActive: "",
     wellboreParentUid: "",
     wellboreParentName: "",
     wellborePurpose: "unknown",

--- a/Src/WitsmlExplorer.Frontend/public/assets/icons/trendingUp.svg
+++ b/Src/WitsmlExplorer.Frontend/public/assets/icons/trendingUp.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path
+    fill-rule="evenodd" clip-rule="evenodd"
+    d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6h-6z"
+    fill="#007079"
+  />
+</svg>


### PR DESCRIPTION
Fixes #232 

## Description
_Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change._

This pull requests adds the isActive parameter to the list of parameters fetched when requesting data on a wellbore. This attribute is then passed to the front-end and displayed with a 'trending-upwards' arrow as seen in the picture. A well is also indicated as active if one or more wellbores are active.

![image](https://user-images.githubusercontent.com/1553016/111027799-d099d980-83f2-11eb-8a00-7c0b30d43c80.png)

...


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Sidebar - added icon to active wells and wellbores
* Wellbore service - added requesting isActive parameter


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments

I have an issue with fetching the `isActive` parameter from Sitecom test server. I'm not sure if this is because there is nothing to get, but I would be happy to update the PR to correctly get the `isActive` parameter from any server which uses it.

If I add `[XmlElement("isActive")] public string IsActive { get; set; }` to `WitsmlWellbore.cs` 
as well as `IsActive = ""`, to the `QueryAll` in `WellboreQueries.cs` then I get true/false values as strings from Aker BP Test server and null values from Sitecom test server.
However if I make the `IsActive` parameter as a boolean then I get a true/false value as a bool from Aker BP Test server, and no wellbore results at all from Sitecom test server.
