### PR TITLE
Added CapabilitiesIn to requests to the Witsml servers.

### DIFF
--- a/Src/Witsml/Data/WitsmlClientCapabilities.cs
+++ b/Src/Witsml/Data/WitsmlClientCapabilities.cs
@@ -20,7 +20,7 @@ namespace Witsml.Data
         public string ApiVersion = "1.4.1";
 
         [XmlElement("contact")]
-        public string Contact { get; init; }
+        public ClientContactInformation Contact { get; init; }
 
         [XmlElement("description")]
         public string Description { get; init; }

--- a/Src/Witsml/Data/WitsmlClientCapabilities.cs
+++ b/Src/Witsml/Data/WitsmlClientCapabilities.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using System.Xml.Serialization;
+using Witsml.Xml;
+
+namespace Witsml.Data
+{
+    [XmlRoot("capClients", Namespace = "http://www.witsml.org/schemas/1series")]
+    public class WitsmlClientCapabilitiesRoot
+    {
+        [XmlAttribute("version")]
+        public string Version = "1.4.1";
+
+        [XmlElement("capClient")]
+        public WitsmlClientCapabilities ClientCapabilities { get; init; }
+    }
+
+    public class WitsmlClientCapabilities
+    {
+        [XmlAttribute("apiVers")]
+        public string ApiVersion = "1.4.1";
+
+        [XmlElement("contact")]
+        public string Contact { get; init; }
+
+        [XmlElement("description")]
+        public string Description { get; init; }
+
+        [XmlElement("name")]
+        public string Name { get; init; }
+
+        [XmlElement("vendor")]
+        public string Vendor { get; init; }
+
+        [XmlElement("version")]
+        public string Version { get; init; }
+
+        [XmlElement("schemaVersion")]
+        public string SchemaVersion = "1.3.1.1,1.4.1.1";
+
+        public string ToXml()
+        {
+            var capClients = new WitsmlClientCapabilitiesRoot {ClientCapabilities = this};
+            return XmlHelper.Serialize(capClients);
+        }
+    }
+
+    public class ClientContactInformation
+    {
+        [XmlElement("name")]
+        public string Name { get; init; }
+
+        [XmlElement("email")]
+        public string Email { get; init; }
+
+        [XmlElement("phone")]
+        public string Phone { get; init; }
+    }
+}

--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -25,15 +25,18 @@ namespace Witsml
 
     public class WitsmlClient : IWitsmlClient
     {
+        private readonly string clientCapabilities;
         private readonly StoreSoapPortClient client;
         private readonly Uri serverUrl;
         private Logger queryLogger;
 
-        public WitsmlClient(string hostname, string username, string password, bool logQueries = false)
+        public WitsmlClient(string hostname, string username, string password, WitsmlClientCapabilities clientCapabilities, bool logQueries = false)
         {
             if (string.IsNullOrEmpty(hostname)) throw new ArgumentNullException(nameof(hostname), "Hostname is required");
             if (string.IsNullOrEmpty(username)) throw new ArgumentNullException(nameof(username), "Username is required");
             if (string.IsNullOrEmpty(password)) throw new ArgumentNullException(nameof(password), "Password is required");
+
+            this.clientCapabilities = clientCapabilities.ToXml();
 
             var serviceBinding = CreateBinding();
             var endpointAddress = new EndpointAddress(hostname);
@@ -81,7 +84,7 @@ namespace Witsml
                     WMLtypeIn = query.TypeName,
                     OptionsIn = optionsIn.GetKeywords(),
                     QueryIn = XmlHelper.Serialize(query),
-                    CapabilitiesIn = ""
+                    CapabilitiesIn = clientCapabilities
                 };
 
                 var response = await client.WMLS_GetFromStoreAsync(request);
@@ -115,7 +118,7 @@ namespace Witsml
                 WMLtypeIn = type,
                 OptionsIn = optionsIn.GetKeywords(),
                 QueryIn = query,
-                CapabilitiesIn = ""
+                CapabilitiesIn = clientCapabilities
             };
 
             var response = await client.WMLS_GetFromStoreAsync(request);
@@ -136,7 +139,8 @@ namespace Witsml
                 {
                     WMLtypeIn = query.TypeName,
                     OptionsIn = optionsIn.GetKeywords(),
-                    XMLin = XmlHelper.Serialize(query)
+                    XMLin = XmlHelper.Serialize(query),
+                    CapabilitiesIn = clientCapabilities
                 };
 
                 var response = await client.WMLS_AddToStoreAsync(request);
@@ -163,7 +167,8 @@ namespace Witsml
                 var request = new WMLS_UpdateInStoreRequest
                 {
                     WMLtypeIn = query.TypeName,
-                    XMLin = XmlHelper.Serialize(query)
+                    XMLin = XmlHelper.Serialize(query),
+                    CapabilitiesIn = clientCapabilities
                 };
 
                 var response = await client.WMLS_UpdateInStoreAsync(request);
@@ -190,7 +195,8 @@ namespace Witsml
                 var request = new WMLS_DeleteFromStoreRequest
                 {
                     WMLtypeIn = query.TypeName,
-                    QueryIn = XmlHelper.Serialize(query)
+                    QueryIn = XmlHelper.Serialize(query),
+                    CapabilitiesIn = clientCapabilities
                 };
 
                 var response = await client.WMLS_DeleteFromStoreAsync(request);

--- a/Src/Witsml/Xml/Serializer.cs
+++ b/Src/Witsml/Xml/Serializer.cs
@@ -15,8 +15,11 @@ namespace Witsml.Xml
             using var textWriter = new StringWriter();
             using var writer = XmlWriter.Create(textWriter, settings);
 
+            var namespaces = new XmlSerializerNamespaces();
+            namespaces.Add("", "http://www.witsml.org/schemas/1series");
+
             var serializer = new XmlSerializer(typeof(T));
-            serializer.Serialize(writer, item);
+            serializer.Serialize(writer, item, namespaces);
 
             return textWriter.ToString();
         }

--- a/Src/WitsmlExplorer.Api/Program.cs
+++ b/Src/WitsmlExplorer.Api/Program.cs
@@ -2,8 +2,10 @@ using System.IO;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Witsml.Data;
 
 namespace WitsmlExplorer.Api
 {
@@ -13,9 +15,15 @@ namespace WitsmlExplorer.Api
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 .ConfigureAppConfiguration(ConfigConfiguration)
+                .ConfigureServices(ConfigureServices)
                 .UseSerilog((hostingContext, loggerConfiguration) => loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration))
                 .UseKestrel()
                 .Build();
+
+        private static void ConfigureServices(WebHostBuilderContext context, IServiceCollection services)
+        {
+            services.Configure<WitsmlClientCapabilities>(context.Configuration.GetSection("Witsml:ClientCapabilities"));
+        }
 
         private static void ConfigConfiguration(WebHostBuilderContext context, IConfigurationBuilder configurationBuilder)
         {

--- a/Src/WitsmlExplorer.Api/appsettings.json
+++ b/Src/WitsmlExplorer.Api/appsettings.json
@@ -1,5 +1,11 @@
 {
   "LogQueries": false,
   "AllowedHosts": "*",
-  "Host": "http://localhost"
+  "Host": "http://localhost",
+  "Witsml": {
+    "ClientCapabilities": {
+      "Name": "Witsml Explorer",
+      "Description": "Browser interface for Witsml servers"
+    }
+  }
 }

--- a/Src/WitsmlExplorer.Console/WitsmlClient/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Console/WitsmlClient/WitsmlClientProvider.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata;
 using Microsoft.Extensions.Configuration;
 using Spectre.Console;
 using Witsml;
+using Witsml.Data;
 using WitsmlExplorer.Console.Extensions;
 
 namespace WitsmlExplorer.Console.WitsmlClient
@@ -17,12 +18,18 @@ namespace WitsmlExplorer.Console.WitsmlClient
     {
         private readonly IWitsmlClient witsmlClient;
 
+        private readonly WitsmlClientCapabilities clientCapabilities = new()
+        {
+            Name = "Witsml Explorer CLI",
+            Description = "CLI interface for Witsml servers"
+        };
+
         public WitsmlClientProvider()
         {
             try
             {
                 var (serverUrl, username, password) = GetCredentialsFromConfiguration();
-                witsmlClient = new Witsml.WitsmlClient(serverUrl, username, password);
+                witsmlClient = new Witsml.WitsmlClient(serverUrl, username, password, clientCapabilities);
             }
             catch (Exception e)
             {

--- a/Tests/Witsml.Tests/Data/WitsmlClientCapabilitiesTests.cs
+++ b/Tests/Witsml.Tests/Data/WitsmlClientCapabilitiesTests.cs
@@ -1,0 +1,42 @@
+using Witsml.Data;
+using Xunit;
+
+namespace Witsml.Tests.Data
+{
+    public class WitsmlClientCapabilitiesTests
+    {
+        [Fact]
+        public void Serializing_DefaultObjectWithRequiredProperties_ReturnsExpected()
+        {
+            var expected = @"<capClients version=""1.4.1"" xmlns=""http://www.witsml.org/schemas/1series"">" +
+                                  @"<capClient apiVers=""1.4.1"">" +
+                                     "<schemaVersion>1.3.1.1,1.4.1.1</schemaVersion>" +
+                                   "</capClient>" +
+                                 "</capClients>";
+            var defaultObject = new WitsmlClientCapabilities();
+            var result = defaultObject.ToXml();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Serializing_WithNameAndDescription_ReturnsExpected()
+        {
+            var expected = @"<capClients version=""1.4.1"" xmlns=""http://www.witsml.org/schemas/1series"">" +
+                                  @"<capClient apiVers=""1.4.1"">" +
+                                     "<schemaVersion>1.3.1.1,1.4.1.1</schemaVersion>" +
+                                     "<description>Just a test</description>" +
+                                     "<name>Witsml Explorer</name>" +
+                                   "</capClient>" +
+                                 "</capClients>";
+            var defaultObject = new WitsmlClientCapabilities
+            {
+                Name = "Witsml Explorer",
+                Description = "Just a test"
+            };
+            var result = defaultObject.ToXml();
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/Tests/Witsml.Tests/Data/WitsmlClientCapabilitiesTests.cs
+++ b/Tests/Witsml.Tests/Data/WitsmlClientCapabilitiesTests.cs
@@ -6,7 +6,7 @@ namespace Witsml.Tests.Data
     public class WitsmlClientCapabilitiesTests
     {
         [Fact]
-        public void Serializing_DefaultObjectWithRequiredProperties_ReturnsExpected()
+        public void ToXml_DefaultObjectWithRequiredProperties_ReturnsExpected()
         {
             var expected = @"<capClients version=""1.4.1"" xmlns=""http://www.witsml.org/schemas/1series"">" +
                                   @"<capClient apiVers=""1.4.1"">" +
@@ -20,7 +20,7 @@ namespace Witsml.Tests.Data
         }
 
         [Fact]
-        public void Serializing_WithNameAndDescription_ReturnsExpected()
+        public void ToXml_WithNameAndDescription_ReturnsExpected()
         {
             var expected = @"<capClients version=""1.4.1"" xmlns=""http://www.witsml.org/schemas/1series"">" +
                                   @"<capClient apiVers=""1.4.1"">" +
@@ -29,12 +29,37 @@ namespace Witsml.Tests.Data
                                      "<name>Witsml Explorer</name>" +
                                    "</capClient>" +
                                  "</capClients>";
-            var defaultObject = new WitsmlClientCapabilities
+            var clientCapabilities = new WitsmlClientCapabilities
             {
                 Name = "Witsml Explorer",
                 Description = "Just a test"
             };
-            var result = defaultObject.ToXml();
+            var result = clientCapabilities.ToXml();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ToXml_WithContactInformation_ReturnsExpected()
+        {
+            var expected = @"<capClients version=""1.4.1"" xmlns=""http://www.witsml.org/schemas/1series"">" +
+                                  @"<capClient apiVers=""1.4.1"">" +
+                                     "<schemaVersion>1.3.1.1,1.4.1.1</schemaVersion>" +
+                                     "<contact>" +
+                                       "<name>Reodor Felgen</name>" +
+                                       "<email>reodor.felgen@flaaklypa.no</email>" +
+                                     "</contact>" +
+                                   "</capClient>" +
+                                 "</capClients>";
+            var clientCapabilities = new WitsmlClientCapabilities
+            {
+                Contact = new ClientContactInformation
+                {
+                    Name = "Reodor Felgen",
+                    Email = "reodor.felgen@flaaklypa.no"
+                }
+            };
+            var result = clientCapabilities.ToXml();
 
             Assert.Equal(expected, result);
         }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/LogObjectTests.cs
@@ -17,12 +17,13 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.AddToStore
     {
         private readonly ITestOutputHelper output;
         private readonly WitsmlClient client;
+        private readonly WitsmlClientCapabilities clientCapabilities = new();
 
         public LogObjectTests(ITestOutputHelper output)
         {
             this.output = output;
             var config = ConfigurationReader.GetWitsmlConfiguration();
-            client = new WitsmlClient(config.Hostname, config.Username, config.Password);
+            client = new WitsmlClient(config.Hostname, config.Username, config.Password, clientCapabilities);
         }
 
         [Fact(Skip="Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/TrajectoryTests.cs
@@ -19,12 +19,13 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.AddToStore
     {
         private readonly ITestOutputHelper output;
         private readonly WitsmlClient client;
+        private readonly WitsmlClientCapabilities clientCapabilities = new();
 
         public TrajectoryTests(ITestOutputHelper output)
         {
             this.output = output;
             var config = ConfigurationReader.GetWitsmlConfiguration();
-            client = new WitsmlClient(config.Hostname, config.Username, config.Password);
+            client = new WitsmlClient(config.Hostname, config.Username, config.Password, clientCapabilities);
         }
 
         [Fact(Skip="Should only be run manually")]


### PR DESCRIPTION
## Fixes
This pull request fixes #480

## Description
This pull requests adds CapabilitiesIn to requests that are sent to Witsml servers. 

The ClientCapabilities class has pre-defined, readonly properties for the required elements (apiVers, schemaVersion). 
The WitsmlClient class takes WitsmlClientCapabilities in as a required argument.
The API project creates a WitsmlClientCapabilities object based on settings defined in the "Witsml:ClientCapabilities" section in appsettings which has predefined values for `Name` and `Description`. This enables customization per installation since these can also be defined as environment variables. Example: If you want to add a value for the <vendor /> element and hosts the API from a docker file, set the `Witsml__ClientCapabilities__Vendor` environment variable to your desired value, for example `Equinor`.

I do not have a local runtime environment, so this PR requires additional assistance for complete testing
...

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* This PR primarily changes the Witsml library to support adding the CapabilitiesIn element in requests.

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests