### PR TITLE
Change Sidebar items to use server list from context directly instead of passing argument

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/LogItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/LogItem.tsx
@@ -9,7 +9,6 @@ import NavigationContext from "../../contexts/navigationContext";
 import OperationType from "../../contexts/operationType";
 import NavigationType from "../../contexts/navigationType";
 import { getContextMenuPosition, preventContextMenuPropagation } from "../ContextMenus/ContextMenu";
-import { Server } from "../../models/server";
 
 interface LogItemProps {
   log: LogObject;
@@ -30,7 +29,7 @@ const LogItem = (props: LogItemProps): React.ReactElement => {
     navigationState: { selectedServer, servers }
   } = useContext(NavigationContext);
 
-  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, log: LogObject, selectedServer: Server, servers: Server[]) => {
+  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, log: LogObject) => {
     preventContextMenuPropagation(event);
     const contextProps: LogObjectContextMenuProps = { checkedLogObjectRows: [].concat(log), dispatchNavigation, dispatchOperation, selectedServer, servers };
     const position = getContextMenuPosition(event);
@@ -39,7 +38,7 @@ const LogItem = (props: LogItemProps): React.ReactElement => {
 
   return (
     <TreeItem
-      onContextMenu={(event) => onContextMenu(event, log, selectedServer, servers)}
+      onContextMenu={(event) => onContextMenu(event, log)}
       key={nodeId}
       nodeId={nodeId}
       labelText={log.runNumber ? `${log.name} (${log.runNumber})` : log.name}

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
@@ -9,7 +9,6 @@ import NavigationType from "../../contexts/navigationType";
 import { getContextMenuPosition, preventContextMenuPropagation } from "../ContextMenus/ContextMenu";
 import OperationType from "../../contexts/operationType";
 import OperationContext from "../../contexts/operationContext";
-import { Server } from "../../models/server";
 
 interface WellItemProps {
   well: Well;
@@ -21,7 +20,7 @@ const WellItem = (props: WellItemProps): React.ReactElement => {
   const { selectedWellbore, selectedWell, servers } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
 
-  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, well: Well, servers: Server[]) => {
+  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, well: Well) => {
     preventContextMenuPropagation(event);
     const contextMenuProps: WellContextMenuProps = { well, servers, dispatchOperation };
     const position = getContextMenuPosition(event);
@@ -34,7 +33,7 @@ const WellItem = (props: WellItemProps): React.ReactElement => {
 
   return (
     <TreeItem
-      onContextMenu={(event) => onContextMenu(event, well, servers)}
+      onContextMenu={(event) => onContextMenu(event, well)}
       selected={selectedWell?.uid === well.uid ? true : undefined}
       key={well.uid}
       labelText={well.name}

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -16,7 +16,6 @@ import NavigationType from "../../contexts/navigationType";
 import { getContextMenuPosition, preventContextMenuPropagation } from "../ContextMenus/ContextMenu";
 import { calculateTrajectoryId } from "../../models/trajectory";
 import { SelectWellboreAction, ToggleTreeNodeAction } from "../../contexts/navigationStateReducer";
-import { Server } from "../../models/server";
 import LogsContextMenu, { LogsContextMenuProps } from "../ContextMenus/LogsContextMenu";
 import { IndexCurve } from "../Modals/LogPropertiesModal";
 
@@ -34,7 +33,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
   const { dispatchOperation } = useContext(OperationContext);
   const [isFetchingData, setIsFetchingData] = useState(false);
 
-  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore, servers: Server[]) => {
+  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore) => {
     preventContextMenuPropagation(event);
     const contextMenuProps: WellboreContextMenuProps = { wellbore, servers, dispatchOperation, dispatchNavigation };
     const position = getContextMenuPosition(event);
@@ -111,7 +110,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
 
   return (
     <TreeItem
-      onContextMenu={(event) => onContextMenu(event, wellbore, servers)}
+      onContextMenu={(event) => onContextMenu(event, wellbore)}
       key={nodeId}
       nodeId={nodeId}
       selected={selected}


### PR DESCRIPTION
## Description
_Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change._

Currently there is a mix of passing server list using the context or as argument. However, when the server list is passed as argument, the classes are still taking the list of servers from context anyway, so they might as well be used directly. This makes the code more readable as well as consistent across the different items in the Sidebar.

## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Sidebar


# Checklist:
_Put an x in the boxes that are fulfilled._

- [ ] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
