### PR TITLE
Added command to show log header

### DIFF
--- a/Src/WitsmlExplorer.Console/ListCommands/ListLogsCommand.cs
+++ b/Src/WitsmlExplorer.Console/ListCommands/ListLogsCommand.cs
@@ -38,15 +38,34 @@ namespace WitsmlExplorer.Console.ListCommands
                     wellName = logs.FirstOrDefault()?.NameWell;
                     wellboreName = logs.FirstOrDefault()?.NameWellbore;
 
+                    var previousIndexType = "";
                     foreach (var log in logs.OrderBy(l => l.IndexType))
                     {
-                        table.AddRow(
-                            log.Uid,
-                            log.Name,
-                            log.ServiceCompany ?? "",
-                            log.GetStartIndexAsString(),
-                            log.GetEndIndexAsString(),
-                            log.ObjectGrowing == "true" ? ":check_mark:" : "");
+                        if (!string.IsNullOrEmpty(previousIndexType) && log.IndexType != previousIndexType)
+                            table.AddEmptyRow();
+
+                        if (log.ObjectGrowing == "true")
+                        {
+                            table.AddRow(
+                                log.Uid.WithColor(Color.Green),
+                                log.Name.WithColor(Color.Green),
+                                log.ServiceCompany.WithColor(Color.Green) ?? "",
+                                log.GetStartIndexAsString().WithColor(Color.Green),
+                                log.GetEndIndexAsString().WithColor(Color.Green),
+                                log.ObjectGrowing == "true" ? ":check_mark:".WithColor(Color.Green) : "");
+                        }
+                        else
+                        {
+                            table.AddRow(
+                                log.Uid,
+                                log.Name,
+                                log.ServiceCompany ?? "",
+                                log.GetStartIndexAsString(),
+                                log.GetEndIndexAsString(),
+                                log.ObjectGrowing == "true" ? ":check_mark:" : "");
+                        }
+
+                        previousIndexType = log.IndexType;
                     }
                 });
 

--- a/Src/WitsmlExplorer.Console/Program.cs
+++ b/Src/WitsmlExplorer.Console/Program.cs
@@ -36,6 +36,7 @@ namespace WitsmlExplorer.Console
             config.AddBranch("show", add =>
             {
                 add.AddCommand<ShowTubularCommand>("tubular").WithDescription("Export tubular within a well/wellbore");
+                add.AddCommand<ShowLogHeaderCommand>("log").WithDescription("Show a log header");
             });
 
             config.AddBranch("query", add =>

--- a/Src/WitsmlExplorer.Console/ShowCommands/ShowLogHeaderCommand.cs
+++ b/Src/WitsmlExplorer.Console/ShowCommands/ShowLogHeaderCommand.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using Witsml;
+using Witsml.Data;
+using Witsml.ServiceReference;
+using WitsmlExplorer.Console.Extensions;
+using WitsmlExplorer.Console.WitsmlClient;
+
+namespace WitsmlExplorer.Console.ShowCommands
+{
+    public class ShowLogHeaderCommand : AsyncCommand<ShowLogHeaderSettings>
+    {
+        private readonly IWitsmlClient witsmlClient;
+
+        public ShowLogHeaderCommand(IWitsmlClientProvider witsmlClientProvider)
+        {
+            witsmlClient = witsmlClientProvider?.GetClient();
+        }
+
+        public override async Task<int> ExecuteAsync(CommandContext context, ShowLogHeaderSettings settings)
+        {
+            if (witsmlClient == null) return -1;
+
+            var table = CreateTable();
+
+            var wellName = "<?>";
+            var wellboreName = "<?>";
+            var logName = "<?>";
+
+            await AnsiConsole.Status()
+                .Spinner(Spinner.Known.Dots)
+                .StartAsync("Fetching log...".WithColor(Color.Orange1), async _ =>
+                {
+                    var log = await GetLogHeader(settings.WellUid, settings.WellboreUid, settings.LogUid);
+                    wellName = log.NameWell;
+                    wellboreName = log.NameWellbore;
+                    logName = log.Name;
+
+                    var list = settings.OrderByEndIndex
+                        ? log.LogCurveInfo.OrderByDescending(lci => DateTime.Parse(lci.MaxDateTimeIndex)).ToList()
+                        : log.LogCurveInfo;
+
+
+                    foreach (var logCurveInfo in list.Take(settings.MaxMnemonics))
+                    {
+                        if (!string.IsNullOrEmpty(settings.FilterOnMnemonic) && logCurveInfo.Mnemonic != settings.FilterOnMnemonic)
+                            continue;
+
+                        table.AddRow(
+                            logCurveInfo.Mnemonic,
+                            logCurveInfo.MinDateTimeIndex,
+                            logCurveInfo.MaxDateTimeIndex
+                        );
+                    }
+                });
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"{"Well UID:".Bold()} {settings.WellUid}");
+            AnsiConsole.MarkupLine($"{"Wellbore UID:".Bold()} {settings.WellboreUid}");
+            AnsiConsole.MarkupLine($"{"Log UID".Bold()} {settings.LogUid}");
+            AnsiConsole.MarkupLine($"{"Well name:".Bold()} {wellName}");
+            AnsiConsole.MarkupLine($"{"Wellbore name:".Bold()} {wellboreName}");
+            AnsiConsole.MarkupLine($"{"Log name:".Bold()} {logName}");
+            AnsiConsole.Render(table);
+
+            return 0;
+        }
+
+        private Table CreateTable()
+        {
+            var table = new Table();
+            table.AddColumn("Mnemonic".Bold());
+            table.AddColumn("Start index".Bold());
+            table.AddColumn("End index".Bold());
+            return table;
+        }
+
+        private async Task<WitsmlLog> GetLogHeader(string wellUid, string wellboreUid, string logUid)
+        {
+            var query = new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog>
+                {
+                    new()
+                    {
+                        Uid = logUid,
+                        UidWell = wellUid,
+                        UidWellbore = wellboreUid
+                    }
+                }
+            };
+
+            var result = await witsmlClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.HeaderOnly));
+            return result?.Logs.FirstOrDefault();
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Console/ShowCommands/ShowLogHeaderSettings.cs
+++ b/Src/WitsmlExplorer.Console/ShowCommands/ShowLogHeaderSettings.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace WitsmlExplorer.Console.ShowCommands
+{
+    public class ShowLogHeaderSettings : CommandSettings
+    {
+        [CommandArgument(0, "<WELL_UID>")]
+        public string WellUid { get; init; }
+
+        [CommandArgument(1, "<WELLBORE_UID>")]
+        public string WellboreUid { get; init; }
+
+        [CommandArgument(2, "<LOG_UID>")]
+        public string LogUid { get; init; }
+
+        [CommandOption("--mnemonic")]
+        [Description("Filter on a given mnemonic")]
+        public string FilterOnMnemonic { get; init; }
+
+        [CommandOption("--orderByEndIndex")]
+        [Description("Order by descending end index instead of name")]
+        public bool OrderByEndIndex { get; init; }
+
+        [CommandOption("--max")]
+        [Description("Maximum number of mnemonics to list")]
+        [DefaultValue(999)]
+        public int MaxMnemonics { get; init; }
+    }
+}


### PR DESCRIPTION
## Fixes
This pull request is not related to an issue

## Description
This PR adds a command in the console application to list the log header for a given log, including mnemonic, start- and end index.

It also contains a change in the command for listing logs for a given well/wellbore to have a more visual representation of which logs are growing.
...

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* WitsmlExplorer.Console

## Checklist:

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests