### PR TITLE
Enabled executing custom queries from Console app

### DIFF
--- a/Src/Witsml/ServiceReference/EnumMemberHelpers.cs
+++ b/Src/Witsml/ServiceReference/EnumMemberHelpers.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Witsml.ServiceReference
+{
+    public static class EnumMemberToString
+    {
+        public static string GetEnumMemberValue<T>(this T value) where T : Enum
+        {
+            return typeof(T)
+                .GetTypeInfo()
+                .DeclaredMembers
+                .SingleOrDefault(x => x.Name == value.ToString())
+                ?.GetCustomAttribute<EnumMemberAttribute>(false)
+                ?.Value;
+        }
+    }
+
+    public static class EnumParser<T> where T : Enum
+    {
+        public static T GetEnum(string enumMemberValue)
+        {
+            var stringValue = typeof(T)
+                .GetTypeInfo()
+                .DeclaredMembers
+                .Where(member => member.GetCustomAttribute<EnumMemberAttribute>(false)?.Value == enumMemberValue)
+                .Select(f => f.Name)
+                .FirstOrDefault();
+            if (!string.IsNullOrEmpty(stringValue))
+                return (T) Enum.Parse(typeof(T), stringValue);
+
+            throw new ArgumentException($"No members of {typeof(T).Name} has a specified EnumMember value of '{enumMemberValue}'");
+        }
+    }
+}

--- a/Src/Witsml/ServiceReference/OptionsIn.cs
+++ b/Src/Witsml/ServiceReference/OptionsIn.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -36,18 +33,5 @@ namespace Witsml.ServiceReference
         LatestChangeOnly,
         [EnumMember(Value = "requested")]
         Requested
-    }
-
-    public static class EnumMemberToString
-    {
-        public static string GetEnumMemberValue<T>(this T value) where T : Enum
-        {
-            return typeof(T)
-                .GetTypeInfo()
-                .DeclaredMembers
-                .SingleOrDefault(x => x.Name == value.ToString())
-                ?.GetCustomAttribute<EnumMemberAttribute>(false)
-                ?.Value;
-        }
     }
 }

--- a/Src/WitsmlExplorer.Console/.gitignore
+++ b/Src/WitsmlExplorer.Console/.gitignore
@@ -1,1 +1,2 @@
 appsettings.witsml.json
+CustomQueries/**

--- a/Src/WitsmlExplorer.Console/CustomQueries/GetAllWellbores.xml
+++ b/Src/WitsmlExplorer.Console/CustomQueries/GetAllWellbores.xml
@@ -1,0 +1,7 @@
+<wellbores xmlns="http://www.witsml.org/schemas/1series" version="1.4.1.1">
+  <wellbore uidWell="" uid="">
+    <nameWell />
+    <name />
+    <isActive />
+  </wellbore>
+</wellbores>

--- a/Src/WitsmlExplorer.Console/Program.cs
+++ b/Src/WitsmlExplorer.Console/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 using WitsmlExplorer.Console.ListCommands;
 using WitsmlExplorer.Console.Injection;
+using WitsmlExplorer.Console.QueryCommands;
 using WitsmlExplorer.Console.ShowCommands;
 using WitsmlExplorer.Console.WitsmlClient;
 
@@ -35,6 +36,11 @@ namespace WitsmlExplorer.Console
             config.AddBranch("show", add =>
             {
                 add.AddCommand<ShowTubularCommand>("tubular").WithDescription("Export tubular within a well/wellbore");
+            });
+
+            config.AddBranch("query", add =>
+            {
+                add.AddCommand<GetQueryCommand>("get").WithDescription("Execute GET query");
             });
             return config;
         }

--- a/Src/WitsmlExplorer.Console/QueryCommands/GetQueryCommand.cs
+++ b/Src/WitsmlExplorer.Console/QueryCommands/GetQueryCommand.cs
@@ -31,12 +31,13 @@ namespace WitsmlExplorer.Console.QueryCommands
             public string QueryFile { get; init; }
 
             [CommandOption("--returnElements")]
-            [Description("Indicates which elements and attributes are requested to be returned in addition to data-object selection items [requested(default)|all|id-only|header-only|data-only|station-location-only|latest-change-only")]
+            [Description("Indicates which elements and attributes are requested to be returned in addition to data-object selection items (requested(default)|all|id-only|header-only|data-only|station-location-only|latest-change-only)")]
             [DefaultValue("requested")]
             public string ReturnElements { get; init; }
 
             [CommandOption("--maxReturnNodes")]
             [Description("Max number of data nodes to return. Must be a whole number greater than zero, if provided")]
+            [DefaultValue("")]
             public int? MaxReturnNodes { get; init; }
 
             public override ValidationResult Validate()

--- a/Src/WitsmlExplorer.Console/QueryCommands/GetQueryCommand.cs
+++ b/Src/WitsmlExplorer.Console/QueryCommands/GetQueryCommand.cs
@@ -1,61 +1,18 @@
-using System;
-using System.ComponentModel;
 using System.IO;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using System.Xml.Linq;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using Witsml;
-using Witsml.Data;
-using Witsml.Extensions;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Console.Extensions;
 using WitsmlExplorer.Console.WitsmlClient;
 
 namespace WitsmlExplorer.Console.QueryCommands
 {
-    public class GetQueryCommand : AsyncCommand<GetQueryCommand.QuerySettings>
+    public class GetQueryCommand : AsyncCommand<GetQuerySettings>
     {
-        public class QuerySettings : CommandSettings
-        {
-            private readonly string[] validReturnElements = {"requested", "all", "id-only", "header-only", "data-only", "station-location-only", "latest-change-only"};
-
-            [CommandArgument(0, "<PATH_TO_QUERY_FILE>")]
-            [Description("Path to query file in XML format")]
-            public string QueryFile { get; init; }
-
-            [CommandOption("--returnElements")]
-            [Description("Indicates which elements and attributes are requested to be returned in addition to data-object selection items (requested(default)|all|id-only|header-only|data-only|station-location-only|latest-change-only)")]
-            [DefaultValue("requested")]
-            public string ReturnElements { get; init; }
-
-            [CommandOption("--maxReturnNodes")]
-            [Description("Max number of data nodes to return. Must be a whole number greater than zero, if provided")]
-            [DefaultValue("")]
-            public int? MaxReturnNodes { get; init; }
-
-            public override ValidationResult Validate()
-            {
-                var queryPath = Path.Combine(Directory.GetCurrentDirectory(), QueryFile);
-                if (!File.Exists(queryPath))
-                    return ValidationResult.Error($"Could not find query file: {queryPath}");
-
-                if (!validReturnElements.Contains(ReturnElements))
-                    return ValidationResult.Error($"Invalid value for returnElements ({ReturnElements})");
-
-                if (MaxReturnNodes is < 1)
-                    return ValidationResult.Error("MaxReturnNodes must be a whole number greater than zero");
-
-                return ValidationResult.Success();
-            }
-        }
-
         private readonly IWitsmlClient witsmlClient;
 
         public GetQueryCommand(IWitsmlClientProvider witsmlClientProvider)
@@ -63,7 +20,7 @@ namespace WitsmlExplorer.Console.QueryCommands
             witsmlClient = witsmlClientProvider?.GetClient();
         }
 
-        public override async Task<int> ExecuteAsync(CommandContext context, QuerySettings settings)
+        public override async Task<int> ExecuteAsync(CommandContext context, GetQuerySettings settings)
         {
             if (witsmlClient == null) return -1;
 

--- a/Src/WitsmlExplorer.Console/QueryCommands/GetQueryCommand.cs
+++ b/Src/WitsmlExplorer.Console/QueryCommands/GetQueryCommand.cs
@@ -1,0 +1,108 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Witsml;
+using Witsml.Data;
+using Witsml.Extensions;
+using Witsml.ServiceReference;
+using WitsmlExplorer.Console.Extensions;
+using WitsmlExplorer.Console.WitsmlClient;
+
+namespace WitsmlExplorer.Console.QueryCommands
+{
+    public class GetQueryCommand : AsyncCommand<GetQueryCommand.QuerySettings>
+    {
+        public class QuerySettings : CommandSettings
+        {
+            private readonly string[] validReturnElements = {"requested", "all", "id-only", "header-only", "data-only", "station-location-only", "latest-change-only"};
+
+            [CommandArgument(0, "<PATH_TO_QUERY_FILE>")]
+            [Description("Path to query file in XML format")]
+            public string QueryFile { get; init; }
+
+            [CommandOption("--returnElements")]
+            [Description("Indicates which elements and attributes are requested to be returned in addition to data-object selection items [requested(default)|all|id-only|header-only|data-only|station-location-only|latest-change-only")]
+            [DefaultValue("requested")]
+            public string ReturnElements { get; init; }
+
+            [CommandOption("--maxReturnNodes")]
+            [Description("Max number of data nodes to return. Must be a whole number greater than zero, if provided")]
+            public int? MaxReturnNodes { get; init; }
+
+            public override ValidationResult Validate()
+            {
+                var queryPath = Path.Combine(Directory.GetCurrentDirectory(), QueryFile);
+                if (!File.Exists(queryPath))
+                    return ValidationResult.Error($"Could not find query file: {queryPath}");
+
+                if (!validReturnElements.Contains(ReturnElements))
+                    return ValidationResult.Error($"Invalid value for returnElements ({ReturnElements})");
+
+                if (MaxReturnNodes is < 1)
+                    return ValidationResult.Error("MaxReturnNodes must be a whole number greater than zero");
+
+                return ValidationResult.Success();
+            }
+        }
+
+        private readonly IWitsmlClient witsmlClient;
+
+        public GetQueryCommand(IWitsmlClientProvider witsmlClientProvider)
+        {
+            witsmlClient = witsmlClientProvider?.GetClient();
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, QuerySettings settings)
+        {
+            if (witsmlClient == null) return -1;
+
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync("Executing query...".WithColor(Color.Orange1), async _ =>
+                {
+                    var results = await ExecuteQuery(settings.QueryFile, settings.ReturnElements, settings.MaxReturnNodes);
+                    await using var memoryStream = new MemoryStream();
+                    await using var writer = new XmlTextWriter(memoryStream, Encoding.Unicode) {Formatting = Formatting.Indented};
+                    var document = new XmlDocument();
+
+                    document.LoadXml(results);
+                    document.WriteContentTo(writer);
+                    writer.Flush();
+                    memoryStream.Flush();
+                    memoryStream.Position = 0;
+
+                    var streamReader = new StreamReader(memoryStream);
+                    while (true)
+                    {
+                        var line = await streamReader.ReadLineAsync();
+                        if (string.IsNullOrEmpty(line)) break;
+
+                        AnsiConsole.WriteLine(line);
+                    }
+                });
+
+            return 0;
+        }
+
+        private async Task<string> ExecuteQuery(string queryFile, string returnElements, int? maxReturnNodes)
+        {
+            var queryPath = Path.Combine(Directory.GetCurrentDirectory(), queryFile);
+            var query = await File.ReadAllTextAsync(queryPath);
+
+            var returnElementsEnum = EnumParser<ReturnElements>.GetEnum(returnElements);
+            var optionsIn = new OptionsIn(returnElementsEnum, maxReturnNodes);
+
+            return await witsmlClient.GetFromStoreAsync(query, optionsIn);
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Console/QueryCommands/GetQuerySettings.cs
+++ b/Src/WitsmlExplorer.Console/QueryCommands/GetQuerySettings.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace WitsmlExplorer.Console.QueryCommands
+{
+    public class GetQuerySettings : CommandSettings
+    {
+        private readonly string[] validReturnElements = {"requested", "all", "id-only", "header-only", "data-only", "station-location-only", "latest-change-only"};
+
+        [CommandArgument(0, "<PATH_TO_QUERY_FILE>")]
+        [Description("Path to query file in XML format")]
+        public string QueryFile { get; init; }
+
+        [CommandOption("--returnElements")]
+        [Description("Indicates which elements and attributes are requested to be returned in addition to data-object selection items (requested(default)|all|id-only|header-only|data-only|station-location-only|latest-change-only)")]
+        [DefaultValue("requested")]
+        public string ReturnElements { get; init; }
+
+        [CommandOption("--maxReturnNodes")]
+        [Description("Max number of data nodes to return. Must be a whole number greater than zero, if provided")]
+        [DefaultValue("")]
+        public int? MaxReturnNodes { get; init; }
+
+        public override ValidationResult Validate()
+        {
+            var queryPath = Path.Combine(Directory.GetCurrentDirectory(), QueryFile);
+            if (!File.Exists(queryPath))
+                return ValidationResult.Error($"Could not find query file: {queryPath}");
+
+            if (!validReturnElements.Contains(ReturnElements))
+                return ValidationResult.Error($"Invalid value for returnElements ({ReturnElements})");
+
+            if (MaxReturnNodes is < 1)
+                return ValidationResult.Error("MaxReturnNodes must be a whole number greater than zero");
+
+            return ValidationResult.Success();
+        }
+    }
+}

--- a/Tests/Witsml.Tests/ServiceReference/EnumMemberHelpersTests.cs
+++ b/Tests/Witsml.Tests/ServiceReference/EnumMemberHelpersTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Witsml.ServiceReference;
+using Xunit;
+
+namespace Witsml.Tests.ServiceReference
+{
+    public class EnumMemberHelpersTests
+    {
+        [Fact]
+        public void GetEnumMemberValue_DataOnly_ReturnsCorrectString()
+        {
+            var enumMemberValue = ReturnElements.DataOnly.GetEnumMemberValue();
+
+            Assert.Equal("data-only", enumMemberValue);
+        }
+
+        [Fact]
+        public void EnumParser_ValidInputRequested_ReturnsCorrectEnumValue()
+        {
+            var returnElements = "requested";
+            var enumValue = EnumParser<ReturnElements>.GetEnum(returnElements);
+
+            Assert.Equal(ReturnElements.Requested, enumValue);
+        }
+
+        [Fact]
+        public void EnumParser_InvalidInput_ThrowsArgumentException()
+        {
+            var invalidInput = "foobar";
+
+            var exception = Assert.Throws<ArgumentException>(() => EnumParser<ReturnElements>.GetEnum(invalidInput));
+            Assert.Equal("No members of ReturnElements has a specified EnumMember value of 'foobar'", exception.Message);
+        }
+    }
+}

--- a/Tests/Witsml.Tests/ServiceReference/OptionsInTests.cs
+++ b/Tests/Witsml.Tests/ServiceReference/OptionsInTests.cs
@@ -6,11 +6,19 @@ namespace Witsml.Tests.ServiceReference
     public class OptionsInTests
     {
         [Fact]
-        public void ToString_WithReturnElementsAll_ReturnsCorrectValue()
+        public void GetKeywords_WithReturnElementsAll_ReturnsCorrectValue()
         {
             var optionsIn = new OptionsIn(ReturnElements.All);
 
             Assert.Equal("returnElements=all", optionsIn.GetKeywords());
+        }
+
+        [Fact]
+        public void GetKeyWords_WithReturnElementsDataOnly_And_MaxReturnNodes50_ReturnsCorrectValue()
+        {
+            var optionsIn = new OptionsIn(ReturnElements.DataOnly, 50);
+
+            Assert.Equal("returnElements=data-only;maxReturnNodes=50", optionsIn.GetKeywords());
         }
     }
 }


### PR DESCRIPTION
## Fixes
This pull request fixes #18 by adding an option to execute custom queries from the console app.

## Description
Example usage of console app:
`dotnet run -- query get CustomQueries/query.xml --returnElements all --maxReturnNodes 1`
This will execute the query located in `CustomQueries/query.xml` with returnElements set to `all` and only return the first data node from the result.

An example query is available in the CustomQueries folder which returns all wellbores.

...

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* WitsmlExplorer.Console (CLI application)

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests