### PR TITLE
Rename QuerybyId to GetWitsmlLogById

### DIFF
--- a/Src/WitsmlExplorer.Api/Query/LogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/LogQueries.cs
@@ -46,7 +46,7 @@ namespace WitsmlExplorer.Api.Query
         }
         public static WitsmlLogs QueryById(string wellUid, string wellboreUid, string logUid)
         {
-            return GetWitsmlLogById(wellUid, wellboreUid, logUid)
+            return GetWitsmlLogById(wellUid, wellboreUid, logUid);
         }
 
         public static WitsmlLogs GetLogContent(

--- a/Src/WitsmlExplorer.Api/Query/LogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/LogQueries.cs
@@ -44,6 +44,10 @@ namespace WitsmlExplorer.Api.Query
                 }.AsSingletonList()
             };
         }
+        public static WitsmlLogs QueryById(string wellUid, string wellboreUid, string logUid)
+        {
+            return GetWitsmlLogById(wellUid, wellboreUid, logUid)
+        }
 
         public static WitsmlLogs GetLogContent(
             string wellUid,

--- a/Src/WitsmlExplorer.Api/Query/LogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/LogQueries.cs
@@ -81,7 +81,7 @@ namespace WitsmlExplorer.Api.Query
 
             return new WitsmlLogs
             {
-                Logs = new List<WitsmlLog> {queryLog}
+                Logs = new List<WitsmlLog> { queryLog }
             };
         }
 
@@ -120,7 +120,7 @@ namespace WitsmlExplorer.Api.Query
 
             return new WitsmlLogs
             {
-                Logs = new List<WitsmlLog> {queryLog}
+                Logs = new List<WitsmlLog> { queryLog }
             };
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs
@@ -24,7 +24,7 @@ namespace WitsmlExplorer.Api.Workers
 
         private async Task<WitsmlLog> GetLogHeader(string wellUid, string wellboreUid, string logUid)
         {
-            var query = LogQueries.QueryById(wellUid, wellboreUid, logUid);
+            var query = LogQueries.GetWitsmlLogById(wellUid, wellboreUid, logUid);
             var result = await witsmlClient.GetFromStoreAsync(query, OptionsIn.HeaderOnly);
             return result?.Logs.FirstOrDefault();
         }


### PR DESCRIPTION
# Request Template Witsml Explorer


## Fixes
Name refactoring bug

## Description
Missing rename of method in `Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs`

## Type of change
rename

* Bugfix


## Impacted Areas in Application


## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [x] New code is covered by passing tests

## Further comments

