### PR TITLE
Fix show on server being enabled when no log item is checked

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -201,7 +201,7 @@ const LogObjectContextMenu = (props: LogObjectContextMenuProps): React.ReactElem
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedLogObjectRows.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(server)}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(server)} disabled={checkedLogObjectRows.length !== 1}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}


### PR DESCRIPTION
# Request Template Witsml Explorer
Fixes #326

## Description
It is no longer possible to select server to show log item on when no log items are checked


## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Log Item Context Menu


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
