### PR TITLE
Improved GetFromStore for growing data-objects

### DIFF
--- a/Src/Witsml/Data/IWitsmlQueryType.cs
+++ b/Src/Witsml/Data/IWitsmlQueryType.cs
@@ -4,4 +4,6 @@ namespace Witsml.Data
     {
         string TypeName { get; }
     }
+
+    public interface IWitsmlGrowingDataQueryType : IWitsmlQueryType { }
 }

--- a/Src/Witsml/Data/WitsmlLogs.cs
+++ b/Src/Witsml/Data/WitsmlLogs.cs
@@ -4,13 +4,13 @@ using System.Xml.Serialization;
 namespace Witsml.Data
 {
     [XmlRoot("logs", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlLogs : IWitsmlQueryType
+    public class WitsmlLogs : IWitsmlGrowingDataQueryType
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
 
         [XmlElement("log")]
-        public List<WitsmlLog> Logs { get; set; } = new List<WitsmlLog>();
+        public List<WitsmlLog> Logs { get; set; } = new();
 
         public string TypeName => "log";
     }

--- a/Src/Witsml/Data/WitsmlMudLogs.cs
+++ b/Src/Witsml/Data/WitsmlMudLogs.cs
@@ -4,13 +4,13 @@ using System.Xml.Serialization;
 namespace Witsml.Data
 {
     [XmlRoot("mudLogs", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlMudLogs : IWitsmlQueryType
+    public class WitsmlMudLogs : IWitsmlGrowingDataQueryType
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
 
         [XmlElement("mudLog")]
-        public List<WitsmlMudLog> MudLogs { get; set; } = new List<WitsmlMudLog>();
+        public List<WitsmlMudLog> MudLogs { get; set; } = new();
         public string TypeName => "mudLog";
     }
 }

--- a/Src/Witsml/Data/WitsmlTrajectories.cs
+++ b/Src/Witsml/Data/WitsmlTrajectories.cs
@@ -4,13 +4,13 @@ using System.Xml.Serialization;
 namespace Witsml.Data
 {
     [XmlRoot("trajectorys", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlTrajectories : IWitsmlQueryType
+    public class WitsmlTrajectories : IWitsmlGrowingDataQueryType
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
 
         [XmlElement("trajectory")]
-        public List<WitsmlTrajectory> Trajectories { get; set; } = new List<WitsmlTrajectory>();
+        public List<WitsmlTrajectory> Trajectories { get; set; } = new();
 
         public string TypeName => "trajectory";
     }

--- a/Src/Witsml/Extensions/ResponseExtensions.cs
+++ b/Src/Witsml/Extensions/ResponseExtensions.cs
@@ -5,28 +5,18 @@ namespace Witsml.Extensions
     public static class ResponseExtensions
     {
         public static bool IsSuccessful(this WMLS_GetFromStoreResponse response)
-        {
-            return response.Result > 0;
-        }
+            => response.Result > 0;
 
         public static bool IsSuccessful(this WMLS_AddToStoreResponse response)
-        {
-            return response.Result > 0;
-        }
+            => response.Result > 0;
 
         public static bool IsSuccessful(this WMLS_UpdateInStoreResponse response)
-        {
-            return response.Result > 0;
-        }
+            => response.Result > 0;
 
         public static bool IsSuccessful(this WMLS_DeleteFromStoreResponse response)
-        {
-            return response.Result > 0;
-        }
+            => response.Result > 0;
 
         public static bool IsSuccessful(this WMLS_GetCapResponse response)
-        {
-            return response.Result > 0;
-        }
+            => response.Result > 0;
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Witsml;
+using Witsml.Data;
+using Witsml.ServiceReference;
+using Xunit;
+
+namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
+{
+    public class LogObjectTests
+    {
+        private readonly WitsmlClient client;
+        private readonly WitsmlClientCapabilities clientCapabilities = new();
+        private const string IsoPattern = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+        private const string UidWell = "bbd34996-a1f6-4767-8b02-5e3b46a990e8";
+        private const string UidWellbore = "064fc089-fb1d-4302-b85f-a1cd21455314";
+        private const string UidLog = "064fc089-fb1d-4302-b85f-a1cd21455314";
+
+        public LogObjectTests()
+        {
+            var config = ConfigurationReader.GetWitsmlConfiguration();
+            client = new WitsmlClient(config.Hostname, config.Username, config.Password, clientCapabilities);
+        }
+
+        [Fact]
+        public async Task GetGrowingDataObjectFromStoreAsync_ShortTimeSpan_Returns_ResultCode_1()
+        {
+            var endIndex = new DateTime(2021, 11, 3, 12, 0, 0);
+            var startIndex = endIndex.Subtract(TimeSpan.FromHours(1));
+            var query = new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog>
+                {
+                    new()
+                    {
+                        UidWell = UidWell,
+                        UidWellbore = UidWellbore,
+                        Uid = UidLog,
+                        StartDateTimeIndex = startIndex.ToString(IsoPattern),
+                        EndDateTimeIndex = endIndex.ToString(IsoPattern)
+                    }
+                }
+            };
+            var (result, resultCode) = await client.GetGrowingDataObjectFromStoreAsync(query, new OptionsIn(ReturnElements.All));
+            Assert.Equal(1, resultCode);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task GetGrowingDataObjectFromStoreAsync_LongTimeSpan_Returns_ResultCode_2()
+        {
+            var endIndex = new DateTime(2021, 11, 3, 12, 0, 0);
+            var startIndex = endIndex.Subtract(TimeSpan.FromHours(24));
+            var query = new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog>
+                {
+                    new()
+                    {
+                        UidWell = UidWell,
+                        UidWellbore = UidWellbore,
+                        Uid = UidLog,
+                        StartDateTimeIndex = startIndex.ToString(IsoPattern),
+                        EndDateTimeIndex = endIndex.ToString(IsoPattern)
+                    }
+                }
+            };
+            var (result, resultCode) = await client.GetGrowingDataObjectFromStoreAsync(query, new OptionsIn(ReturnElements.All));
+            Assert.Equal(2, resultCode);
+            Assert.Equal(10000, result.Logs.First().LogData.Data.Count);
+            Assert.NotNull(result);
+        }
+    }
+}


### PR DESCRIPTION
Added GetGrowingDataObjectFromStoreAsync for fetching Logs, MudLogs and Trajectories and returns resultCode in addition to deserialized data. 

## Fixes
This pull request fixes #763 

## Description
This PR includes an extra GetFromStore method in `WitsmlClient`, `GetGrowingDataObjectFromStoreAsync`. This method can be used with growing data-objects (`WitsmlLogs`, `WitsmlMudLogs` and `WitsmlTrajectories`) and have an additional resultCode returned from the method.

...

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* WitsmlClient

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests