### PR TITLE
Moved publishing of nuget from github repo to nuget.org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Package
         run: dotnet pack --configuration Release Src/Witsml -p:Version=1.0.${GITHUB_RUN_NUMBER}
       - name: Publish
-        run: dotnet nuget push Src/Witsml/bin/Release/Witsml.1.0.${GITHUB_RUN_NUMBER}.nupkg
+        run: dotnet nuget push --api-key ${{secrets.NUGET_PUBLISH_KEY}} --source https://api.nuget.org/v3/index.json Src/Witsml/bin/Release/Witsml.1.0.${GITHUB_RUN_NUMBER}.nupkg

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Witsml Explorer is a data management tool used for browsing and editing data dir
 * Deep linking directly to objects using the URL
 
 ## Witsml as a Nuget package
-Please see [nuget.md](/nuget_witsml.md)
+Please see [nuget_witsml.md](/nuget_witsml.md)
 
 ## Contributing
 Please see our [contributing.md](/CONTRIBUTING.md).

--- a/Src/Witsml/Witsml.csproj
+++ b/Src/Witsml/Witsml.csproj
@@ -3,9 +3,19 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <LangVersion>default</LangVersion>
-    <PackageDescription>Witsml 1.4.1.1</PackageDescription>
-    <RepositoryUrl>https://github.com/equinor/witsml-explorer</RepositoryUrl>    
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>WitsmlClient</PackageId>
+    <Authors>WitsmlExplorer contributors</Authors>
+    <Description>This client library enables working with WITSML servers. The library supports a growing subset of the WITSML 1.4 standard and have CRUD operations for supported data objects</Description>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/equinor/witsml-explorer</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/equinor/witsml-explorer/</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageTags>witsml;sitecom</PackageTags>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/nuget_witsml.md
+++ b/nuget_witsml.md
@@ -1,35 +1,5 @@
 ## Access pre-built Witsml nuget package
 
-If you only need to include the [Witsml](https://github.com/equinor/witsml-explorer/tree/main/Src/Witsml) project
-```sh
-witsml-explorer/Src/Witsml
-``` 
-Witsml nuget package can be added to your own project using [nuget](https://docs.microsoft.com/en-us/nuget/). 
-It is necessary to author a new personal access token to be able to add the package to your project. A `nuget.config` (config file at solution, user or global scope) has to accommodate for username and the token afterwards.
-
-**Example** 
-
-1. Create your api access token at [https://github.com/settings/tokens](https://github.com/settings/tokens)
-2. Make the token available through a config file at your preferred location (see: [configuring-nuget-behavior](https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior))
-3. Add the Witsml package to your project
-   ```sh
-   dotnet add PROJECT package Witsml --version 1.0.18
-   ```
-To keep secrets out of your solution, use environment variables or place you nuget.config file under user scope (e.g. `~/.nuget/nuget.config`). An example with credentials as environment variables has been outlined below
-
-***nuget.conf***
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="equinor" value="https://nuget.pkg.github.com/equinor/index.json" />
-        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    </packageSources>
-    <packageSourceCredentials>
-        <equinor>
-            <add key="Username" value="%USERNAME%" />
-            <add key="ClearTextPassword" value="%CLEARTEXTPASSWORD%" />
-        </equinor>
-    </packageSourceCredentials>
-</configuration>
-```
+If you only need to include the [Witsml](https://github.com/equinor/witsml-explorer/tree/main/Src/Witsml) project (`witsml-explorer/Src/Witsml`),
+then you can simply add a pre-published nuget package for that library:
+`dotnet add PROJECT package WitsmlClient`


### PR DESCRIPTION
# Request Template Witsml Explorer
## Fixes
This pull request fixes #766

## Description
This PR replaces the current workflow that publishes a nuget package for the `Witsml` library to Github. It will now instead publish to nuget.org (https://www.nuget.org/packages/WitsmlClient/).
...

## Type of change
* Enhancement of existing functionality
* This change requires a documentation update

## Checklist:

*Communication*
* [x] PR is related to an issue
* [x] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
