### PR TITLE
Fix incorrect isActive column for depthCurves

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -71,13 +71,16 @@ export const ContentTable = (props: ContentTableProps): React.ReactElement => {
             </TableHeaderCell>
           )}
           {columns &&
-            columns.map((column) => (
-              <TableHeaderCell key={column.property} align={column.type === ContentType.Number ? "right" : "left"}>
-                <TableSortLabel active={sortedColumn === column} direction={sortOrder} onClick={() => sortByColumn(column)}>
-                  {column.label}
-                </TableSortLabel>
-              </TableHeaderCell>
-            ))}
+            columns.map(
+              (column) =>
+                column && (
+                  <TableHeaderCell key={column.property} align={column.type === ContentType.Number ? "right" : "left"}>
+                    <TableSortLabel active={sortedColumn === column} direction={sortOrder} onClick={() => sortByColumn(column)}>
+                      {column.label}
+                    </TableSortLabel>
+                  </TableHeaderCell>
+                )
+            )}
         </TableRow>
       </TableHead>
       <TableBody>


### PR DESCRIPTION
# Request Template Witsml Explorer
Thank you for contributing to WITSML Explorer!
Before submitting this PR, please fill in the following template.

## Fixes
This pull request fixes # (issue)

## Description
_Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change._
This fixes incorrect empty isActive column for depth curves.

**Before**
![image](https://user-images.githubusercontent.com/1553016/121701752-839cd080-cad1-11eb-801b-ec5fe1ed5d4c.png)

**After**
![image](https://user-images.githubusercontent.com/1553016/121701708-767fe180-cad1-11eb-8c3d-5b1140016037.png)



## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* Bugfix

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Curve list view (depth)

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* ~~PR is related to an issue~~
* ~~I have made corresponding changes to the documentation~~

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* ~~New code is covered by passing tests~~

## Further comments
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
