### PR TITLE
Range adjusting buttons

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import moment, { Moment } from "moment";
 import { KeyboardDateTimePicker } from "@material-ui/pickers";
 import { DateFormat } from "../../Constants";
+import { SetRangeButtonRow } from "./SetRangeButtonRow";
+import { Button } from "@material-ui/core";
 
 export interface AdjustDateTimeModelProps {
   minDate: Moment;
@@ -11,17 +13,29 @@ export interface AdjustDateTimeModelProps {
   onValidChange: (isValid: boolean) => void;
 }
 
+interface SetRangeButton {
+  timeInMilliseconds: number;
+  displayText: string;
+}
+
 const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElement => {
   const { minDate, maxDate, onStartDateChanged, onEndDateChanged, onValidChange } = props;
   const [startIndex, setStartIndex] = useState<Moment>(minDate);
   const [endIndex, setEndIndex] = useState<Moment>(maxDate);
   const [startIndexIsValid, setStartIndexIsValid] = useState<boolean>();
   const [endIndexIsValid, setEndIndexIsValid] = useState<boolean>();
+  const setRangeButtons: SetRangeButton[] = [
+    { timeInMilliseconds: 3600000, displayText: 'hour' },
+    { timeInMilliseconds: 21600000, displayText: '6 hours' },
+    { timeInMilliseconds: 86400000, displayText: 'day' },
+    { timeInMilliseconds: 604800000, displayText: 'week' }
+  ];
+  const totalTimeSpan = Number(maxDate) - Number(minDate);
 
   useEffect(() => {
     onStartDateChanged(startIndex);
     onEndDateChanged(endIndex);
-  }, []);
+  }, [startIndex, endIndex]);
 
   useEffect(() => {
     if (startIndex && endIndex) {
@@ -36,16 +50,38 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
 
   const handleStartIndexChanged = (value: Moment) => {
     setStartIndex(value);
-    onStartDateChanged(value);
   };
 
   const handleEndIndexChanged = (value: Moment) => {
     setEndIndex(value);
-    onEndDateChanged(value);
   };
 
   return (
     <>
+      <SetRangeButtonRow>
+        {setRangeButtons.map((buttonValue) => {
+          return totalTimeSpan > buttonValue.timeInMilliseconds && (
+            <Button
+              key={"last" + buttonValue.displayText}
+              onClick={() => {
+                setStartIndex(endIndex.clone().subtract(buttonValue.timeInMilliseconds, "millisecond"));
+                setEndIndex(maxDate);
+              }}
+            >
+              {"Last " + buttonValue.displayText}
+            </Button>
+          )
+        })}
+        <Button
+          key={"resetRangeValues"}
+          onClick={() => {
+            setStartIndex(minDate);
+            setEndIndex(maxDate);
+          }}>
+            Reset
+          </Button>
+      </SetRangeButtonRow>
+
       <KeyboardDateTimePicker
         fullWidth
         disableToolbar

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import moment, { Moment } from "moment";
 import { KeyboardDateTimePicker } from "@material-ui/pickers";
 import { DateFormat } from "../../Constants";
-import { SetRangeButtonRow } from "./SetRangeButtonRow";
-import { Button } from "@material-ui/core";
+import { Button, ButtonGroup } from "@material-ui/core";
 
 export interface AdjustDateTimeModelProps {
   minDate: Moment;
@@ -58,7 +57,7 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
 
   return (
     <>
-      <SetRangeButtonRow>
+      <ButtonGroup aria-label="set time range button group" color="primary" style={{ margin: ".5rem" }}>
         {setRangeButtons.map((buttonValue) => {
           return (
             totalTimeSpan > buttonValue.timeInMilliseconds && (
@@ -83,7 +82,7 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
         >
           Reset
         </Button>
-      </SetRangeButtonRow>
+      </ButtonGroup>
 
       <KeyboardDateTimePicker
         fullWidth

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
@@ -25,10 +25,10 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
   const [startIndexIsValid, setStartIndexIsValid] = useState<boolean>();
   const [endIndexIsValid, setEndIndexIsValid] = useState<boolean>();
   const setRangeButtons: SetRangeButton[] = [
-    { timeInMilliseconds: 3600000, displayText: 'hour' },
-    { timeInMilliseconds: 21600000, displayText: '6 hours' },
-    { timeInMilliseconds: 86400000, displayText: 'day' },
-    { timeInMilliseconds: 604800000, displayText: 'week' }
+    { timeInMilliseconds: 3600000, displayText: "hour" },
+    { timeInMilliseconds: 21600000, displayText: "6 hours" },
+    { timeInMilliseconds: 86400000, displayText: "day" },
+    { timeInMilliseconds: 604800000, displayText: "week" }
   ];
   const totalTimeSpan = Number(maxDate) - Number(minDate);
 
@@ -60,26 +60,29 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
     <>
       <SetRangeButtonRow>
         {setRangeButtons.map((buttonValue) => {
-          return totalTimeSpan > buttonValue.timeInMilliseconds && (
-            <Button
-              key={"last" + buttonValue.displayText}
-              onClick={() => {
-                setStartIndex(endIndex.clone().subtract(buttonValue.timeInMilliseconds, "millisecond"));
-                setEndIndex(maxDate);
-              }}
-            >
-              {"Last " + buttonValue.displayText}
-            </Button>
-          )
+          return (
+            totalTimeSpan > buttonValue.timeInMilliseconds && (
+              <Button
+                key={"last" + buttonValue.displayText}
+                onClick={() => {
+                  setStartIndex(endIndex.clone().subtract(buttonValue.timeInMilliseconds, "millisecond"));
+                  setEndIndex(maxDate);
+                }}
+              >
+                {"Last " + buttonValue.displayText}
+              </Button>
+            )
+          );
         })}
         <Button
           key={"resetRangeValues"}
           onClick={() => {
             setStartIndex(minDate);
             setEndIndex(maxDate);
-          }}>
-            Reset
-          </Button>
+          }}
+        >
+          Reset
+        </Button>
       </SetRangeButtonRow>
 
       <KeyboardDateTimePicker

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Button, TextField } from "@material-ui/core";
-import { SetRangeButtonRow } from "./SetRangeButtonRow";
+import { Button, ButtonGroup, TextField } from "@material-ui/core";
 
 export interface AdjustNumberRangeModalProps {
   minValue: number;
@@ -47,7 +46,7 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
 
   return (
     <>
-      <SetRangeButtonRow>
+      <ButtonGroup aria-label="set depth range button group" color="primary" style={{ margin: ".5rem" }}>
         {setRangeButtonValues.map((buttonValue) => {
           return (
             totalDepthSpan > buttonValue && (
@@ -72,7 +71,7 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
         >
           Reset
         </Button>
-      </SetRangeButtonRow>
+      </ButtonGroup>
       <TextField
         fullWidth
         label={"Start index"}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { TextField } from "@material-ui/core";
+import { Button, TextField } from "@material-ui/core";
+import styled from "styled-components";
 
 export interface AdjustNumberRangeModalProps {
   minValue: number;
@@ -15,6 +16,8 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
   const [endValue, setEndIndex] = useState<number>(maxValue);
   const [startIndexIsValid, setStartIndexIsValid] = useState<boolean>();
   const [endIndexIsValid, setEndIndexIsValid] = useState<boolean>();
+  const buttonValues = [20, 50, 200, 1000];
+  const totalValueRange = maxValue - minValue;
 
   useEffect(() => {
     onStartValueChanged(startValue);
@@ -46,6 +49,32 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
 
   return (
     <>
+      <ButtonRow>
+        {buttonValues.map((buttonValue) => {
+          return (totalValueRange > buttonValue) && (
+            <Button
+              key={"last" + buttonValue}
+              onClick={() => {
+                setStartIndex(endValue - buttonValue);
+                onStartValueChanged(endValue - buttonValue);
+              }}
+            >
+              {"Last " + buttonValue}
+            </Button>
+          )
+        })}
+        <Button
+          key={"resetRangeValues"}
+          onClick={() => {
+            setStartIndex(minValue);
+            onStartValueChanged(minValue);
+            setEndIndex(maxValue);
+            onEndValueChanged(maxValue)
+          }}>
+          Reset
+        </Button>
+      </ButtonRow>
+
       <TextField
         fullWidth
         label={"Start index"}
@@ -67,5 +96,12 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
     </>
   );
 };
+
+const ButtonRow = styled("div")`
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  gap: 1rem;
+`
 
 export default AdjustNumberRangeModal;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
@@ -49,24 +49,27 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
     <>
       <SetRangeButtonRow>
         {setRangeButtonValues.map((buttonValue) => {
-          return (totalDepthSpan > buttonValue) && (
-            <Button
-              key={"last" + buttonValue}
-              onClick={() => {
-                setStartIndex(maxValue - buttonValue);
-                setEndIndex(maxValue);
-              }}
-            >
-              {"Last " + buttonValue}
-            </Button>
-          )
+          return (
+            totalDepthSpan > buttonValue && (
+              <Button
+                key={"last" + buttonValue}
+                onClick={() => {
+                  setStartIndex(maxValue - buttonValue);
+                  setEndIndex(maxValue);
+                }}
+              >
+                {"Last " + buttonValue}
+              </Button>
+            )
+          );
         })}
         <Button
           key={"resetRangeValues"}
           onClick={() => {
             setStartIndex(minValue);
             setEndIndex(maxValue);
-          }}>
+          }}
+        >
           Reset
         </Button>
       </SetRangeButtonRow>

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustNumberRangeModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Button, TextField } from "@material-ui/core";
-import styled from "styled-components";
+import { SetRangeButtonRow } from "./SetRangeButtonRow";
 
 export interface AdjustNumberRangeModalProps {
   minValue: number;
@@ -16,13 +16,13 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
   const [endValue, setEndIndex] = useState<number>(maxValue);
   const [startIndexIsValid, setStartIndexIsValid] = useState<boolean>();
   const [endIndexIsValid, setEndIndexIsValid] = useState<boolean>();
-  const buttonValues = [20, 50, 200, 1000];
-  const totalValueRange = maxValue - minValue;
+  const setRangeButtonValues = [20, 50, 200, 1000];
+  const totalDepthSpan = maxValue - minValue;
 
   useEffect(() => {
     onStartValueChanged(startValue);
     onEndValueChanged(endValue);
-  }, []);
+  }, [startValue, endValue]);
 
   useEffect(() => {
     setStartIndexIsValid(startValue < endValue);
@@ -36,27 +36,25 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
   const handleStartIndexChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.value) {
       setStartIndex(Number(event.target.value));
-      onStartValueChanged(Number(event.target.value));
     }
   };
 
   const handleEndIndexChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.value) {
       setEndIndex(Number(event.target.value));
-      onEndValueChanged(Number(event.target.value));
     }
   };
 
   return (
     <>
-      <ButtonRow>
-        {buttonValues.map((buttonValue) => {
-          return (totalValueRange > buttonValue) && (
+      <SetRangeButtonRow>
+        {setRangeButtonValues.map((buttonValue) => {
+          return (totalDepthSpan > buttonValue) && (
             <Button
               key={"last" + buttonValue}
               onClick={() => {
-                setStartIndex(endValue - buttonValue);
-                onStartValueChanged(endValue - buttonValue);
+                setStartIndex(maxValue - buttonValue);
+                setEndIndex(maxValue);
               }}
             >
               {"Last " + buttonValue}
@@ -67,14 +65,11 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
           key={"resetRangeValues"}
           onClick={() => {
             setStartIndex(minValue);
-            onStartValueChanged(minValue);
             setEndIndex(maxValue);
-            onEndValueChanged(maxValue)
           }}>
           Reset
         </Button>
-      </ButtonRow>
-
+      </SetRangeButtonRow>
       <TextField
         fullWidth
         label={"Start index"}
@@ -96,12 +91,5 @@ const AdjustNumberRangeModal = (props: AdjustNumberRangeModalProps): React.React
     </>
   );
 };
-
-const ButtonRow = styled("div")`
-  display: flex;
-  flex-direction: row;
-  justify-content: start;
-  gap: 1rem;
-`
 
 export default AdjustNumberRangeModal;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/SetRangeButtonRow.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/SetRangeButtonRow.ts
@@ -5,4 +5,4 @@ export const SetRangeButtonRow = styled.div`
   flex-direction: row;
   justify-content: start;
   gap: 1rem;
-`
+`;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/SetRangeButtonRow.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/SetRangeButtonRow.ts
@@ -1,8 +1,0 @@
-﻿import styled from "styled-components";
-
-export const SetRangeButtonRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: start;
-  gap: 1rem;
-`;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/SetRangeButtonRow.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/SetRangeButtonRow.ts
@@ -1,0 +1,8 @@
+﻿import styled from "styled-components";
+
+export const SetRangeButtonRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  gap: 1rem;
+`


### PR DESCRIPTION
## Fixes
This pull request fixes #654

## Description
Buttons for the depth and time modals to quickly set the range to commonly used values.

![SetRangeButtons](https://user-images.githubusercontent.com/1553016/133255852-3b852f34-e550-423e-b134-80eb9927e3d9.gif)


## Type of change
* Enhancement of existing functionality

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Depth and Time modals for viewing curves

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
