### PR TITLE
Add DotProgress as loading indicator when fetching wellbores

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/TreeItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/TreeItem.tsx
@@ -8,15 +8,17 @@ import NavigationContext from "../../contexts/navigationContext";
 import { ToggleTreeNodeAction } from "../../contexts/navigationStateReducer";
 import NavigationType from "../../contexts/navigationType";
 import { IsActiveIcon } from "../Icons/IsActiveIcon";
+import { DotProgress } from "@equinor/eds-core-react";
 
 interface StyledTreeItemProps extends TreeItemProps {
   labelText: string;
   selected?: boolean;
   isActive?: boolean;
+  isLoading?: boolean;
 }
 
 const StyledTreeItem = (props: StyledTreeItemProps): React.ReactElement => {
-  const { labelText, selected, isActive, ...other } = props; // eslint-disable-line
+  const { labelText, selected, isActive, isLoading, ...other } = props; // eslint-disable-line
   const { dispatchNavigation } = useContext(NavigationContext);
   const isCompactMode = useTheme().props.MuiCheckbox.size === "small";
 
@@ -32,7 +34,7 @@ const StyledTreeItem = (props: StyledTreeItemProps): React.ReactElement => {
         <Label>
           {isActive && <IsActiveIcon />}
           <NavigationDrawer selected={selected} compactMode={isCompactMode}>
-            {labelText}
+            {labelText} {isLoading && <DotProgress color={"primary"} size={32} />}
           </NavigationDrawer>
         </Label>
       }

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -125,6 +125,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
       onLabelClick={onLabelClick}
       onIconClick={onIconClick}
       isActive={wellbore.isActive}
+      isLoading={isFetchingData}
     >
       <TreeItem
         nodeId={logGroupId}

--- a/Src/WitsmlExplorer.Frontend/package.json
+++ b/Src/WitsmlExplorer.Frontend/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@date-io/moment": "^2.11.0",
+    "@equinor/eds-core-react": "^0.13.1",
     "@equinor/eds-tokens": "^0.6.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",


### PR DESCRIPTION
## Fixes
This pull request fixes #660 

## Descriptio
Adds a loading indicator next to wellbores in the tree view.

![WellboreTreeviewLoadingIndicators](https://user-images.githubusercontent.com/1553016/134185305-624d2d1e-ac93-4bfc-8242-a7f8480cde1b.gif)

## Type of change
* Enhancement of existing functionality
* 
## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Tree view

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass

## Further comments
Note that this only adds a loading indicator to the tree view, not the list view. We should probably add this to the list view as well.