### PR TITLE
Refactored copy log data and fixed check for existing mnemonics to be case insensitive

### DIFF
--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -22,4 +22,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Witsml\Witsml.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Update="appsettings.Development.json">
+      <DependentUpon>appsettings.json</DependentUpon>
+    </Content>
+    <Content Update="appsettings.Production.json">
+      <DependentUpon>appsettings.json</DependentUpon>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
@@ -117,9 +117,9 @@ namespace WitsmlExplorer.Api.Workers
         private async Task VerifyTargetHasRequiredLogCurveInfos(WitsmlLog sourceLog, IEnumerable<string> sourceMnemonics, WitsmlLog targetLog)
         {
             var newLogCurveInfos = new List<WitsmlLogCurveInfo>();
-            foreach (var mnemonic in sourceMnemonics.Where(mnemonic => !string.Equals(mnemonic, targetLog.IndexCurve.Value, StringComparison.OrdinalIgnoreCase)))
+            foreach (var mnemonic in sourceMnemonics.Where(mnemonic => !string.Equals(targetLog.IndexCurve.Value, mnemonic, StringComparison.OrdinalIgnoreCase)))
             {
-                if (targetLog.LogCurveInfo.All(lci => lci.Mnemonic != mnemonic))
+                if (targetLog.LogCurveInfo.All(lci => !string.Equals(lci.Mnemonic, mnemonic, StringComparison.OrdinalIgnoreCase)))
                     newLogCurveInfos.Add(sourceLog.LogCurveInfo.Find(lci => lci.Mnemonic == mnemonic));
             }
 
@@ -181,7 +181,7 @@ namespace WitsmlExplorer.Api.Workers
             throw new Exception($"Source and Target has different index mnemonics. Source: {sourceIndexMnemonic}, Target: {targetIndexMnemonic}");
         }
 
-        private static void VerifyIndexCurveIsIncludedInMnemonics(WitsmlLog log, List<string> newMnemonics, List<string> existingMnemonics)
+        private static void VerifyIndexCurveIsIncludedInMnemonics(WitsmlLog log, IList<string> newMnemonics, IList<string> existingMnemonics)
         {
             var indexMnemonic = log.IndexCurve.Value;
             if (!newMnemonics.Contains(indexMnemonic, StringComparer.InvariantCultureIgnoreCase))

--- a/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Serilog;
 using Witsml;
 using Witsml.Data;
-using Witsml.Extensions;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
@@ -34,8 +33,8 @@ namespace WitsmlExplorer.Api.Workers
                 : sourceLog.LogCurveInfo.Select(lci => lci.Mnemonic).ToList();
 
             var targetLogMnemonics = targetLog.LogCurveInfo.Select(lci => lci.Mnemonic);
-            var existingMnemonicsInTarget = mnemonicsToCopy.Where(mnemonic => targetLogMnemonics.Contains(mnemonic)).ToList();
-            var newMnemonicsInTarget = mnemonicsToCopy.Where(mnemonic => !targetLogMnemonics.Contains(mnemonic)).ToList();
+            var existingMnemonicsInTarget = mnemonicsToCopy.Where(mnemonic => targetLogMnemonics.Contains(mnemonic, StringComparer.OrdinalIgnoreCase)).ToList();
+            var newMnemonicsInTarget = mnemonicsToCopy.Where(mnemonic => !targetLogMnemonics.Contains(mnemonic, StringComparer.OrdinalIgnoreCase)).ToList();
 
             try
             {
@@ -43,10 +42,11 @@ namespace WitsmlExplorer.Api.Workers
                 VerifyValidInterval(sourceLog);
                 VerifyMatchingIndexCurves(sourceLog, targetLog);
                 VerifyIndexCurveIsIncludedInMnemonics(sourceLog, newMnemonicsInTarget, existingMnemonicsInTarget);
+                await VerifyTargetHasRequiredLogCurveInfos(sourceLog, job.SourceLogCurvesReference.Mnemonics, targetLog);
             }
             catch (Exception e)
             {
-                Log.Error("Failed to copy log data", e);
+                Log.Error(e, "Failed to copy log data");
                 return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to copy log data", e.Message), null);
             }
 
@@ -90,7 +90,7 @@ namespace WitsmlExplorer.Api.Workers
                 var sourceData = await witsmlSourceClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.DataOnly));
                 if (!sourceData.Logs.Any()) break;
                 var sourceLogWithData = sourceData.Logs.First();
-                var copyNewCurvesQuery = CreateCopyQuery(targetLog, sourceLog, sourceLogWithData);
+                var copyNewCurvesQuery = CreateCopyQuery(targetLog, sourceLogWithData);
                 var result = await witsmlClient.UpdateInStoreAsync(copyNewCurvesQuery);
                 if (result.IsSuccessful)
                 {
@@ -103,10 +103,10 @@ namespace WitsmlExplorer.Api.Workers
                         "Failed to copy log data. " +
                         "Source: UidWell: {SourceWellUid}, UidWellbore: {SourceWellboreUid}, Uid: {SourceLogUid}. " +
                         "Target: UidWell: {TargetWellUid}, UidWellbore: {TargetWellboreUid}, Uid: {TargetLogUid}. " +
-                        "Current index: {startIndex}",
+                        "Current index: {StartIndex}",
                         job.SourceLogCurvesReference.LogReference.WellUid, job.SourceLogCurvesReference.LogReference.WellboreUid, job.SourceLogCurvesReference.LogReference.LogUid,
                         job.TargetLogReference.WellUid, job.TargetLogReference.WellboreUid, job.TargetLogReference.LogUid,
-                        startIndex);
+                        startIndex.GetValueAsString());
                     return new CopyResult { Success = false, NumberOfRowsCopied = numberOfDataRowsCopied };
                 }
             }
@@ -114,40 +114,38 @@ namespace WitsmlExplorer.Api.Workers
             return new CopyResult { Success = true, NumberOfRowsCopied = numberOfDataRowsCopied };
         }
 
-        private static WitsmlLogs CreateCopyQuery(WitsmlLog targetLog, WitsmlLog sourceLog, WitsmlLog sourceLogWithData)
+        private async Task VerifyTargetHasRequiredLogCurveInfos(WitsmlLog sourceLog, IEnumerable<string> sourceMnemonics, WitsmlLog targetLog)
         {
-            var sourceMnemonics = sourceLogWithData.LogData.MnemonicList.Split(",");
+            var newLogCurveInfos = new List<WitsmlLogCurveInfo>();
+            foreach (var mnemonic in sourceMnemonics.Where(mnemonic => !string.Equals(mnemonic, targetLog.IndexCurve.Value, StringComparison.OrdinalIgnoreCase)))
+            {
+                if (targetLog.LogCurveInfo.All(lci => lci.Mnemonic != mnemonic))
+                    newLogCurveInfos.Add(sourceLog.LogCurveInfo.Find(lci => lci.Mnemonic == mnemonic));
+            }
+
+            if (newLogCurveInfos.Any())
+            {
+                targetLog.LogCurveInfo.AddRange(newLogCurveInfos);
+                var query = new WitsmlLogs { Logs = new List<WitsmlLog> { targetLog } };
+
+                var result = await witsmlClient.UpdateInStoreAsync(query);
+                if (!result.IsSuccessful)
+                {
+                    var newMnemonics = string.Join(",", newLogCurveInfos.Select(lci => lci.Mnemonic));
+                    Log.Error("Failed to update LogCurveInfo for wellbore during copy data. Mnemonics: {Mnemonics}. " +
+                              "Target: UidWell: {TargetWellUid}, UidWellbore: {TargetWellboreUid}, Uid: {TargetLogUid}. ",
+                        newMnemonics, targetLog.UidWell, targetLog.UidWellbore, targetLog.Uid);
+                }
+            }
+        }
+
+        private static WitsmlLogs CreateCopyQuery(WitsmlLog targetLog, WitsmlLog sourceLogWithData)
+        {
             var updatedData = new WitsmlLog
             {
                 UidWell = targetLog.UidWell,
                 UidWellbore = targetLog.UidWellbore,
                 Uid = targetLog.Uid,
-                LogCurveInfo = sourceLog.LogCurveInfo
-                    .Where(LogCurveHasMnemonic(sourceMnemonics))
-                    .Select(lci => new WitsmlLogCurveInfo
-                    {
-                        Uid = GetTargetUidForCurve(lci, targetLog),
-                        Mnemonic = GetTargetNameForCurve(lci, targetLog),
-                        ClassWitsml = lci.ClassWitsml.NullIfEmpty(),
-                        ClassIndex = lci.ClassIndex.NullIfEmpty(),
-                        Unit = lci.Unit.NullIfEmpty(),
-                        MnemAlias = lci.MnemAlias.NullIfEmpty(),
-                        NullValue = lci.NullValue.NullIfEmpty(),
-                        AlternateIndex = lci.AlternateIndex.NullIfEmpty(),
-                        WellDatum = lci.WellDatum.NullIfEmpty(),
-                        MinIndex = null,
-                        MaxIndex = null,
-                        MinDateTimeIndex = null,
-                        MaxDateTimeIndex = null,
-                        CurveDescription = lci.CurveDescription.NullIfEmpty(),
-                        SensorOffset = lci.SensorOffset.NullIfEmpty(),
-                        DataSource = lci.DataSource.NullIfEmpty(),
-                        DensData = lci.DensData.NullIfEmpty(),
-                        TraceState = lci.TraceState.NullIfEmpty(),
-                        TraceOrigin = lci.TraceOrigin.NullIfEmpty(),
-                        TypeLogData = lci.TypeLogData.NullIfEmpty(),
-                        AxisDefinition = lci.AxisDefinition,
-                    }).ToList(),
                 LogData = sourceLogWithData.LogData
             };
 
@@ -156,11 +154,6 @@ namespace WitsmlExplorer.Api.Workers
                 Logs = new List<WitsmlLog> { updatedData }
             };
             return updatedWitsmlLog;
-        }
-
-        private static Func<WitsmlLogCurveInfo, bool> LogCurveHasMnemonic(string[] mnemonics)
-        {
-            return lci => mnemonics.Contains(lci.Mnemonic);
         }
 
         private static void VerifyMatchingIndexTypes(WitsmlLog sourceLog, WitsmlLog targetLog)
@@ -191,10 +184,10 @@ namespace WitsmlExplorer.Api.Workers
         private static void VerifyIndexCurveIsIncludedInMnemonics(WitsmlLog log, List<string> newMnemonics, List<string> existingMnemonics)
         {
             var indexMnemonic = log.IndexCurve.Value;
-            if (!newMnemonics.Contains(indexMnemonic))
+            if (!newMnemonics.Contains(indexMnemonic, StringComparer.InvariantCultureIgnoreCase))
                 newMnemonics.Insert(0, indexMnemonic);
 
-            if (!existingMnemonics.Contains(indexMnemonic))
+            if (!existingMnemonics.Contains(indexMnemonic, StringComparer.InvariantCultureIgnoreCase))
                 existingMnemonics.Insert(0, indexMnemonic);
         }
 
@@ -212,21 +205,6 @@ namespace WitsmlExplorer.Api.Workers
                                     $"UidWellbore: {job.SourceLogCurvesReference.LogReference.WellboreUid}, Uid: {job.SourceLogCurvesReference.LogReference.LogUid}");
 
             return (sourceLog.Result, targetLog.Result);
-        }
-
-        private static string GetTargetUidForCurve(WitsmlLogCurveInfo lci, WitsmlLog targetLog)
-        {
-            return targetLog.LogCurveInfo.Find(GetTargetCurveIfExists(lci))?.Uid ?? lci.Uid;
-        }
-
-        private static string GetTargetNameForCurve(WitsmlLogCurveInfo lci, WitsmlLog targetLog)
-        {
-            return targetLog.LogCurveInfo.Find(GetTargetCurveIfExists(lci))?.Mnemonic ?? lci.Mnemonic;
-        }
-
-        private static Predicate<WitsmlLogCurveInfo> GetTargetCurveIfExists(WitsmlLogCurveInfo lci)
-        {
-            return curve => curve.Mnemonic.Equals(lci.Mnemonic, StringComparison.OrdinalIgnoreCase);
         }
 
         private class CopyResult


### PR DESCRIPTION
# Request Template Witsml Explorer
Thank you for contributing to WITSML Explorer!
Before submitting this PR, please fill in the following template.

## Fixes
This pull request fixes #722

## Description
Refactored CopyLogDataWorker to not send LogCurveInfo when updating data. A verification check before copy is done to make sure that potential missing LogCurveInfos are added before copy.

Also done some updates to the checks for existing mnemonics to be case insensitive. This is a partial fix for #721

...

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Copying of log data

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests