### PR TITLE
Ignore Console package in .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,7 @@ Tests
 Src/Witsml
 Src/WitsmlExplorer.Api
 Src/WitsmlExplorer.Console
-Src/WitsmlExplorer.Frontend/
+Src/WitsmlExplorer.Frontend/build
 Src/WitsmlExplorer.Frontend/obj
 Src/WitsmlExplorer.Frontend/bin
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,9 +2,12 @@
 Tests
 Src/Witsml
 Src/WitsmlExplorer.Api
-Src/WitsmlExplorer.Frontend/build
+Src/WitsmlExplorer.Console
+Src/WitsmlExplorer.Frontend/
 Src/WitsmlExplorer.Frontend/obj
 Src/WitsmlExplorer.Frontend/bin
+
+.vscode/*
 
 *.md
 *.yml


### PR DESCRIPTION
## Description
When formatting code with prettier, `WitsmlExplorer.Console` was included

## Type of change
Added entry to ignore Console

* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application
lint-staged code formatting by prettier

## Checklist:

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [ ] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
Toolset configuration