### PR TITLE
Add missing COPY for Console.csproj in Dockerfile-api

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY witsml-explorer.sln .
 COPY Src/Witsml/Witsml.csproj Src/Witsml/Witsml.csproj
 COPY Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+COPY Src/WitsmlExplorer.Console/WitsmlExplorer.Console.csproj Src/WitsmlExplorer.Console/WitsmlExplorer.Console.csproj
 COPY Src/WitsmlExplorer.Frontend/WitsmlExplorer.Frontend.csproj Src/WitsmlExplorer.Frontend/WitsmlExplorer.Frontend.csproj
 COPY Tests/WitsmlExplorer.Api.Tests/WitsmlExplorer.Api.Tests.csproj Tests/WitsmlExplorer.Api.Tests/WitsmlExplorer.Api.Tests.csproj
 COPY Tests/WitsmlExplorer.IntegrationTests/WitsmlExplorer.IntegrationTests.csproj Tests/WitsmlExplorer.IntegrationTests/WitsmlExplorer.IntegrationTests.csproj


### PR DESCRIPTION
# Request Template Witsml Explorer
Thank you for contributing to WITSML Explorer!
Before submitting this PR, please fill in the following template.

## Fixes
This pull request does not relate to any issue.

build_docker_images.sh currently fails because it is expecting to find Console.csproj, which is not copied.


## Description
_Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change._

This PR adds missing COPY statement of Console.csproj in the Docker-api file.

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* Bugfix

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Docker builds

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass