### PR TITLE
Add option to filter on isActive parameter for wells and wellbores

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -73,7 +73,7 @@ const Routing = (): React.ReactElement => {
 
   useEffect(() => {
     if (isSyncingUrlAndState && selectedWell) {
-      const setFilterAction: SetFilterAction = { type: NavigationType.SetFilter, payload: { filter: selectedWell.name } };
+      const setFilterAction: SetFilterAction = { type: NavigationType.SetFilter, payload: { filter: { ...navigationState.selectedFilter, wellName: selectedWell.name } } };
       dispatchNavigation(setFilterAction);
     }
   }, [selectedWell]);

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -2,20 +2,23 @@ import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import { TreeView } from "@material-ui/lab";
 import { TextField as MuiTextField } from "@material-ui/core";
+import { FormControlLabel as MuiFormControlLabel } from "@material-ui/core";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import WellItem from "./WellItem";
 import PropertiesPanel from "./PropertiesPanel";
 import NavigationContext from "../../contexts/navigationContext";
+import filter, { EMPTY_FILTER } from "../../contexts/filter";
 import NavigationType from "../../contexts/navigationType";
 import ServerManager from "./ServerManager";
 import { colors } from "../../styles/Colors";
 import Well from "../../models/well";
+import { Checkbox } from "@material-ui/core";
 
 const Sidebar = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
   const { filteredWells, expandedTreeNodes, currentProperties, selectedFilter } = navigationState;
-  const [filter, setFilter] = useState<string>("");
+  const [filter, setFilter] = useState<filter>(EMPTY_FILTER);
 
   useEffect(() => {
     setFilter(selectedFilter);
@@ -27,10 +30,21 @@ const Sidebar = (): React.ReactElement => {
       <TextField
         id="filter-tree"
         label="Filter wells"
-        onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: event.target.value } })}
-        value={filter}
+        onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, wellName: event.target.value } } })}
+        value={filter.wellName}
         autoComplete={"off"}
       />
+      <FormControlLabel
+        control={
+          <Checkbox
+            id="filter-isActive"
+            onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, isActive: event.target.checked } } })}
+            value={filter.isActive}
+          />
+        }
+        label={"Filter on active"}
+      />
+
       <SidebarTreeView>
         {filteredWells && filteredWells.length > 0 && (
           <TreeView
@@ -61,6 +75,15 @@ const TextField = styled(MuiTextField)`
   && {
     background-color: ${colors.ui.backgroundLight};
     margin-left: 0.5rem;
+  }
+`;
+
+const FormControlLabel = styled(MuiFormControlLabel)`
+  && {
+    margin: 0.2rem 0.5rem 0.2rem 0.5rem;
+    :hover {
+      background-color: ${colors.ui.backgroundLight};
+    }
   }
 `;
 

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -8,7 +8,7 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import WellItem from "./WellItem";
 import PropertiesPanel from "./PropertiesPanel";
 import NavigationContext from "../../contexts/navigationContext";
-import filter, { EMPTY_FILTER } from "../../contexts/filter";
+import Filter, { EMPTY_FILTER } from "../../contexts/filter";
 import NavigationType from "../../contexts/navigationType";
 import ServerManager from "./ServerManager";
 import { colors } from "../../styles/Colors";
@@ -18,7 +18,7 @@ import { Checkbox } from "@material-ui/core";
 const Sidebar = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
   const { filteredWells, expandedTreeNodes, currentProperties, selectedFilter } = navigationState;
-  const [filter, setFilter] = useState<filter>(EMPTY_FILTER);
+  const [filter, setFilter] = useState<Filter>(EMPTY_FILTER);
 
   useEffect(() => {
     setFilter(selectedFilter);

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -171,7 +171,7 @@ it("Should also update well and wellbore when a trajectory is selected", () => {
     servers: [SERVER_1],
     wells: WELLS,
     filteredWells: WELLS,
-    selectedFilter: "",
+    selectedFilter: EMPTY_FILTER,
     currentProperties: getTrajectoryProperties(TRAJECTORY_1, WELLBORE_2)
   });
 });
@@ -179,7 +179,7 @@ it("Should also update well and wellbore when a trajectory is selected", () => {
 it("Should filter wells", () => {
   const setFilterAction = {
     type: NavigationType.SetFilter,
-    payload: { filter: "2" }
+    payload: { filter: { ...EMPTY_FILTER, wellName: "2" } }
   };
   const actual = reducer(getInitialState(), setFilterAction);
   expect(actual).toStrictEqual({
@@ -188,7 +188,7 @@ it("Should filter wells", () => {
     servers: [SERVER_1],
     wells: WELLS,
     filteredWells: [WELL_2],
-    selectedFilter: "2"
+    selectedFilter: { ...EMPTY_FILTER, wellName: "2" }
   });
 });
 

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -25,7 +25,7 @@ import Trajectory, { getTrajectoryProperties } from "../../models/trajectory";
 import { Server } from "../../models/server";
 import ModificationType from "../modificationType";
 import Rig from "../../models/rig";
-import filter, { EMPTY_FILTER } from "../filter";
+import Filter, { EMPTY_FILTER } from "../filter";
 
 it("Should not update state when selecting current selected server", () => {
   const initialState = {
@@ -701,7 +701,7 @@ const TRAJECTORY_1: Trajectory = {
   dTimTrajEnd: null,
   dTimTrajStart: null
 };
-const FILTER_1: filter = { ...EMPTY_FILTER, wellName: WELL_1.name };
+const FILTER_1: Filter = { ...EMPTY_FILTER, wellName: WELL_1.name };
 const TRAJECTORY_GROUP_1 = "TrajectoryGroup";
 
 const getInitialState = (): NavigationState => {

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -25,6 +25,7 @@ import Trajectory, { getTrajectoryProperties } from "../../models/trajectory";
 import { Server } from "../../models/server";
 import ModificationType from "../modificationType";
 import Rig from "../../models/rig";
+import filter, { EMPTY_FILTER } from "../filter";
 
 it("Should not update state when selecting current selected server", () => {
   const initialState = {
@@ -32,7 +33,7 @@ it("Should not update state when selecting current selected server", () => {
     currentSelected: SERVER_1,
     wells: [WELL_1],
     filteredWells: [WELL_1],
-    selectedFilter: WELL_1.name,
+    selectedFilter: FILTER_1,
     servers: [SERVER_1, SERVER_2]
   };
   const selectServerAction: SelectServerAction = { type: NavigationType.SelectServer, payload: { server: SERVER_1 } };
@@ -47,7 +48,7 @@ it("Should update state when selecting another server", () => {
     ...getInitialState(),
     wells: [WELL_1],
     filteredWells: [WELL_1],
-    selectedFilter: WELL_1.name,
+    selectedFilter: FILTER_1,
     servers: [SERVER_1, SERVER_2]
   };
   const selectServerAction: SelectServerAction = { type: NavigationType.SelectServer, payload: { server: SERVER_2 } };
@@ -700,6 +701,7 @@ const TRAJECTORY_1: Trajectory = {
   dTimTrajEnd: null,
   dTimTrajStart: null
 };
+const FILTER_1: filter = { ...EMPTY_FILTER, wellName: WELL_1.name };
 const TRAJECTORY_GROUP_1 = "TrajectoryGroup";
 
 const getInitialState = (): NavigationState => {

--- a/Src/WitsmlExplorer.Frontend/contexts/filter.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/filter.tsx
@@ -1,0 +1,38 @@
+﻿import Well from "../models/well";
+
+interface filter {
+  wellName: string;
+  isActive: boolean;
+  objectGrowing: boolean;
+}
+
+export const EMPTY_FILTER: filter = {
+  wellName: "",
+  isActive: false,
+  objectGrowing: false
+};
+
+export const filterWells = (wells: Well[], filter: filter): Well[] => {
+  const limit = 30;
+
+  if (filter) {
+    let filteredWells: Well[] = wells;
+
+    if (filter.wellName) {
+      filteredWells = filteredWells.filter((well: Well) => well.name.toLowerCase().includes(filter.wellName.toLowerCase()));
+    }
+
+    if (filter.isActive) {
+      filteredWells = filteredWells.filter((well: Well) => well.wellbores.some((wellbore) => wellbore.isActive));
+      filteredWells = filteredWells.map((well) => {
+        return { ...well, wellbores: [...well.wellbores.filter((wellbore) => wellbore.isActive)] };
+      });
+    }
+
+    return filteredWells.slice(0, limit);
+  }
+
+  return wells.slice(0, limit);
+};
+
+export default filter;

--- a/Src/WitsmlExplorer.Frontend/contexts/filter.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/filter.tsx
@@ -1,18 +1,18 @@
 ﻿import Well from "../models/well";
 
-interface filter {
+interface Filter {
   wellName: string;
   isActive: boolean;
   objectGrowing: boolean;
 }
 
-export const EMPTY_FILTER: filter = {
+export const EMPTY_FILTER: Filter = {
   wellName: "",
   isActive: false,
   objectGrowing: false
 };
 
-export const filterWells = (wells: Well[], filter: filter): Well[] => {
+export const filterWells = (wells: Well[], filter: Filter): Well[] => {
   const limit = 30;
 
   if (filter) {
@@ -35,4 +35,4 @@ export const filterWells = (wells: Well[], filter: filter): Well[] => {
   return wells.slice(0, limit);
 };
 
-export default filter;
+export default Filter;

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -15,7 +15,7 @@ import { Server } from "../models/server";
 import ModificationType from "./modificationType";
 import Rig from "../models/rig";
 import { LogCurveInfoRow } from "../components/ContentViews/LogCurveInfoListView";
-import filter, { EMPTY_FILTER, filterWells } from "./filter";
+import Filter, { EMPTY_FILTER, filterWells } from "./filter";
 
 export interface NavigationState {
   selectedServer: Server;
@@ -32,7 +32,7 @@ export interface NavigationState {
   currentSelected: Selectable;
   wells: Well[];
   filteredWells: Well[];
-  selectedFilter: filter;
+  selectedFilter: Filter;
   expandedTreeNodes: string[];
   currentProperties: Map<string, string>;
 }
@@ -768,7 +768,7 @@ export interface SelectTrajectoryAction extends Action {
 
 export interface SetFilterAction extends Action {
   type: NavigationType.SetFilter;
-  payload: { filter: filter };
+  payload: { filter: Filter };
 }
 
 export type NavigationAction =

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -15,6 +15,7 @@ import { Server } from "../models/server";
 import ModificationType from "./modificationType";
 import Rig from "../models/rig";
 import { LogCurveInfoRow } from "../components/ContentViews/LogCurveInfoListView";
+import filter, { EMPTY_FILTER, filterWells } from "./filter";
 
 export interface NavigationState {
   selectedServer: Server;
@@ -31,7 +32,7 @@ export interface NavigationState {
   currentSelected: Selectable;
   wells: Well[];
   filteredWells: Well[];
-  selectedFilter: string;
+  selectedFilter: filter;
   expandedTreeNodes: string[];
   currentProperties: Map<string, string>;
 }
@@ -57,7 +58,7 @@ export const EMPTY_NAVIGATION_STATE: NavigationState = {
   currentSelected: null,
   wells: [],
   filteredWells: [],
-  selectedFilter: "",
+  selectedFilter: EMPTY_FILTER,
   expandedTreeNodes: [],
   currentProperties: new Map<string, string>()
 };
@@ -616,15 +617,6 @@ const setFilter = (state: NavigationState, { payload }: SetFilterAction) => {
   };
 };
 
-const filterWells = (wells: Well[], filter = ""): Well[] => {
-  const limit = 30;
-  if (filter) {
-    const partialMatchFilter = (well: Well) => well.name.toLowerCase().includes(filter.toLowerCase());
-    return wells.filter(partialMatchFilter).slice(0, limit);
-  }
-  return wells.slice(0, limit);
-};
-
 const treeNodeIsExpanded = (expandedTreeNodes: string[], nodeId: string) => {
   const nodeIndex = expandedTreeNodes.findIndex((expandedNode) => expandedNode === nodeId);
   return nodeIndex !== -1;
@@ -776,7 +768,7 @@ export interface SelectTrajectoryAction extends Action {
 
 export interface SetFilterAction extends Action {
   type: NavigationType.SetFilter;
-  payload: { filter: string };
+  payload: { filter: filter };
 }
 
 export type NavigationAction =


### PR DESCRIPTION
# Request Template Witsml Explorer
Fixes #233 

## Description
This pull requests adds the functionality of filtering the sidebar list of wells and wellbores to only show elements with the isActive parameter, as seen in the gif.

![filteractivewell1](https://user-images.githubusercontent.com/1553016/111787755-9b442e80-88bf-11eb-9257-2a98e0a445b9.gif)


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Sidebar
* Filter

# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments
This is the first iteration of adding additional filters to the existing functionality. Future iterations should consider extracting the filter options from the Sidebar into a separate component.
