### PR TITLE
Refactored worker service to not block requests

### DIFF
--- a/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NetCore.AutoRegisterDi;
+using Serilog;
+using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Repositories;
+using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Workers;
+
+namespace WitsmlExplorer.Api.Configuration
+{
+    public static class Dependencies
+    {
+        public static void ConfigureDependencies(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.AddSingleton<ICredentialsService, CredentialsService>();
+            services.AddScoped<IWitsmlClientProvider, WitsmlClientProvider>();
+            AddRepository<Server, Guid>(services, configuration);
+            services.RegisterAssemblyPublicNonGenericClasses(Assembly.GetAssembly(typeof(Program))).AsPublicImplementedInterfaces();
+            services.AddSingleton<IJobQueue, JobQueue>();
+        }
+
+        private static void AddRepository<TDocument, I>(IServiceCollection services, IConfiguration configuration) where TDocument : DbDocument<I>
+        {
+            if (!string.IsNullOrEmpty(configuration["MongoDb:Name"]))
+            {
+                Log.Information("Detected database config for MongoDB");
+                services.AddSingleton<IDocumentRepository<TDocument, I>, MongoRepository<TDocument, I>>();
+            }
+            else if (!string.IsNullOrEmpty(configuration["CosmosDb:Name"]))
+            {
+                Log.Information("Detected database config for CosmosDB");
+                services.AddSingleton<IDocumentRepository<TDocument, I>, CosmosRepository<TDocument, I>>();
+            }
+            else
+            {
+                Log.Error("Did not detect any configuration for database");
+                return;
+            }
+
+            var serviceProvider = services.BuildServiceProvider();
+            var repository = serviceProvider.GetService<IDocumentRepository<TDocument, I>>();
+            repository?.InitClient();
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Jobs/BatchModifyWellJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/BatchModifyWellJob.cs
@@ -3,8 +3,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class BatchModifyWellJob
+    public record BatchModifyWellJob
     {
-        public IEnumerable<Well> Wells { get; set; }
+        public IEnumerable<Well> Wells { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CopyLogDataJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyLogDataJob.cs
@@ -2,9 +2,9 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CopyLogDataJob
+    public record CopyLogDataJob
     {
-        public LogCurvesReference SourceLogCurvesReference { get; set; }
-        public LogReference TargetLogReference { get; set; }
+        public LogCurvesReference SourceLogCurvesReference { get; init; }
+        public LogReference TargetLogReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CopyLogJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyLogJob.cs
@@ -2,9 +2,9 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CopyLogJob
+    public record CopyLogJob
     {
-        public LogReferences Source { get; set; }
-        public WellboreReference Target { get; set; }
+        public LogReferences Source { get; init; }
+        public WellboreReference Target { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CopyTrajectoryJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyTrajectoryJob.cs
@@ -2,9 +2,9 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CopyTrajectoryJob
+    public record CopyTrajectoryJob
     {
-        public TrajectoryReference Source { get; set; }
-        public WellboreReference Target { get; set; }
+        public TrajectoryReference Source { get; init; }
+        public WellboreReference Target { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CreateLogJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CreateLogJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CreateLogJob
+    public record CreateLogJob
     {
-        public LogObject LogObject { get; set; }
+        public LogObject LogObject { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CreateMudLogJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CreateMudLogJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CreateMudLogJob
+    public record CreateMudLogJob
     {
-        public MudLog MudLog { get; set; }
+        public MudLog MudLog { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CreateRiskJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CreateRiskJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CreateRiskJob
+    public record CreateRiskJob
     {
-        public Risk Risk { get; set; }
+        public Risk Risk { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CreateWellJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CreateWellJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CreateWellJob
+    public record CreateWellJob
     {
-        public Well Well { get; set; }
+        public Well Well { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CreateWellboreJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CreateWellboreJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class CreateWellboreJob
+    public record CreateWellboreJob
     {
-        public Wellbore Wellbore { get; set; }
+        public Wellbore Wellbore { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteCurveValuesJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteCurveValuesJob.cs
@@ -3,16 +3,16 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteCurveValuesJob
+    public record DeleteCurveValuesJob
     {
-        public LogReference LogReference { get; set; }
-        public List<string> Mnemonics { get; set; }
-        public IEnumerable<IndexRange> IndexRanges { get; set; }
+        public LogReference LogReference { get; init; }
+        public IEnumerable<string> Mnemonics { get; init; }
+        public IEnumerable<IndexRange> IndexRanges { get; init; }
     }
 
-    public class IndexRange {
+    public record IndexRange {
 
-        public string StartIndex { get; set; }
-        public string EndIndex { get; set; }
+        public string StartIndex { get; init; }
+        public string EndIndex { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteLogObjectsJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteLogObjectsJob.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteLogObjectsJob
+    public record DeleteLogObjectsJob
     {
-        public IEnumerable<LogReference> LogReferences { get; set; }
+        public IEnumerable<LogReference> LogReferences { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteMessageObjectsJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteMessageObjectsJob.cs
@@ -4,8 +4,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteMessageObjectsJob
+    public record DeleteMessageObjectsJob
     {
-        public IEnumerable<MessageObjectReference> MessageObjects { get; set; }
+        public IEnumerable<MessageObjectReference> MessageObjects { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteMnemonicsJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteMnemonicsJob.cs
@@ -1,10 +1,11 @@
+using System.Collections.Generic;
 using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteMnemonicsJob
+    public record DeleteMnemonicsJob
     {
-        public LogReference LogObject { get; set; }
-        public string[] Mnemonics { get; set; }
+        public LogReference LogObject { get; init; }
+        public IEnumerable<string> Mnemonics { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteMudLogJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteMudLogJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteMudLogJob
+    public record DeleteMudLogJob
     {
-        public MudLogReference MudLogReference { get; set; }
+        public MudLogReference MudLogReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteRiskJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteRiskJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteRiskJob
+    public record DeleteRiskJob
     {
-        public RiskReference RiskReference { get; set; }
+        public RiskReference RiskReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteTrajectoryJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteTrajectoryJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteTrajectoryJob
+    public record DeleteTrajectoryJob
     {
-        public TrajectoryReference TrajectoryReference { get; set; }
+        public TrajectoryReference TrajectoryReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteWellJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteWellJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteWellJob
+    public record DeleteWellJob
     {
-        public WellReference WellReference { get; set; }
+        public WellReference WellReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteWellboreJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteWellboreJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class DeleteWellboreJob
+    public record DeleteWellboreJob
     {
-        public WellboreReference WellboreReference { get; set; }
+        public WellboreReference WellboreReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/ImportLogDataJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/ImportLogDataJob.cs
@@ -3,11 +3,11 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class ImportLogDataJob
+    public record ImportLogDataJob
     {
-        public LogReference TargetLog { get; set; }
-        public List<string> Mnemonics { get; set; }
-        public List<string> Units { get; set; }
-        public IEnumerable<IEnumerable<string>> DataRows { get; set; }
+        public LogReference TargetLog { get; init; }
+        public IEnumerable<string> Mnemonics { get; init; }
+        public IEnumerable<string> Units { get; init; }
+        public IEnumerable<IEnumerable<string>> DataRows { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/ModifyLogObjectJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/ModifyLogObjectJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class ModifyLogObjectJob
+    public record ModifyLogObjectJob
     {
-        public LogObject LogObject { get; set; }
+        public LogObject LogObject { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/ModifyMessageObjectJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/ModifyMessageObjectJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class ModifyMessageObjectJob
+    public record ModifyMessageObjectJob
     {
-        public MessageObject MessageObject { get; set; }
+        public MessageObject MessageObject { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/ModifyMudLogJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/ModifyMudLogJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class ModifyMudLogJob
+    public record ModifyMudLogJob
     {
-        public MudLog MudLog { get; set; }
+        public MudLog MudLog { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/ModifyWellJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/ModifyWellJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class ModifyWellJob
+    public record ModifyWellJob
     {
-        public Well Well { get; set; }
+        public Well Well { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/ModifyWellboreJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/ModifyWellboreJob.cs
@@ -2,8 +2,8 @@ using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class ModifyWellboreJob
+    public record ModifyWellboreJob
     {
-        public Wellbore Wellbore { get; set; }
+        public Wellbore Wellbore { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/RenameMnemonicJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/RenameMnemonicJob.cs
@@ -2,10 +2,10 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class RenameMnemonicJob
+    public record RenameMnemonicJob
     {
-        public LogReference LogReference { get; set; }
-        public string Mnemonic { get; set; }
-        public string NewMnemonic { get; set; }
+        public LogReference LogReference { get; init; }
+        public string Mnemonic { get; init; }
+        public string NewMnemonic { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/TrimLogDataJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/TrimLogDataJob.cs
@@ -2,12 +2,12 @@ using WitsmlExplorer.Api.Jobs.Common;
 
 namespace WitsmlExplorer.Api.Jobs
 {
-    public class TrimLogDataJob
+    public record TrimLogDataJob
     {
-        public LogReference LogObject { get; set; }
+        public LogReference LogObject { get; init; }
 
-        public string StartIndex { get; set; }
+        public string StartIndex { get; init; }
 
-        public string EndIndex { get; set; }
+        public string EndIndex { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Query/LogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/LogQueries.cs
@@ -124,7 +124,7 @@ namespace WitsmlExplorer.Api.Query
             };
         }
 
-        public static WitsmlLogs DeleteMnemonics(string wellUid, string wellboreUid, string logUid, string[] mnemonics)
+        public static WitsmlLogs DeleteMnemonics(string wellUid, string wellboreUid, string logUid, IEnumerable<string> mnemonics)
         {
             return new WitsmlLogs
             {

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -206,7 +206,7 @@ namespace WitsmlExplorer.Api
             var wellUid = httpRequest.RouteValues.As<string>("wellUid");
             var wellboreUid = httpRequest.RouteValues.As<string>("wellboreUid");
             var logUid = httpRequest.RouteValues.As<string>("logUid");
-            var mnemonics = await httpRequest.ReadFromJsonAsync<IEnumerable<string>>();
+            var mnemonics = (await httpRequest.ReadFromJsonAsync<IEnumerable<string>>() ?? Array.Empty<string>()).ToList();
             if (mnemonics.Any())
             {
                 string startIndex = null;
@@ -284,10 +284,11 @@ namespace WitsmlExplorer.Api
             await httpResponse.AsJson(mudLog);
         }
 
-        private async Task CreateJob(HttpRequest httpRequest, HttpResponse httpResponse)
+        private Task CreateJob(HttpRequest httpRequest, HttpResponse httpResponse)
         {
             var jobType = httpRequest.RouteValues.As<JobType>("jobType");
-            await jobService.CreateJob(jobType, httpRequest.Body);
+            jobService.CreateJob(jobType, httpRequest.Body);
+            return Task.CompletedTask;
         }
 
         private async Task Authorize(HttpRequest httpRequest, HttpResponse httpResponse)

--- a/Src/WitsmlExplorer.Api/Services/JobService.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobService.cs
@@ -1,10 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
-using WitsmlExplorer.Api.Extensions;
-using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Workers;
 
@@ -12,218 +10,27 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface IJobService
     {
-        Task CreateJob(JobType jobType, Stream httpRequestBody);
+        void CreateJob(JobType jobType, Stream httpRequestBody);
     }
 
     public class JobService : IJobService
     {
-        private readonly IHubContext<NotificationsHub> hubContext;
-        private readonly IWorker<CopyLogJob> copyLogWorker;
-        private readonly IWorker<CopyLogDataJob> copyLogDataWorker;
-        private readonly IWorker<CopyTrajectoryJob> copyTrajectoryWorker;
-        private readonly IWorker<TrimLogDataJob> trimLogObjectWorker;
-        private readonly IWorker<ModifyLogObjectJob> modifyLogObjectWorker;
-        private readonly IWorker<DeleteMessageObjectsJob> deleteMessageObjectWorker;
-        private readonly IWorker<ModifyMessageObjectJob> modifyMessageObjectWorker;
-        private readonly IDeleteCurveValuesWorker deleteCurveValuesWorker;
-        private readonly IDeleteLogObjectsWorker deleteLogObjectsWorker;
-        private readonly IDeleteMnemonicsWorker deleteMnemonicsWorker;
-        private readonly IDeleteWellWorker deleteWellWorker;
-        private readonly IDeleteWellboreWorker deleteWellboreWorker;
-        private readonly IDeleteRiskWorker deleteRiskWorker;
-        private readonly IDeleteMudLogWorker deleteMudLogWorker;
-        private readonly IDeleteTrajectoryWorker deleteTrajectoryWorker;
-        private readonly IRenameMnemonicWorker renameMnemonicWorker;
-        private readonly IWorker<ModifyWellJob> modifyWellWorker;
-        private readonly IWorker<ModifyWellboreJob> modifyWellboreWorker;
-        private readonly IWorker<ModifyMudLogJob> modifyMudLogWorker;
-        private readonly IWorker<CreateLogJob> createLogWorker;
-        private readonly IWorker<CreateWellJob> createWellWorker;
-        private readonly IWorker<CreateWellboreJob> createWellboreWorker;
-        private readonly IWorker<CreateRiskJob> createRiskWorker;
-        private readonly IWorker<CreateMudLogJob> createMudLogWorker;
-        private readonly IWorker<BatchModifyWellJob> batchModifyWellWorker;
-        private readonly IWorker<ImportLogDataJob> importLogDataWorker;
+        private readonly IJobQueue jobQueue;
+        private readonly IEnumerable<IWorker> workers;
 
-        public JobService(
-            IHubContext<NotificationsHub> hubContext,
-            IWorker<CopyLogJob> copyLogWorker,
-            IWorker<CopyLogDataJob> copyLogDataWorker,
-            IWorker<CopyTrajectoryJob> copyTrajectoryWorker,
-            IWorker<TrimLogDataJob> trimLogObjectWorker,
-            IWorker<ModifyLogObjectJob> modifyLogObjectWorker,
-            IDeleteCurveValuesWorker deleteCurveValuesWorker,
-            IDeleteLogObjectsWorker deleteLogObjectsWorker,
-            IDeleteMnemonicsWorker deleteMnemonicsWorker,
-            IDeleteTrajectoryWorker deleteTrajectoryWorker,
-            IDeleteWellWorker deleteWellWorker,
-            IDeleteWellboreWorker deleteWellboreWorker,
-            IDeleteRiskWorker deleteRiskWorker,
-            IDeleteMudLogWorker deleteMudLogWorker,
-            IRenameMnemonicWorker renameMnemonicWorker,
-            IWorker<ModifyWellJob> modifyWellWorker,
-            IWorker<ModifyWellboreJob> modifyWellboreWorker,
-            IWorker<ModifyMudLogJob> modifyMudLogWorker,
-            IWorker<CreateLogJob> createLogWorker,
-            IWorker<CreateWellJob> createWellWorker,
-            IWorker<CreateWellboreJob> createWellboreWorker,
-            IWorker<CreateRiskJob> createRiskWorker,
-            IWorker<CreateMudLogJob> createMudLogWorker,
-            IWorker<ImportLogDataJob> importLogDataWorker,
-            IWorker<BatchModifyWellJob> batchModifyWellWorker,
-            IWorker<DeleteMessageObjectsJob> deleteMessageObjectWorker,
-            IWorker<ModifyMessageObjectJob> modifyMessageObjectWorker)
+        public JobService(IJobQueue jobQueue, IEnumerable<IWorker> workers)
         {
-            this.hubContext = hubContext;
-            this.copyLogWorker = copyLogWorker;
-            this.copyLogDataWorker = copyLogDataWorker;
-            this.copyTrajectoryWorker = copyTrajectoryWorker;
-            this.trimLogObjectWorker = trimLogObjectWorker;
-            this.modifyLogObjectWorker = modifyLogObjectWorker;
-            this.deleteCurveValuesWorker = deleteCurveValuesWorker;
-            this.deleteLogObjectsWorker = deleteLogObjectsWorker;
-            this.deleteMnemonicsWorker = deleteMnemonicsWorker;
-            this.deleteTrajectoryWorker = deleteTrajectoryWorker;
-            this.deleteWellWorker = deleteWellWorker;
-            this.deleteWellboreWorker = deleteWellboreWorker;
-            this.deleteRiskWorker = deleteRiskWorker;
-            this.deleteMudLogWorker = deleteMudLogWorker;
-            this.renameMnemonicWorker = renameMnemonicWorker;
-            this.modifyWellWorker = modifyWellWorker;
-            this.modifyWellboreWorker = modifyWellboreWorker;
-            this.modifyMudLogWorker = modifyMudLogWorker;
-            this.createLogWorker = createLogWorker;
-            this.deleteMessageObjectWorker = deleteMessageObjectWorker;
-            this.modifyMessageObjectWorker = modifyMessageObjectWorker;
-            this.createWellWorker = createWellWorker;
-            this.createWellboreWorker = createWellboreWorker;
-            this.createRiskWorker = createRiskWorker;
-            this.createMudLogWorker = createMudLogWorker;
-            this.batchModifyWellWorker = batchModifyWellWorker;
-            this.importLogDataWorker = importLogDataWorker;
+            this.jobQueue = jobQueue;
+            this.workers = workers;
         }
 
-        public async Task CreateJob(JobType jobType, Stream jobStream)
+        public void CreateJob(JobType jobType, Stream jobStream)
         {
-            WorkerResult result;
-            RefreshAction refreshAction = null;
-            switch (jobType)
-            {
-                case JobType.CopyLog:
-                    var copyLogJob = await jobStream.Deserialize<CopyLogJob>();
-                    (result, refreshAction) = await copyLogWorker.Execute(copyLogJob);
-                    break;
-                case JobType.CopyLogData:
-                    var copyLogDataJob = await jobStream.Deserialize<CopyLogDataJob>();
-                    (result, refreshAction) = await copyLogDataWorker.Execute(copyLogDataJob);
-                    break;
-                case JobType.CopyTrajectory:
-                    var copyTrajectoryJob = await jobStream.Deserialize<CopyTrajectoryJob>();
-                    (result, refreshAction) = await copyTrajectoryWorker.Execute(copyTrajectoryJob);
-                    break;
-                case JobType.TrimLogObject:
-                    var trimLogObjectJob = await jobStream.Deserialize<TrimLogDataJob>();
-                    (result, refreshAction) = await trimLogObjectWorker.Execute(trimLogObjectJob);
-                    break;
-                case JobType.ModifyLogObject:
-                    var modifyLogObjectJob = await jobStream.Deserialize<ModifyLogObjectJob>();
-                    (result, refreshAction) = await modifyLogObjectWorker.Execute(modifyLogObjectJob);
-                    break;
-                case JobType.DeleteCurveValues:
-                    var deleteCurveValuesJob = await jobStream.Deserialize<DeleteCurveValuesJob>();
-                    (result, refreshAction) = await deleteCurveValuesWorker.Execute(deleteCurveValuesJob);
-                    break;
-                case JobType.DeleteLogObjects:
-                    var deleteLogObjectsJob = await jobStream.Deserialize<DeleteLogObjectsJob>();
-                    (result, refreshAction) = await deleteLogObjectsWorker.Execute(deleteLogObjectsJob);
-                    break;
-                case JobType.DeleteMnemonics:
-                    var deleteMnemonicsJob = await jobStream.Deserialize<DeleteMnemonicsJob>();
-                    (result, refreshAction) = await deleteMnemonicsWorker.Execute(deleteMnemonicsJob);
-                    break;
-                case JobType.DeleteWell:
-                    var deleteWellJob = await jobStream.Deserialize<DeleteWellJob>();
-                    (result, refreshAction) = await deleteWellWorker.Execute(deleteWellJob);
-                    break;
-                case JobType.DeleteWellbore:
-                    var deleteWellboreJob = await jobStream.Deserialize<DeleteWellboreJob>();
-                    (result, refreshAction) = await deleteWellboreWorker.Execute(deleteWellboreJob);
-                    break;
-                case JobType.DeleteRisk:
-                    var deleteRiskJob = await jobStream.Deserialize<DeleteRiskJob>();
-                    (result, refreshAction) = await deleteRiskWorker.Execute(deleteRiskJob);
-                    break;
-                case JobType.DeleteMudLog:
-                    var deleteMudLogJob = await jobStream.Deserialize<DeleteMudLogJob>();
-                    (result, refreshAction) = await deleteMudLogWorker.Execute(deleteMudLogJob);
-                    break;
-                case JobType.RenameMnemonic:
-                    var modifyLogCurveInfoJob = await jobStream.Deserialize<RenameMnemonicJob>();
-                    (result, refreshAction) = await renameMnemonicWorker.Execute(modifyLogCurveInfoJob);
-                    break;
-                case JobType.ModifyWell:
-                    var modifyWellJob = await jobStream.Deserialize<ModifyWellJob>();
-                    (result, refreshAction) = await modifyWellWorker.Execute(modifyWellJob);
-                    break;
-                case JobType.ModifyWellbore:
-                    var modifyWellboreJob = await jobStream.Deserialize<ModifyWellboreJob>();
-                    (result, refreshAction) = await modifyWellboreWorker.Execute(modifyWellboreJob);
-                    break;
-                case JobType.ModifyMudLog:
-                    var modifyMudLogJob = await jobStream.Deserialize<ModifyMudLogJob>();
-                    (result, refreshAction) = await modifyMudLogWorker.Execute(modifyMudLogJob);
-                    break;
-                case JobType.DeleteTrajectory:
-                    var deleteTrajectoryJob = await jobStream.Deserialize<DeleteTrajectoryJob>();
-                    result = await deleteTrajectoryWorker.Execute(deleteTrajectoryJob);
-                    break;
-                case JobType.CreateLogObject:
-                    var createLogObject = await jobStream.Deserialize<CreateLogJob>();
-                    (result, refreshAction) = await createLogWorker.Execute(createLogObject);
-                    break;
-                case JobType.DeleteMessageObjects:
-                    var deleteMessageObjectJob = await jobStream.Deserialize<DeleteMessageObjectsJob>();
-                    (result, refreshAction) = await deleteMessageObjectWorker.Execute(deleteMessageObjectJob);
-                    break;
-                case JobType.ModifyMessageObject:
-                    var modifyMessageObjectJob = await jobStream.Deserialize<ModifyMessageObjectJob>();
-                    (result, refreshAction) = await modifyMessageObjectWorker.Execute(modifyMessageObjectJob);
-                    break;
-                case JobType.CreateWell:
-                    var createWellJob = await jobStream.Deserialize<CreateWellJob>();
-                    (result, refreshAction) = await createWellWorker.Execute(createWellJob);
-                    break;
-                case JobType.CreateWellbore:
-                    var createWellboreJob = await jobStream.Deserialize<CreateWellboreJob>();
-                    (result, refreshAction) = await createWellboreWorker.Execute(createWellboreJob);
-                    break;
-                case JobType.CreateRisk:
-                    var createRiskJob = await jobStream.Deserialize<CreateRiskJob>();
-                    (result, refreshAction) = await createRiskWorker.Execute(createRiskJob);
-                    break;
-                case JobType.CreateMudLog:
-                    var createMudLogJob = await jobStream.Deserialize<CreateMudLogJob>();
-                    (result, refreshAction) = await createMudLogWorker.Execute(createMudLogJob);
-                    break;
-                case JobType.BatchModifyWell:
-                    var batchModifyWellJob = await jobStream.Deserialize<BatchModifyWellJob>();
-                    (result, refreshAction) = await batchModifyWellWorker.Execute(batchModifyWellJob);
-                    break;
-                case JobType.ImportLogData:
-                    var importJob = await jobStream.Deserialize<ImportLogDataJob>();
-                    (result, refreshAction) = await importLogDataWorker.Execute(importJob);
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(jobType), jobType, $"No worker setup to execute {jobType.GetDisplayName()}");
-            }
+            var worker = workers.FirstOrDefault(worker => worker.JobType == jobType);
+            if (worker == null)
+                throw new ArgumentOutOfRangeException(nameof(jobType), jobType, $"No worker setup to execute {jobType.GetDisplayName()}");
 
-            if (hubContext != null)
-            {
-                await hubContext.Clients.All.SendCoreAsync("jobFinished", new object[] { result });
-
-                if (refreshAction != null)
-                    await hubContext.Clients.All.SendCoreAsync("refresh", new object[] { refreshAction });
-            }
+            jobQueue.Enqueue(worker.Execute(jobStream));
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Startup.cs
+++ b/Src/WitsmlExplorer.Api/Startup.cs
@@ -12,10 +12,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NetCore.AutoRegisterDi;
 using Serilog;
+using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Middleware;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Repositories;
 using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Workers;
 
 namespace WitsmlExplorer.Api
 {
@@ -55,34 +57,9 @@ namespace WitsmlExplorer.Api
             services.AddCarter();
             services.AddSignalR();
             services.AddHttpContextAccessor();
-            services.RegisterAssemblyPublicNonGenericClasses(Assembly.GetAssembly(typeof(Program))).AsPublicImplementedInterfaces();
             services.AddDataProtection();
-            services.AddSingleton<ICredentialsService, CredentialsService>();
-            services.AddScoped<IWitsmlClientProvider, WitsmlClientProvider>();
-            AddRepository<Server, Guid>(services, Configuration);
-        }
-
-        private static void AddRepository<TDocument, I>(IServiceCollection services, IConfiguration configuration) where TDocument : DbDocument<I>
-        {
-            if (!string.IsNullOrEmpty(configuration["MongoDb:Name"]))
-            {
-                Log.Information("Detected database config for MongoDB");
-                services.AddSingleton<IDocumentRepository<TDocument, I>, MongoRepository<TDocument, I>>();
-            }
-            else if (!string.IsNullOrEmpty(configuration["CosmosDb:Name"]))
-            {
-                Log.Information("Detected database config for CosmosDB");
-                services.AddSingleton<IDocumentRepository<TDocument, I>, CosmosRepository<TDocument, I>>();
-            }
-            else
-            {
-                Log.Error("Did not detect any configuration for database");
-                return;
-            }
-
-            var serviceProvider = services.BuildServiceProvider();
-            var repository = serviceProvider.GetService<IDocumentRepository<TDocument, I>>();
-            repository.InitClient();
+            services.ConfigureDependencies(Configuration);
+            services.AddHostedService<BackgroundWorkerService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Src/WitsmlExplorer.Api/Workers/BackgroundWorkerService.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BackgroundWorkerService.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using WitsmlExplorer.Api.Services;
+
+namespace WitsmlExplorer.Api.Workers
+{
+    public class BackgroundWorkerService : BackgroundService
+    {
+        private readonly IJobQueue jobQueue;
+        private readonly IHubContext<NotificationsHub> hubContext;
+        private const int NumberOfThreadsToUse = 2;
+
+        public BackgroundWorkerService(IJobQueue jobQueue, IHubContext<NotificationsHub> hubContext)
+        {
+            this.jobQueue = jobQueue;
+            this.hubContext = hubContext;
+        }
+
+        public override Task StopAsync(CancellationToken cancellationToken)
+        {
+            Log.Warning("Background worker is stopping due to a host shutdown. Any queued jobs might be removed");
+            return base.StopAsync(cancellationToken);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            var backgroundWorkers = new List<Task>();
+            for (var i = 0; i < NumberOfThreadsToUse; i++)
+                backgroundWorkers.Add(BackgroundProcessing(cancellationToken));
+
+            await Task.WhenAll(backgroundWorkers);
+        }
+
+        private async Task BackgroundProcessing(CancellationToken cancellationToken)
+        {
+            Log.Information("Background processing thread is started");
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var job = jobQueue.Dequeue();
+                if (job == null)
+                {
+                    await Task.Delay(500, cancellationToken);
+                    continue;
+                }
+
+                var (result, refreshAction) = await job;
+
+                if (hubContext == null) continue;
+
+                await hubContext.Clients.All.SendCoreAsync("jobFinished", new object[] { result }, cancellationToken);
+
+                if (refreshAction != null)
+                    await hubContext.Clients.All.SendCoreAsync("refresh", new object[] { refreshAction }, cancellationToken);
+            }
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Workers/BackgroundWorkerService.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BackgroundWorkerService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +33,7 @@ namespace WitsmlExplorer.Api.Workers
             for (var i = 0; i < NumberOfThreadsToUse; i++)
                 backgroundWorkers.Add(BackgroundProcessing(cancellationToken));
 
-            await Task.WhenAll(backgroundWorkers);
+            await Task.WhenAny(backgroundWorkers);
         }
 
         private async Task BackgroundProcessing(CancellationToken cancellationToken)

--- a/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Threading.Tasks;
+using WitsmlExplorer.Api.Extensions;
+using WitsmlExplorer.Api.Models;
+
+namespace WitsmlExplorer.Api.Workers
+{
+    public abstract class BaseWorker<T>
+    {
+        public async Task<(WorkerResult, RefreshAction)> Execute(Stream jobStream)
+        {
+            var job = await jobStream.Deserialize<T>();
+            return await Execute(job);
+        }
+
+        public abstract Task<(WorkerResult, RefreshAction)> Execute(T job);
+    }
+}

--- a/Src/WitsmlExplorer.Api/Workers/BatchModifyWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BatchModifyWellWorker.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Witsml;
-using Witsml.Data;
-using Witsml.Extensions;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Query;
@@ -13,16 +11,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class BatchModifyWellWorker : IWorker<BatchModifyWellJob>
+    public class BatchModifyWellWorker : BaseWorker<BatchModifyWellJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.BatchModifyWell;
 
         public BatchModifyWellWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(BatchModifyWellJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(BatchModifyWellJob job)
         {
             Verify(job.Wells);
 
@@ -45,7 +44,7 @@ namespace WitsmlExplorer.Api.Workers
             return (workerResult, refreshAction);
         }
 
-        private void Verify(IEnumerable<Well> wells)
+        private static void Verify(IEnumerable<Well> wells)
         {
             if (!wells.Any()) throw new InvalidOperationException("payload cannot be empty");
         }

--- a/Src/WitsmlExplorer.Api/Workers/BatchModifyWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BatchModifyWellWorker.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Witsml;
-using Witsml.Data;
-using Witsml.Extensions;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Query;
@@ -13,20 +11,21 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class BatchModifyWellWorker : IWorker<BatchModifyWellJob>
+    public class BatchModifyWellWorker : BaseWorker<BatchModifyWellJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.BatchModifyWell;
 
         public BatchModifyWellWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(BatchModifyWellJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(BatchModifyWellJob job)
         {
             Verify(job.Wells);
 
-            var wellsToUpdate = job.Wells.Select(well => WellQueries.UpdateWitsmlWell(well));
+            var wellsToUpdate = job.Wells.Select(WellQueries.UpdateWitsmlWell);
             var updateWellTasks = wellsToUpdate.Select(wellToUpdate => witsmlClient.UpdateInStoreAsync(wellToUpdate));
 
             Task resultTask = Task.WhenAll(updateWellTasks);

--- a/Src/WitsmlExplorer.Api/Workers/BatchModifyWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BatchModifyWellWorker.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Witsml;
+using Witsml.Data;
+using Witsml.Extensions;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Query;
@@ -11,17 +13,16 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class BatchModifyWellWorker : BaseWorker<BatchModifyWellJob>, IWorker
+    public class BatchModifyWellWorker : IWorker<BatchModifyWellJob>
     {
         private readonly IWitsmlClient witsmlClient;
-        public JobType JobType => JobType.BatchModifyWell;
 
         public BatchModifyWellWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public override async Task<(WorkerResult, RefreshAction)> Execute(BatchModifyWellJob job)
+        public async Task<(WorkerResult, RefreshAction)> Execute(BatchModifyWellJob job)
         {
             Verify(job.Wells);
 

--- a/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
@@ -15,7 +16,12 @@ using Index = Witsml.Data.Curves.Index;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class CopyLogDataWorker : BaseWorker<CopyLogDataJob>, IWorker
+    public interface ICopyLogDataWorker
+    {
+        Task<(WorkerResult, RefreshAction)> Execute(Stream jobStream);
+    }
+
+    public class CopyLogDataWorker : BaseWorker<CopyLogDataJob>, IWorker, ICopyLogDataWorker
     {
         private readonly IWitsmlClient witsmlClient;
         private readonly IWitsmlClient witsmlSourceClient;

--- a/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyLogDataWorker.cs
@@ -15,10 +15,11 @@ using Index = Witsml.Data.Curves.Index;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class CopyLogDataWorker : IWorker<CopyLogDataJob>
+    public class CopyLogDataWorker : BaseWorker<CopyLogDataJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
         private readonly IWitsmlClient witsmlSourceClient;
+        public JobType JobType => JobType.CopyLogData;
 
         public CopyLogDataWorker(IWitsmlClientProvider witsmlClientProvider)
         {
@@ -26,7 +27,7 @@ namespace WitsmlExplorer.Api.Workers
             witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? witsmlClient;
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CopyLogDataJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CopyLogDataJob job)
         {
             var (sourceLog, targetLog) = await GetLogs(job);
             var mnemonicsToCopy = job.SourceLogCurvesReference.Mnemonics.Any()

--- a/Src/WitsmlExplorer.Api/Workers/CopyLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyLogWorker.cs
@@ -20,10 +20,10 @@ namespace WitsmlExplorer.Api.Workers
     {
         private readonly IWitsmlClient witsmlClient;
         private readonly IWitsmlClient witsmlSourceClient;
-        private readonly IWorker copyLogDataWorker;
+        private readonly ICopyLogDataWorker copyLogDataWorker;
         public JobType JobType => JobType.CopyLog;
 
-        public CopyLogWorker(IWitsmlClientProvider witsmlClientProvider, IWorker copyLogDataWorker = null)
+        public CopyLogWorker(IWitsmlClientProvider witsmlClientProvider, ICopyLogDataWorker copyLogDataWorker = null)
         {
             witsmlClient = witsmlClientProvider.GetClient();
             witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? witsmlClient;

--- a/Src/WitsmlExplorer.Api/Workers/CopyTrajectoryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyTrajectoryWorker.cs
@@ -13,10 +13,11 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class CopyTrajectoryWorker : IWorker<CopyTrajectoryJob>
+    public class CopyTrajectoryWorker : BaseWorker<CopyTrajectoryJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
         private readonly IWitsmlClient witsmlSourceClient;
+        public JobType JobType => JobType.CopyTrajectory;
 
         public CopyTrajectoryWorker(IWitsmlClientProvider witsmlClientProvider)
         {
@@ -24,7 +25,7 @@ namespace WitsmlExplorer.Api.Workers
             witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? witsmlClient;
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CopyTrajectoryJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CopyTrajectoryJob job)
         {
             var (trajectory, targetWellbore) = await FetchData(job);
             var trajectoryToCopy = TrajectoryQueries.CopyWitsmlTrajectory(trajectory, targetWellbore);

--- a/Src/WitsmlExplorer.Api/Workers/CreateLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CreateLogWorker.cs
@@ -14,16 +14,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class CreateLogWorker : IWorker<CreateLogJob>
+    public class CreateLogWorker : BaseWorker<CreateLogJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.CreateLogObject;
 
         public CreateLogWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CreateLogJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CreateLogJob job)
         {
             var targetWellbore = await GetWellbore(witsmlClient, job.LogObject);
             var copyLogQuery = CreateLogQuery(job, targetWellbore);

--- a/Src/WitsmlExplorer.Api/Workers/CreateMudLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CreateMudLogWorker.cs
@@ -14,18 +14,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-
-
-    public class CreateMudLogWorker : IWorker<CreateMudLogJob>
+    public class CreateMudLogWorker : BaseWorker<CreateMudLogJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.CreateMudLog;
 
         public CreateMudLogWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CreateMudLogJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CreateMudLogJob job)
         {
             var mudLog = job.MudLog;
             Verify(mudLog);
@@ -113,7 +112,7 @@ namespace WitsmlExplorer.Api.Workers
             };
         }
 
-        private void Verify(MudLog mudLog)
+        private static void Verify(MudLog mudLog)
         {
             if (string.IsNullOrEmpty(mudLog.Uid)) throw new InvalidOperationException($"{nameof(mudLog.Uid)} cannot be empty");
             if (string.IsNullOrEmpty(mudLog.Name)) throw new InvalidOperationException($"{nameof(mudLog.Name)} cannot be empty");

--- a/Src/WitsmlExplorer.Api/Workers/CreateRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CreateRiskWorker.cs
@@ -15,16 +15,17 @@ using WitsmlExplorer.Api.Services;
 namespace WitsmlExplorer.Api.Workers
 {
 
-    public class CreateRiskWorker : IWorker<CreateRiskJob>
+    public class CreateRiskWorker : BaseWorker<CreateRiskJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.CreateRisk;
 
         public CreateRiskWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CreateRiskJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CreateRiskJob job)
         {
             var risk = job.Risk;
             Verify(risk);

--- a/Src/WitsmlExplorer.Api/Workers/CreateRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CreateRiskWorker.cs
@@ -108,7 +108,7 @@ namespace WitsmlExplorer.Api.Workers
             };
         }
 
-        private void Verify(Risk risk)
+        private static void Verify(Risk risk)
         {
             if (string.IsNullOrEmpty(risk.Uid)) throw new InvalidOperationException($"{nameof(risk.Uid)} cannot be empty");
             if (string.IsNullOrEmpty(risk.Name)) throw new InvalidOperationException($"{nameof(risk.Name)} cannot be empty");

--- a/Src/WitsmlExplorer.Api/Workers/CreateWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CreateWellWorker.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
 using Witsml;
-using Witsml.Data;
 using Witsml.Extensions;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
@@ -14,16 +13,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class CreateWellWorker : IWorker<CreateWellJob>
+    public class CreateWellWorker : BaseWorker<CreateWellJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.CreateWell;
 
         public CreateWellWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CreateWellJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CreateWellJob job)
         {
             var well = job.Well;
             Verify(well);

--- a/Src/WitsmlExplorer.Api/Workers/CreateWellboreWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CreateWellboreWorker.cs
@@ -13,16 +13,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class CreateWellboreWorker : IWorker<CreateWellboreJob>
+    public class CreateWellboreWorker : BaseWorker<CreateWellboreJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.CreateWellbore;
 
         public CreateWellboreWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(CreateWellboreJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CreateWellboreJob job)
         {
             var wellbore = job.Wellbore;
             Verify(wellbore);

--- a/Src/WitsmlExplorer.Api/Workers/DeleteCurveValuesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteCurveValuesWorker.cs
@@ -14,21 +14,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteCurveValuesWorker
-    {
-        Task<(WorkerResult workerResult, RefreshLogObject refreshAction)> Execute(DeleteCurveValuesJob job);
-    }
-
-    public class DeleteCurveValuesWorker : IDeleteCurveValuesWorker
+    public class DeleteCurveValuesWorker : BaseWorker<DeleteCurveValuesJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteCurveValues;
 
         public DeleteCurveValuesWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult workerResult, RefreshLogObject refreshAction)> Execute(DeleteCurveValuesJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteCurveValuesJob job)
         {
             var wellUid = job.LogReference.WellUid;
             var wellboreUid = job.LogReference.WellboreUid;

--- a/Src/WitsmlExplorer.Api/Workers/DeleteLogObjectsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteLogObjectsWorker.cs
@@ -12,57 +12,43 @@ using Witsml.Extensions;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteLogObjectsWorker
-    {
-        Task<(WorkerResult workerResult, RefreshWellbore refreshAction)> Execute(DeleteLogObjectsJob job);
-    }
-
-    public class DeleteLogObjectsWorker : IDeleteLogObjectsWorker
+    public class DeleteLogObjectsWorker : BaseWorker<DeleteLogObjectsJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteLogObjects;
 
         public DeleteLogObjectsWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult workerResult, RefreshWellbore refreshAction)> Execute(DeleteLogObjectsJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteLogObjectsJob job)
         {
-            (WorkerResult workerResult, RefreshWellbore refreshAction) results;
+            Verify(job);
 
-            if (!job.LogReferences.Any()) throw new ArgumentException($"A minimum of one job is required");
-            if (job.LogReferences.Select(l => l.WellboreUid).Distinct().Count() != 1)  throw new ArgumentException($"All logs should belong to the same Wellbore");
-
-            var wellUid = job.LogReferences.FirstOrDefault().WellUid;
-            var wellboreUid = job.LogReferences.FirstOrDefault().WellboreUid;
+            var wellUid = job.LogReferences.First().WellUid;
+            var wellboreUid = job.LogReferences.First().WellboreUid;
 
             var logsExpanded = $"[ {string.Join(", ",job.LogReferences.Select(l=>l.LogUid))} ]";
             var jobDescription = $"Delete {job.LogReferences.Count()} Logs under wellUid: {wellUid}, wellboreUid: {wellboreUid}. Logs: {logsExpanded}";
 
-            var queries = job.LogReferences.Select( l => CreateRequest(l) );
-            var tasks = queries.Select(q=> witsmlClient.DeleteFromStoreAsync(q));
+            var queries = job.LogReferences.Select(CreateRequest);
+            var tasks = queries.Select(q=> witsmlClient.DeleteFromStoreAsync(q)).ToList();
 
             await Task.WhenAll(tasks);
             if (tasks.Any(t => t.IsFaulted))
             {
                 var numFailed = tasks.Count(t => !t.Result.IsSuccessful);
                 var reasons = string.Join(",",tasks.Where(t => !t.Result.IsSuccessful).Select(t => t.Result.Reason).ToArray());
-                Log.Error($"FAILURE deleting {numFailed} of {tasks.Count()} Logs due to {reasons}");
-                results =
-                (
-                    new WorkerResult(witsmlClient.GetServerHostname(), false, $"Job failed deleting {numFailed} log objects. Reasons: {reasons}"),
-                    null
-                );
-
-            } else {
-                Log.Information($"SUCCESS - {jobDescription}");
-                results =
-                (
-                    new WorkerResult(witsmlClient.GetServerHostname(), true, $"{tasks.Count()} log objects deleted for wellbore {wellboreUid}"),
-                    new RefreshWellbore(witsmlClient.GetServerHostname(),wellUid, wellboreUid, RefreshType.Update)
-                );
+                Log.Error($"FAILURE deleting {numFailed} of {tasks.Count} Logs due to {reasons}");
+                return (new WorkerResult(witsmlClient.GetServerHostname(), false, $"Job failed deleting {numFailed} log objects", reasons), null);
             }
-            return results;
+
+            Log.Information($"SUCCESS - {jobDescription}");
+            return (
+                new WorkerResult(witsmlClient.GetServerHostname(), true, $"{tasks.Count} log objects deleted for wellbore {wellboreUid}"),
+                new RefreshWellbore(witsmlClient.GetServerHostname(), wellUid, wellboreUid, RefreshType.Update)
+            );
         }
 
         private static WitsmlLogs CreateRequest(LogReference logReference)
@@ -76,6 +62,14 @@ namespace WitsmlExplorer.Api.Workers
                     Uid = logReference.LogUid
                 }.AsSingletonList()
             };
+        }
+
+        private static void Verify(DeleteLogObjectsJob job)
+        {
+            if (!job.LogReferences.Any()) throw new ArgumentException("A minimum of one job is required");
+            if (job.LogReferences.Select(l => l.WellboreUid).Distinct().Count() != 1)  throw new ArgumentException("All logs should belong to the same Wellbore");
+            if (string.IsNullOrEmpty(job.LogReferences.First().WellUid)) throw new ArgumentException("WellUid is required");
+            if (string.IsNullOrEmpty(job.LogReferences.First().WellboreUid)) throw new ArgumentException("WellboreUid is required");
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/DeleteMessagesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteMessagesWorker.cs
@@ -10,55 +10,51 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class DeleteMessagesWorker : IWorker<DeleteMessageObjectsJob>
+    public class DeleteMessagesWorker : BaseWorker<DeleteMessageObjectsJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteMessageObjects;
 
         public DeleteMessagesWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(DeleteMessageObjectsJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteMessageObjectsJob job)
         {
-            (WorkerResult workerResult, RefreshMessageObjects refreshAction) results;
+            Verify(job);
 
-            if (!job.MessageObjects.Any()) throw new ArgumentException($"A minimum of one message is required");
-            if (job.MessageObjects.Select(l => l.WellboreUid).Distinct().Count() != 1) throw new ArgumentException($"All messages should belong to the same Wellbore");
-
-            var wellUid = job.MessageObjects.FirstOrDefault()?.WellUid;
-            var wellboreUid = job.MessageObjects.FirstOrDefault()?.WellboreUid;
+            var wellUid = job.MessageObjects.First().WellUid;
+            var wellboreUid = job.MessageObjects.First().WellboreUid;
 
             var messagesExpanded = $"[ {string.Join(", ", job.MessageObjects.Select(l => l.Uid))} ]";
             var jobDescription = $"Delete {job.MessageObjects.Count()} Messages under wellUid: {wellUid}, wellboreUid: {wellboreUid}. Messages: {messagesExpanded}";
 
             var queries = job.MessageObjects.Select(l => MessageQueries.GetMessageById(l.WellUid, l.WellboreUid, l.Uid));
-            var tasks = queries.Select(q => witsmlClient.DeleteFromStoreAsync(q));
+            var tasks = queries.Select(q => witsmlClient.DeleteFromStoreAsync(q)).ToList();
 
             await Task.WhenAll(tasks);
             if (tasks.Any(t => t.IsFaulted))
             {
                 var numFailed = tasks.Count(t => !t.Result.IsSuccessful);
                 var reasons = string.Join(",", tasks.Where(t => !t.Result.IsSuccessful).Select(t => t.Result.Reason).ToArray());
-                Log.Error($"FAILURE deleting {numFailed} of {tasks.Count()} Messages due to {reasons}");
-                results =
-                (
-                    new WorkerResult(witsmlClient.GetServerHostname(), false, $"Job failed deleting {numFailed} messages. Reasons: {reasons}"),
-                    null
-                );
+                Log.Error($"FAILURE deleting {numFailed} of {tasks.Count} Messages due to {reasons}");
+                return (new WorkerResult(witsmlClient.GetServerHostname(), false, $"Job failed deleting {numFailed} messages", reasons), null);
+            }
 
-            }
-            else
-            {
-                Log.Information($"SUCCESS - {jobDescription}");
-                results =
-                (
-                    new WorkerResult(witsmlClient.GetServerHostname(), true, $"{tasks.Count()} mesages deleted for wellbore {wellboreUid}"),
-                    new RefreshMessageObjects(witsmlClient.GetServerHostname(), wellUid, wellboreUid, RefreshType.Update)
-                );
-            }
-            return results;
+            Log.Information($"SUCCESS - {jobDescription}");
+            return (
+                new WorkerResult(witsmlClient.GetServerHostname(), true, $"{tasks.Count} messages deleted for wellbore {wellboreUid}"),
+                new RefreshMessageObjects(witsmlClient.GetServerHostname(), wellUid, wellboreUid, RefreshType.Update)
+            );
         }
 
+        private static void Verify(DeleteMessageObjectsJob job)
+        {
+            if (!job.MessageObjects.Any()) throw new ArgumentException($"A minimum of one message is required");
+            if (job.MessageObjects.Select(l => l.WellboreUid).Distinct().Count() != 1) throw new ArgumentException($"All messages should belong to the same Wellbore");
+            if (string.IsNullOrEmpty(job.MessageObjects.First().WellUid)) throw new ArgumentException("WellUid is required");
+            if (string.IsNullOrEmpty(job.MessageObjects.First().WellboreUid)) throw new ArgumentException("WellboreUid is required");
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/DeleteMnemonicsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteMnemonicsWorker.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
@@ -10,26 +11,22 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteMnemonicsWorker
-    {
-        Task<(WorkerResult workerResult, RefreshLogObject refreshAction)> Execute(DeleteMnemonicsJob job);
-    }
-
-    public class DeleteMnemonicsWorker : IDeleteMnemonicsWorker
+    public class DeleteMnemonicsWorker : BaseWorker<DeleteMnemonicsJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteMnemonics;
 
         public DeleteMnemonicsWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult workerResult, RefreshLogObject refreshAction)> Execute(DeleteMnemonicsJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteMnemonicsJob job)
         {
             var wellUid = job.LogObject.WellUid;
             var wellboreUid = job.LogObject.WellboreUid;
             var logUid = job.LogObject.LogUid;
-            var mnemonics = job.Mnemonics;
+            var mnemonics = new ReadOnlyCollection<string>(job.Mnemonics.ToList());
             var mnemonicsString = string.Join(", ", mnemonics);
 
             var query = LogQueries.DeleteMnemonics(wellUid, wellboreUid, logUid, mnemonics);

--- a/Src/WitsmlExplorer.Api/Workers/DeleteMudlogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteMudlogWorker.cs
@@ -6,28 +6,23 @@ using Witsml.Query;
 using Witsml.Data;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
-using WitsmlExplorer.Api.Jobs.Common;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 using Witsml.Extensions;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteMudLogWorker
-    {
-        Task<(WorkerResult, RefreshAction)> Execute(DeleteMudLogJob job);
-    }
-
-    public class DeleteMudlogWorker : IDeleteMudLogWorker
+    public class DeleteMudLogWorker : BaseWorker<DeleteMudLogJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteMudLog;
 
-        public DeleteMudlogWorker(IWitsmlClientProvider witsmlClientProvider)
+        public DeleteMudLogWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(DeleteMudLogJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteMudLogJob job)
         {
             var wellUid = job.MudLogReference.WellUid;
             var wellboreUid = job.MudLogReference.WellboreUid;
@@ -39,26 +34,26 @@ namespace WitsmlExplorer.Api.Workers
 
             if (result.IsSuccessful)
             {
-                Log.Information("{JobType} - Job successful.", GetType().Name);
+                Log.Information("{JobType} - Job successful", GetType().Name);
                 var refreshAction = new RefreshWell(witsmlClient.GetServerHostname(), wellUid, RefreshType.Remove);
-                var workerResult = new WorkerResult(witsmlClient.GetServerHostname(), true, $"Deleted mudlog with uid ${wellUid}");
+                var workerResult = new WorkerResult(witsmlClient.GetServerHostname(), true, $"Deleted mudLog with uid ${wellUid}");
                 return (workerResult, refreshAction);
             }
 
-            Log.Error("Failed to delete Mudlog. : {uid}", uid);
+            Log.Error("Failed to delete mudLog. : {Uid}", uid);
 
             var query = MudLogQueries.QueryById(wellUid, wellboreUid, uid);
             var queryResult = await witsmlClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.IdOnly));
             EntityDescription description = null;
-            var mudlog = queryResult.MudLogs.FirstOrDefault();
-            if (mudlog != null)
+            var mudLog = queryResult.MudLogs.FirstOrDefault();
+            if (mudLog != null)
             {
                 description = new EntityDescription
                 {
-                    ObjectName = mudlog.Name
+                    ObjectName = mudLog.Name
                 };
             }
-            return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to delete mudlog", result.Reason, description), null);
+            return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to delete mudLog", result.Reason, description), null);
 
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/DeleteRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteRiskWorker.cs
@@ -10,21 +10,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteRiskWorker
-    {
-        Task<(WorkerResult, RefreshAction)> Execute(DeleteRiskJob job);
-    }
-
-    public class DeleteRiskWorker : IDeleteRiskWorker
+    public class DeleteRiskWorker : BaseWorker<DeleteRiskJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteRisk;
 
         public DeleteRiskWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(DeleteRiskJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteRiskJob job)
         {
             var wellUid = job.RiskReference.WellUid;
             var wellboreUid = job.RiskReference.WellboreUid;

--- a/Src/WitsmlExplorer.Api/Workers/DeleteWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteWellWorker.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using Witsml;
-using Witsml.Data;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
@@ -11,21 +10,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteWellWorker
-    {
-        Task<(WorkerResult, RefreshWell)> Execute(DeleteWellJob job);
-    }
-
-    public class DeleteWellWorker : IDeleteWellWorker
+    public class DeleteWellWorker : BaseWorker<DeleteWellJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteWell;
 
         public DeleteWellWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshWell)> Execute(DeleteWellJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteWellJob job)
         {
             var wellUid = job.WellReference.WellUid;
 

--- a/Src/WitsmlExplorer.Api/Workers/DeleteWellboreWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteWellboreWorker.cs
@@ -10,21 +10,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IDeleteWellboreWorker
-    {
-        Task<(WorkerResult, RefreshWellbore)> Execute(DeleteWellboreJob job);
-    }
-
-    public class DeleteWellboreWorker : IDeleteWellboreWorker
+    public class DeleteWellboreWorker : BaseWorker<DeleteWellboreJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.DeleteWellbore;
 
         public DeleteWellboreWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshWellbore)> Execute(DeleteWellboreJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteWellboreJob job)
         {
             var wellUid = job.WellboreReference.WellUid;
             var wellboreUid = job.WellboreReference.WellboreUid;

--- a/Src/WitsmlExplorer.Api/Workers/IWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/IWorker.cs
@@ -1,10 +1,24 @@
+using System.IO;
 using System.Threading.Tasks;
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public interface IWorker<in T>
+    public interface IWorker
     {
-        Task<(WorkerResult, RefreshAction)> Execute(T job);
+        JobType JobType { get; }
+        Task<(WorkerResult, RefreshAction)> Execute(Stream jobStream);
+    }
+
+    public abstract class BaseWorker<T>
+    {
+        public async Task<(WorkerResult, RefreshAction)> Execute(Stream jobStream)
+        {
+            var job = await jobStream.Deserialize<T>();
+            return await Execute(job);
+        }
+
+        public abstract Task<(WorkerResult, RefreshAction)> Execute(T job);
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/IWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/IWorker.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Threading.Tasks;
-using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api.Workers
@@ -9,16 +8,5 @@ namespace WitsmlExplorer.Api.Workers
     {
         JobType JobType { get; }
         Task<(WorkerResult, RefreshAction)> Execute(Stream jobStream);
-    }
-
-    public abstract class BaseWorker<T>
-    {
-        public async Task<(WorkerResult, RefreshAction)> Execute(Stream jobStream)
-        {
-            var job = await jobStream.Deserialize<T>();
-            return await Execute(job);
-        }
-
-        public abstract Task<(WorkerResult, RefreshAction)> Execute(T job);
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/ModifyLogObjectWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ModifyLogObjectWorker.cs
@@ -13,16 +13,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class ModifyLogObjectWorker : IWorker<ModifyLogObjectJob>
+    public class ModifyLogObjectWorker : BaseWorker<ModifyLogObjectJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.ModifyLogObject;
 
         public ModifyLogObjectWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(ModifyLogObjectJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(ModifyLogObjectJob job)
         {
             Verify(job.LogObject);
 
@@ -78,7 +79,7 @@ namespace WitsmlExplorer.Api.Workers
             };
         }
 
-        private void Verify(LogObject logObject)
+        private static void Verify(LogObject logObject)
         {
             if (string.IsNullOrEmpty(logObject.Name)) throw new InvalidOperationException($"{nameof(logObject.Name)} cannot be empty");
         }

--- a/Src/WitsmlExplorer.Api/Workers/ModifyMessageWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ModifyMessageWorker.cs
@@ -1,9 +1,6 @@
-using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using Witsml;
-using Witsml.Data;
-using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Query;
@@ -11,22 +8,23 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class ModifyMessageWorker : IWorker<ModifyMessageObjectJob>
+    public class ModifyMessageWorker : BaseWorker<ModifyMessageObjectJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.ModifyMessageObject;
 
         public ModifyMessageWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
-        public async Task<(WorkerResult, RefreshAction)> Execute(ModifyMessageObjectJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(ModifyMessageObjectJob job)
         {
             var modifyMessageQuery = MessageQueries.CreateMessageObject(job.MessageObject);
             var modifyMessageResult = await witsmlClient.UpdateInStoreAsync(modifyMessageQuery);
 
             if (!modifyMessageResult.IsSuccessful)
             {
-                const string errorMessage = "Failed to modify messageobject.";
+                const string errorMessage = "Failed to modify message object";
                 Log.Error("{ErrorMessage}. Target: UidWell: {TargetWellUid}, UidWellbore: {TargetWellboreUid}",
                     errorMessage, job.MessageObject.WellUid, job.MessageObject.WellboreUid);
                 return (new WorkerResult(witsmlClient.GetServerHostname(), false, errorMessage, modifyMessageResult.Reason), null);
@@ -37,13 +35,6 @@ namespace WitsmlExplorer.Api.Workers
             var workerResult = new WorkerResult(witsmlClient.GetServerHostname(), true, $"MessageObject {job.MessageObject.Name} updated for {job.MessageObject.WellboreName}");
 
             return (workerResult, refreshAction);
-        }
-
-        private static async Task<WitsmlWellbore> GetWellbore(IWitsmlClient client, MessageObject messageObject)
-        {
-            var query = WellboreQueries.GetWitsmlWellboreByUid(messageObject.WellUid, messageObject.WellboreUid);
-            var wellbores = await client.GetFromStoreAsync(query, new OptionsIn(ReturnElements.Requested));
-            return !wellbores.Wellbores.Any() ? null : wellbores.Wellbores.First();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/ModifyMudLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ModifyMudLogWorker.cs
@@ -5,24 +5,23 @@ using Serilog;
 using Witsml;
 using Witsml.Data;
 using Witsml.Extensions;
-using Witsml.Query;
-using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class ModifyMudLogWorker : IWorker<ModifyMudLogJob>
+    public class ModifyMudLogWorker : BaseWorker<ModifyMudLogJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.ModifyMudLog;
 
         public ModifyMudLogWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(ModifyMudLogJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(ModifyMudLogJob job)
         {
             var mudLog = job.MudLog;
             Verify(mudLog);
@@ -36,7 +35,7 @@ namespace WitsmlExplorer.Api.Workers
 
             }
             var description = new EntityDescription { WellboreName = mudLog.WellboreName };
-            Log.Error($"Job failed. An error occurred when modifying mudlog: {job.MudLog.PrintProperties()}");
+            Log.Error($"Job failed. An error occurred when modifying mudLog: {job.MudLog.PrintProperties()}");
 
             return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to update log", result.Reason, description), null);
         }
@@ -91,7 +90,7 @@ namespace WitsmlExplorer.Api.Workers
             };
         }
 
-        private void Verify(MudLog mudLog)
+        private static void Verify(MudLog mudLog)
         {
             if (string.IsNullOrEmpty(mudLog.Name)) throw new InvalidOperationException($"{nameof(mudLog.Name)} cannot be empty");
         }

--- a/Src/WitsmlExplorer.Api/Workers/ModifyWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ModifyWellWorker.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using Witsml;
-using Witsml.Data;
 using Witsml.Extensions;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
@@ -13,18 +12,20 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class ModifyWellWorker : IWorker<ModifyWellJob>
+    public class ModifyWellWorker : BaseWorker<ModifyWellJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.ModifyWell;
 
         public ModifyWellWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(ModifyWellJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(ModifyWellJob job)
         {
             Verify(job.Well);
+
             var wellUid = job.Well.Uid;
             var wellName = job.Well.Name;
             var witsmlWellToUpdate = WellQueries.UpdateWitsmlWell(job.Well);

--- a/Src/WitsmlExplorer.Api/Workers/ModifyWellWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ModifyWellWorker.cs
@@ -49,7 +49,7 @@ namespace WitsmlExplorer.Api.Workers
             return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to update well", result.Reason, description), null);
         }
 
-        private void Verify(Well well)
+        private static void Verify(Well well)
         {
             if (string.IsNullOrEmpty(well.Name)) throw new InvalidOperationException($"{nameof(well.Name)} cannot be empty");
         }

--- a/Src/WitsmlExplorer.Api/Workers/ModifyWellboreWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ModifyWellboreWorker.cs
@@ -12,20 +12,21 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class ModifyWellboreWorker : IWorker<ModifyWellboreJob>
+    public class ModifyWellboreWorker : BaseWorker<ModifyWellboreJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.ModifyWellbore;
 
         public ModifyWellboreWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(ModifyWellboreJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(ModifyWellboreJob job)
         {
             Verify(job.Wellbore);
 
-            var witsmlWellbore = WellboreQueries.UpdateWitsmlWellbore(job.Wellbore);            
+            var witsmlWellbore = WellboreQueries.UpdateWitsmlWellbore(job.Wellbore);
             var result = await witsmlClient.UpdateInStoreAsync(witsmlWellbore);
             if (result.IsSuccessful)
             {
@@ -45,7 +46,7 @@ namespace WitsmlExplorer.Api.Workers
             return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to update wellbore", result.Reason, description), null);
         }
 
-        private void Verify(Wellbore wellbore)
+        private static void Verify(Wellbore wellbore)
         {
             if (string.IsNullOrEmpty(wellbore.Uid) || string.IsNullOrEmpty(wellbore.WellUid)) throw new InvalidOperationException($"{nameof(wellbore.Uid)}/{nameof(wellbore.WellUid)} cannot be empty");
             if (wellbore.Name == string.Empty) throw new InvalidOperationException($"{nameof(wellbore.Name)} cannot be empty");

--- a/Src/WitsmlExplorer.Api/Workers/TrimLogObjectWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/TrimLogObjectWorker.cs
@@ -15,16 +15,17 @@ using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Workers
 {
-    public class TrimLogObjectWorker : IWorker<TrimLogDataJob>
+    public class TrimLogObjectWorker : BaseWorker<TrimLogDataJob>, IWorker
     {
         private readonly IWitsmlClient witsmlClient;
+        public JobType JobType => JobType.TrimLogObject;
 
         public TrimLogObjectWorker(IWitsmlClientProvider witsmlClientProvider)
         {
             witsmlClient = witsmlClientProvider.GetClient();
         }
 
-        public async Task<(WorkerResult, RefreshAction)> Execute(TrimLogDataJob job)
+        public override async Task<(WorkerResult, RefreshAction)> Execute(TrimLogDataJob job)
         {
             var witsmlLogQuery = LogQueries.GetWitsmlLogById(job.LogObject.WellUid, job.LogObject.WellboreUid, job.LogObject.LogUid);
             var witsmlLogs = await witsmlClient.GetFromStoreAsync(witsmlLogQuery, new OptionsIn(ReturnElements.HeaderOnly));
@@ -35,7 +36,7 @@ namespace WitsmlExplorer.Api.Workers
             var currentEndIndex = Index.End(witsmlLog);
             var newEndIndex = Index.End(witsmlLog, job.EndIndex);
 
-            bool trimmedStartOfLog = false;
+            var trimmedStartOfLog = false;
             if (currentStartIndex < newStartIndex && newStartIndex < currentEndIndex)
             {
                 var trimLogObjectStartQuery = CreateRequest(
@@ -57,7 +58,7 @@ namespace WitsmlExplorer.Api.Workers
                 }
             }
 
-            bool trimmedEndOfLog = false;
+            var trimmedEndOfLog = false;
             if (currentEndIndex > newEndIndex && newEndIndex > currentStartIndex)
             {
                 var trimLogObjectEndQuery = CreateRequest(

--- a/Src/WitsmlExplorer.Api/Workers/WorkQueue.cs
+++ b/Src/WitsmlExplorer.Api/Workers/WorkQueue.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using WitsmlExplorer.Api.Models;
+
+namespace WitsmlExplorer.Api.Workers
+{
+    public interface IJobQueue
+    {
+        void Enqueue(Task<(WorkerResult, RefreshAction)> job);
+        Task<(WorkerResult, RefreshAction)> Dequeue();
+    }
+
+    public class JobQueue : IJobQueue
+    {
+        private readonly ConcurrentQueue<Task<(WorkerResult, RefreshAction)>> jobs = new();
+
+        public void Enqueue(Task<(WorkerResult, RefreshAction)> job)
+        {
+            if (job == null) throw new ArgumentNullException(nameof(job));
+
+            jobs.Enqueue(job);
+        }
+
+        public Task<(WorkerResult, RefreshAction)> Dequeue()
+        {
+            var hasJob = jobs.TryDequeue(out var job);
+
+            return hasJob ? job : null;
+        }
+    }
+}

--- a/Tests/WitsmlExplorer.Api.Tests/WitsmlExplorer.Api.Tests.csproj
+++ b/Tests/WitsmlExplorer.Api.Tests/WitsmlExplorer.Api.Tests.csproj
@@ -5,7 +5,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>8</LangVersion>
+        <LangVersion>default</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/BatchModifyWellWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/BatchModifyWellWorkerTests.cs
@@ -31,7 +31,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         [Fact]
         public async Task Modify_Wells_Empty_Payload_ThrowsException()
         {
-            var job = CreateJobTemplate(new string[0]);
+            var job = CreateJobTemplate(Array.Empty<string>());
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => worker.Execute(job));
             Assert.Equal("payload cannot be empty", exception.Message);
@@ -44,7 +44,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             const string expectedWell1Name = "well1UidName";
             const string expectedWell2Name = "well2UidName";
-            var job = CreateJobTemplate(new string[] { Well1Uid, Well2Uid });
+            var job = CreateJobTemplate(new[] { Well1Uid, Well2Uid });
 
             var updatedWells = new List<WitsmlWells>();
             witsmlClient.Setup(client =>
@@ -58,28 +58,18 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Assert.Equal(expectedWell2Name, updatedWells.Last().Wells.First().Name);
         }
 
-        private static BatchModifyWellJob CreateJobTemplate(string[] WellUids)
+        private static BatchModifyWellJob CreateJobTemplate(IEnumerable<string> wellUids)
         {
-            var wells = CreateWells(WellUids);
+            var wells = CreateWells(wellUids);
             return new BatchModifyWellJob
             {
                 Wells = wells
             };
         }
 
-        private static Well[] CreateWells(string[] WellUids)
+        private static IEnumerable<Well> CreateWells(IEnumerable<string> wellUids)
         {
-            List<Well> wells = new List<Well>();
-            foreach(string WellId in WellUids)
-            {
-                var well = new Well
-                {
-                    Uid = WellId,
-                    Name = WellId + "Name"
-                };
-                wells.Add(well);
-            }
-            return wells.ToArray();
+            return wellUids.Select(wellId => new Well { Uid = wellId, Name = wellId + "Name" }).ToArray();
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -20,7 +20,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
     public class CopyLogWorkerTests
     {
         private readonly CopyLogWorker copyLogWorker;
-        private readonly Mock<IWorker> copyLogDataWorker;
+        private readonly Mock<ICopyLogDataWorker> copyLogDataWorker;
         private readonly Mock<IWitsmlClient> witsmlClient;
         private const string WellUid = "wellUid";
         private const string SourceWellboreUid = "sourceWellboreUid";
@@ -42,7 +42,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public CopyLogWorkerTests()
         {
             var witsmlClientProvider = new Mock<IWitsmlClientProvider>();
-            copyLogDataWorker = new Mock<IWorker>();
+            copyLogDataWorker = new Mock<ICopyLogDataWorker>();
             witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(witsmlClient.Object);
             copyLogWorker = new CopyLogWorker(witsmlClientProvider.Object, copyLogDataWorker.Object);

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Moq;
 using Witsml;
 using Witsml.Data;
 using Witsml.Data.Curves;
-using Witsml.Extensions;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Jobs.Common;
@@ -20,14 +20,14 @@ namespace WitsmlExplorer.Api.Tests.Workers
     public class CopyLogWorkerTests
     {
         private readonly CopyLogWorker copyLogWorker;
-        private readonly Mock<IWorker<CopyLogDataJob>> copyLogDataWorker;
+        private readonly Mock<IWorker> copyLogDataWorker;
         private readonly Mock<IWitsmlClient> witsmlClient;
         private const string WellUid = "wellUid";
         private const string SourceWellboreUid = "sourceWellboreUid";
         private const string TargetWellboreUid = "targetWellboreUid";
         private const string LogUid = "sourceLogUid";
 
-        private static readonly Dictionary<string, string[]> SourceMnemonics = new Dictionary<string, string[]>
+        private static readonly Dictionary<string, string[]> SourceMnemonics = new()
         {
             {WitsmlLog.WITSML_INDEX_TYPE_MD, new[] {"Depth", "DepthBit", "DepthHole"}},
             {WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, new[] {"Time", "DepthBit", "DepthHole"}}
@@ -42,7 +42,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public CopyLogWorkerTests()
         {
             var witsmlClientProvider = new Mock<IWitsmlClientProvider>();
-            copyLogDataWorker = new Mock<IWorker<CopyLogDataJob>>();
+            copyLogDataWorker = new Mock<IWorker>();
             witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(witsmlClient.Object);
             copyLogWorker = new CopyLogWorker(witsmlClientProvider.Object, copyLogDataWorker.Object);
@@ -55,7 +55,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME);
             SetupGetWellbore();
             var copyLogQuery = SetupAddInStoreAsync();
-            copyLogDataWorker.Setup(worker => worker.Execute(It.IsAny<CopyLogDataJob>()))
+            copyLogDataWorker.Setup(worker => worker.Execute(It.IsAny<Stream>()))
                 .ReturnsAsync((new WorkerResult(null, true, null), null));
 
             var result = await copyLogWorker.Execute(copyLogJob);
@@ -75,7 +75,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD);
             SetupGetWellbore();
             var copyLogQuery = SetupAddInStoreAsync();
-            copyLogDataWorker.Setup(worker => worker.Execute(It.IsAny<CopyLogDataJob>()))
+            copyLogDataWorker.Setup(worker => worker.Execute(It.IsAny<Stream>()))
                 .ReturnsAsync((new WorkerResult(null, true, null), null));
 
             var result = await copyLogWorker.Execute(copyLogJob);
@@ -125,7 +125,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 });
         }
 
-        private List<WitsmlLogs> SetupAddInStoreAsync()
+        private IEnumerable<WitsmlLogs> SetupAddInStoreAsync()
         {
             var addedLog = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.AddToStoreAsync(It.IsAny<WitsmlLogs>()))
@@ -134,11 +134,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             return addedLog;
         }
 
-        private CopyLogJob CreateJobTemplate(string targetWellboreUid = TargetWellboreUid)
+        private static CopyLogJob CreateJobTemplate(string targetWellboreUid = TargetWellboreUid)
         {
             return new CopyLogJob
             {
-                Source = new LogReferences()
+                Source = new LogReferences
                 {
                     LogReferenceList = new[]
                     {
@@ -158,7 +158,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
         }
 
-        private WitsmlLogs GetSourceLogs(string indexType, string startDateTimeIndex, string endDateTimeIndex)
+        private static WitsmlLogs GetSourceLogs(string indexType, string startDateTimeIndex, string endDateTimeIndex)
         {
             var witsmlLog = new WitsmlLog
             {
@@ -188,7 +188,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
         }
 
-        private WitsmlLogs GetSourceLogs(string indexType, double startIndex, double endIndex)
+        private static WitsmlLogs GetSourceLogs(string indexType, double startIndex, double endIndex)
         {
             var minIndex = new WitsmlIndex(new DepthIndex(startIndex));
             var maxIndex = new WitsmlIndex(new DepthIndex(endIndex));

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteLogObjectsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteLogObjectsWorkerTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Witsml;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Jobs.Common;
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 using WitsmlExplorer.Api.Workers;
 using Xunit;
@@ -12,7 +13,6 @@ namespace WitsmlExplorer.Api.Tests.Workers
 {
     public class DeleteLogObjectsWorkerTests
     {
-        private readonly Mock<IWitsmlClient> witsmlClient;
         private readonly DeleteLogObjectsWorker worker;
         private const string WellUid = "wellUid";
         private const string WellboreUid = "wellboreUid";
@@ -21,7 +21,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public DeleteLogObjectsWorkerTests()
         {
             var witsmlClientProvider = new Mock<IWitsmlClientProvider>();
-            witsmlClient = new Mock<IWitsmlClient>();
+            var witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(witsmlClient.Object);
             worker = new DeleteLogObjectsWorker(witsmlClientProvider.Object);
         }
@@ -33,10 +33,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 LogReferences = LogUids
                             .Select( logUid => new LogReference { WellUid = WellUid,WellboreUid = WellboreUid, LogUid = logUid } )
-                            .AsEnumerable<LogReference>()
+                            .AsEnumerable()
             };
-            var result = await worker.Execute(job);
-            Assert.True(result.workerResult.IsSuccess && result.refreshAction.WellboreUid == WellboreUid);
+            var (result, refreshAction) = await worker.Execute(job);
+            Assert.True(result.IsSuccess && ((RefreshWellbore) refreshAction).WellboreUid == WellboreUid);
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/RenameMnemonicWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/RenameMnemonicWorkerTests.cs
@@ -12,7 +12,6 @@ namespace WitsmlExplorer.Api.Tests.Workers
 {
     public class RenameMnemonicWorkerTests
     {
-        private Mock<IWitsmlClient> witsmlClient;
         private readonly RenameMnemonicWorker worker;
         private const string WellUid = "wellUid";
         private const string WellboreUid = "wellboreUid";
@@ -20,8 +19,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
         public RenameMnemonicWorkerTests()
         {
-            witsmlClient = new Mock<IWitsmlClient>();
-
+            var witsmlClient = new Mock<IWitsmlClient>();
             var witsmlClientProvider = new Mock<IWitsmlClientProvider>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(witsmlClient.Object);
             worker = new RenameMnemonicWorker(witsmlClientProvider.Object);
@@ -30,9 +28,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
         [Fact]
         public async void MnemonicEmpty_RenameMnemonic_ShouldThrowException()
         {
-            var job = CreateJobTemplate();
-            job.Mnemonic = "";
-            job.NewMnemonic = "Felgen";
+            var job = CreateJobTemplate() with
+            {
+                Mnemonic = "",
+                NewMnemonic = "Felgen"
+            };
 
             Task ExecuteWorker() => worker.Execute(job);
 
@@ -42,16 +42,18 @@ namespace WitsmlExplorer.Api.Tests.Workers
         [Fact]
         public async void NewMnemonicNull_RenameMnemonic_ShouldThrowException()
         {
-            var job = CreateJobTemplate();
-            job.Mnemonic = "Reodor";
-            job.NewMnemonic = null;
+            var job = CreateJobTemplate() with
+            {
+                Mnemonic = "Reodor",
+                NewMnemonic = null
+            };
 
             Task ExecuteWorker() => worker.Execute(job);
 
             await Assert.ThrowsAsync<InvalidOperationException>(ExecuteWorker);
         }
 
-        private RenameMnemonicJob CreateJobTemplate()
+        private static RenameMnemonicJob CreateJobTemplate()
         {
             return new RenameMnemonicJob
             {

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/TrimLogObjectWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/TrimLogObjectWorkerTests.cs
@@ -49,17 +49,17 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_MD, new DepthIndex(10), new DepthIndex(100));
 
-            var job = CreateJobTemplate();
-            job.StartIndex = "8";
+            var job = CreateJobTemplate() with { StartIndex = "8" };
             await worker.Execute(job);
 
-            job = CreateJobTemplate();
-            job.EndIndex = "110";
+            job = CreateJobTemplate() with { EndIndex = "110" };
             await worker.Execute(job);
 
-            job = CreateJobTemplate();
-            job.StartIndex = "101";
-            job.EndIndex = "102";
+            job = CreateJobTemplate() with
+            {
+                StartIndex = "101",
+                EndIndex = "102"
+            };
             await worker.Execute(job);
 
             witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
@@ -72,17 +72,20 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var logEnd = new DateTime(2000, 1, 10);
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, new DateTimeIndex(logStart), new DateTimeIndex(logEnd));
 
-            var job = CreateJobTemplate();
-            job.StartIndex = logStart.AddDays(-1).ToISODateTimeString();
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = logStart.AddDays(-1).ToISODateTimeString()
+            };
             await worker.Execute(job);
 
-            job = CreateJobTemplate();
-            job.EndIndex = logEnd.AddDays(1).ToISODateTimeString();
+            job = CreateJobTemplate() with { EndIndex = logEnd.AddDays(1).ToISODateTimeString() };
             await worker.Execute(job);
 
-            job = CreateJobTemplate();
-            job.StartIndex = logEnd.AddDays(1).ToISODateTimeString();
-            job.EndIndex = logEnd.AddDays(2).ToISODateTimeString();
+            job = CreateJobTemplate() with
+            {
+                StartIndex = logEnd.AddDays(1).ToISODateTimeString(),
+                EndIndex = logEnd.AddDays(2).ToISODateTimeString()
+            };
             await worker.Execute(job);
 
             witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
@@ -94,9 +97,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var newStartIndex = "50";
 
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_MD, new DepthIndex(10), new DepthIndex(100));
-            var job = CreateJobTemplate();
-            job.StartIndex = newStartIndex;
-            job.EndIndex = "100";
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = newStartIndex,
+                EndIndex = "100"
+            };
 
             var deleteQueries = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
@@ -119,9 +124,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var newLogStart = new DateTime(2000, 1, 5).ToISODateTimeString();
 
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, new DateTimeIndex(logStart), new DateTimeIndex(logEnd));
-            var job = CreateJobTemplate();
-            job.StartIndex = newLogStart;
-            job.EndIndex = logEnd.ToISODateTimeString();
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = newLogStart,
+                EndIndex = logEnd.ToISODateTimeString()
+            };
 
             var deleteQueries = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
@@ -142,9 +149,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var newEndIndex = "90";
 
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_MD, new DepthIndex(10), new DepthIndex(100));
-            var job = CreateJobTemplate();
-            job.StartIndex = "10";
-            job.EndIndex = newEndIndex;
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = "10",
+                EndIndex = newEndIndex
+            };
 
             var deleteQueries = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
@@ -167,9 +176,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var newLogEnd = new DateTime(2000, 1, 5).ToISODateTimeString();
 
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, new DateTimeIndex(logStart), new DateTimeIndex(logEnd));
-            var job = CreateJobTemplate();
-            job.StartIndex = logStart.ToISODateTimeString();
-            job.EndIndex = newLogEnd;
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = logStart.ToISODateTimeString(),
+                EndIndex = newLogEnd
+            };
 
             var deleteQueries = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
@@ -191,9 +202,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var newLogEnd = "90";
 
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_MD, new DepthIndex(10), new DepthIndex(100));
-            var job = CreateJobTemplate();
-            job.StartIndex = newLogStart;
-            job.EndIndex = newLogEnd;
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = newLogStart,
+                EndIndex = newLogEnd
+            };
 
             var deleteQueries = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
@@ -222,9 +235,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var newLogEnd = logEnd.AddDays(-1).ToISODateTimeString();
 
             SetupLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, new DateTimeIndex(logStart), new DateTimeIndex(logEnd));
-            var job = CreateJobTemplate();
-            job.StartIndex = newLogStart;
-            job.EndIndex = newLogEnd;
+            var job = CreateJobTemplate() with
+            {
+                StartIndex = newLogStart,
+                EndIndex = newLogEnd
+            };
 
             var deleteQueries = new List<WitsmlLogs>();
             witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))

--- a/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/CopyLogWorkerTests.cs
@@ -29,7 +29,8 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
             var configuration = ConfigurationReader.GetConfig();
             var witsmlClientProvider = new WitsmlClientProvider(configuration);
             client = witsmlClientProvider.GetClient();
-            worker = new CopyLogWorker(witsmlClientProvider);
+            var copyLogDataWorker = new CopyLogDataWorker(witsmlClientProvider);
+            worker = new CopyLogWorker(witsmlClientProvider, copyLogDataWorker);
             deleteLogsWorker = new DeleteLogObjectsWorker(witsmlClientProvider);
             logObjectService = new LogObjectService(witsmlClientProvider);
         }

--- a/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/RenameMnemonicWorkerTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/RenameMnemonicWorkerTests.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Witsml;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Jobs.Common;
 using WitsmlExplorer.Api.Services;
@@ -12,7 +11,6 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
     public class RenameMnemonicWorkerTests
     {
         private readonly RenameMnemonicWorker worker;
-        private readonly IWitsmlClient client;
         private const string WellUid = "";
         private const string WellboreUid = "";
         private const string LogUid = "";
@@ -22,22 +20,23 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
             var configuration = ConfigurationReader.GetConfig();
             var witsmlClientProvider = new WitsmlClientProvider(configuration);
             worker = new RenameMnemonicWorker(witsmlClientProvider);
-            client = witsmlClientProvider.GetClient();
         }
 
         [Fact(Skip="Should only be run manually")]
         public async void ValidInput_RenameMnemonic_ShouldReturnSuccess()
         {
-            var job = CreateJobTemplate();
-            job.Mnemonic = "";
-            job.NewMnemonic = "";
+            var job = CreateJobTemplate() with
+            {
+                Mnemonic = "",
+                NewMnemonic = ""
+            };
 
             var (result, _) = await worker.Execute(job);
 
             Assert.True(result.IsSuccess, result.Reason);
         }
 
-        private RenameMnemonicJob CreateJobTemplate()
+        private static RenameMnemonicJob CreateJobTemplate()
         {
             return new RenameMnemonicJob
             {


### PR DESCRIPTION
# Request Template Witsml Explorer
Thank you for contributing to WITSML Explorer!
Before submitting this PR, please fill in the following template.

## Fixes
This pull request is a prerequisite for #723 

## Description
The current worker implementation is not working in the background, but blocks/holds requests for as long as the job is being executed.

This PR refactors the worker logic so that incoming requests are parsed and enqueued to a background queue. A background service is continuously polling this queue to check for new jobs and executes them in order. There is a configuration property in the background service to configure the number of worker threads (currently 2) to avoid that long running jobs are blocking new jobs.

This makes it easy to generate a correlationId before returning the original request that orders the job, but the queue/background worker need to be updated to store correlationId and state (ordered, in progress, done, ..) and a new endpoint need to be added to retrieve the job status for a given correlationId (or all).

The PR also refactors and gets rid of the long switch statement in the `JobService.cs` class and retrieving the correct worker is now managed by dependency injection and a modified set of an `IWorker` interface and an abstract `BaseWorker` class.

All tests are running fine, but this PR touches a lot of code and need to be reviewed and tested thoroughly

...

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* Enhancement of existing functionality
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Background workers

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
