### PR TITLE
Add option to filter on objectGrowing parameter for log objects and add filter option panel

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/FilterPanel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/FilterPanel.tsx
@@ -1,0 +1,96 @@
+﻿import Filter, { EMPTY_FILTER } from "../../contexts/filter";
+import NavigationType from "../../contexts/navigationType";
+import React, { useContext, useEffect, useState } from "react";
+import { Checkbox, FormControlLabel as MuiFormControlLabel, TextField as MuiTextField } from "@material-ui/core";
+import styled from "styled-components";
+import { colors } from "../../styles/Colors";
+import NavigationContext from "../../contexts/navigationContext";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import ChevronRightIcon from "@material-ui/icons/ChevronRight";
+
+const FilterPanel = (): React.ReactElement => {
+  const { navigationState, dispatchNavigation } = useContext(NavigationContext);
+  const { selectedFilter } = navigationState;
+
+  const [filter, setFilter] = useState<Filter>(EMPTY_FILTER);
+  const [expanded, setExpanded] = useState<boolean>(true);
+
+  useEffect(() => {
+    setFilter(selectedFilter);
+  }, [selectedFilter]);
+
+  return (
+    <Container expanded={expanded}>
+      <FilterPanelHeader onClick={() => setExpanded(!expanded)}>
+        <div>{expanded ? <ExpandMoreIcon color={"disabled"} style={{ width: 18 }} /> : <ChevronRightIcon color={"disabled"} style={{ width: 18 }} />}</div>
+        <div>Filter options</div>
+      </FilterPanelHeader>
+      {expanded && (
+        <>
+          <SearchTextField
+            id="filter-tree"
+            label="Filter on well name"
+            onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, wellName: event.target.value } } })}
+            value={filter.wellName}
+            autoComplete={"off"}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                id="filter-isActive"
+                onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, isActive: event.target.checked } } })}
+                value={filter.isActive}
+              />
+            }
+            label={"Show only active wells and wellbores"}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                id="filter-objectGrowing"
+                onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, objectGrowing: event.target.checked } } })}
+                value={filter.objectGrowing}
+              />
+            }
+            label={"Show only growing logs"}
+          />
+        </>
+      )}
+    </Container>
+  );
+};
+
+const Container = styled.div<{ expanded: boolean }>`
+  background-color: ${colors.ui.backgroundLight};
+  display: flex;
+  flex-direction: column;
+  padding: 0.4rem;
+  align-items: stretch;
+`;
+
+const FilterPanelHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  line-height: 1.5rem;
+  font-family: EquinorMedium, sans-serif;
+`;
+
+const SearchTextField = styled(MuiTextField)`
+  && {
+    margin-left: 0.5rem;
+    :hover {
+      background-color: ${colors.ui.backgroundDefault};
+    }
+  }
+`;
+
+const FormControlLabel = styled(MuiFormControlLabel)`
+  && {
+    margin-left 0.4rem;
+    :hover {
+      background-color: ${colors.ui.backgroundDefault};
+    }
+  }
+`;
+
+export default FilterPanel;

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -1,50 +1,23 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
 import { TreeView } from "@material-ui/lab";
-import { TextField as MuiTextField } from "@material-ui/core";
-import { FormControlLabel as MuiFormControlLabel } from "@material-ui/core";
 import ChevronRightIcon from "@material-ui/icons/ChevronRight";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import WellItem from "./WellItem";
 import PropertiesPanel from "./PropertiesPanel";
 import NavigationContext from "../../contexts/navigationContext";
-import Filter, { EMPTY_FILTER } from "../../contexts/filter";
-import NavigationType from "../../contexts/navigationType";
 import ServerManager from "./ServerManager";
-import { colors } from "../../styles/Colors";
 import Well from "../../models/well";
-import { Checkbox } from "@material-ui/core";
+import FilterPanel from "./FilterPanel";
 
 const Sidebar = (): React.ReactElement => {
-  const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { filteredWells, expandedTreeNodes, currentProperties, selectedFilter } = navigationState;
-  const [filter, setFilter] = useState<Filter>(EMPTY_FILTER);
-
-  useEffect(() => {
-    setFilter(selectedFilter);
-  }, [selectedFilter]);
+  const { navigationState } = useContext(NavigationContext);
+  const { filteredWells, expandedTreeNodes, currentProperties } = navigationState;
 
   return (
     <>
       <ServerManager />
-      <TextField
-        id="filter-tree"
-        label="Filter wells"
-        onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, wellName: event.target.value } } })}
-        value={filter.wellName}
-        autoComplete={"off"}
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            id="filter-isActive"
-            onChange={(event) => dispatchNavigation({ type: NavigationType.SetFilter, payload: { filter: { ...filter, isActive: event.target.checked } } })}
-            value={filter.isActive}
-          />
-        }
-        label={"Filter on active"}
-      />
-
+      <FilterPanel />
       <SidebarTreeView>
         {filteredWells && filteredWells.length > 0 && (
           <TreeView
@@ -69,22 +42,6 @@ const SidebarTreeView = styled.div`
   flex: 1 1 auto;
   height: 70%;
   padding-left: 0.5rem;
-`;
-
-const TextField = styled(MuiTextField)`
-  && {
-    background-color: ${colors.ui.backgroundLight};
-    margin-left: 0.5rem;
-  }
-`;
-
-const FormControlLabel = styled(MuiFormControlLabel)`
-  && {
-    margin: 0.2rem 0.5rem 0.2rem 0.5rem;
-    :hover {
-      background-color: ${colors.ui.backgroundLight};
-    }
-  }
 `;
 
 export default Sidebar;

--- a/Src/WitsmlExplorer.Frontend/contexts/filter.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/filter.tsx
@@ -29,6 +29,22 @@ export const filterWells = (wells: Well[], filter: Filter): Well[] => {
       });
     }
 
+    if (filter.objectGrowing) {
+      filteredWells = filteredWells.map((well) => {
+        return {
+          ...well,
+          wellbores: [
+            ...well.wellbores.map((wellbore) => {
+              return {
+                ...wellbore,
+                logs: wellbore.logs ? [...wellbore.logs.filter((logObject) => logObject.objectGrowing)] : wellbore.logs
+              };
+            })
+          ]
+        };
+      });
+    }
+
     return filteredWells.slice(0, limit);
   }
 


### PR DESCRIPTION
# Request Template Witsml Explorer
Fixes #235
Fixes #237 
These issues are essentially the same, so both are fixed by this PR.


## Description
**Filter on growing objects**
This pull requests adds the functionality of filtering the sidebar list of logs to only show elements with the objectGrowing parameter, as seen in the gif below.

![filterobjectgrowing1](https://user-images.githubusercontent.com/1553016/112474151-8cea8c80-8d6f-11eb-817e-d0109fc194c8.gif)

---

**Filter panel**
This pull requests also adds a panel with the filter options which can be expanded and collapsed, as seen in the gif below:
![expandfilteroptions1](https://user-images.githubusercontent.com/1553016/112474270-aee40f00-8d6f-11eb-8f92-16a640825416.gif)

## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Sidebar
* Filter


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
