### PR TITLE
Change LogObjectContextMenu to immediately close when refreshing logs

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -159,12 +159,12 @@ const LogObjectContextMenu = (props: LogObjectContextMenuProps): React.ReactElem
   };
 
   const onClickRefresh = async () => {
+    dispatchOperation({ type: OperationType.HideContextMenu });
     const log = await LogObjectService.getLog(checkedLogObjectRows[0].wellUid, checkedLogObjectRows[0].wellboreUid, checkedLogObjectRows[0].uid);
     dispatchNavigation({
       type: ModificationType.UpdateLogObject,
       payload: { log: log }
     });
-    dispatchOperation({ type: OperationType.HideContextMenu });
   };
 
   return (


### PR DESCRIPTION
# Request Template Witsml Explorer
Fixes #293

## Description
_Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change._
Context menu is now closed immediately, rather than waiting for log to refresh.

## Type of change
_Put an x in the boxes that apply. You can also fill these out after creating the PR._

- [ ] Bugfix
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement of existing functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Log object context menu


# Checklist:
_Put an x in the boxes that are fulfilled._

- [x] PR is related to an issue
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have used descriptive naming on components, functions and variables to avoid additional explanatory comments in the code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Further comments
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
This is a general issue for all options in the context menus. It is worth considering if we should do this fix everywhere, or ignore the issue until we can implement proper loading indication.