### PR TITLE
Fix application crashing when right clicking a wellbore in list view

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -13,7 +13,7 @@ import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 
 export const WellboresListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { selectedWell } = navigationState;
+  const { selectedWell, servers } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
@@ -26,7 +26,7 @@ export const WellboresListView = (): React.ReactElement => {
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore) => {
-    const contextMenuProps: WellboreContextMenuProps = { dispatchNavigation, dispatchOperation, wellbore };
+    const contextMenuProps: WellboreContextMenuProps = { dispatchNavigation, dispatchOperation, servers, wellbore };
     const position = getContextMenuPosition(event);
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <WellboreContextMenu {...contextMenuProps} />, position } });
   };


### PR DESCRIPTION
# Request Template Witsml Explorer
Fixes #296 

## Description
Right clicking wellbore in wellbore list view no longer crashes the application as the server list is passed correctly.


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Wellbore list view


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
