### PR TITLE
Move initialization of server repo to Startup.Configure()

### DIFF
--- a/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Linq;
 using System.Reflection;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NetCore.AutoRegisterDi;
 using Serilog;
-using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Repositories;
 using WitsmlExplorer.Api.Services;
@@ -44,9 +43,12 @@ namespace WitsmlExplorer.Api.Configuration
                 return;
             }
 
-            var serviceProvider = services.BuildServiceProvider();
-            var repository = serviceProvider.GetService<IDocumentRepository<TDocument, T>>();
-            repository?.InitClient();
+        }
+
+        public static void InitializeRepository(this IApplicationBuilder app)
+        {
+            var repository = app.ApplicationServices.GetService<IDocumentRepository<Server, Guid>>();
+            repository?.InitClientAsync().GetAwaiter().GetResult();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Repositories/CosmosRepository.cs
+++ b/Src/WitsmlExplorer.Api/Repositories/CosmosRepository.cs
@@ -24,10 +24,10 @@ namespace WitsmlExplorer.Api.Repositories
                 // SerializerOptions = new CosmosSerializationOptions{ PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase }
             });
         }
-        public async Task InitClient()
+        public async Task InitClientAsync()
         {
             await cosmosClient.CreateDatabaseIfNotExistsAsync(dbName);
-            await cosmosClient.GetDatabase(dbName).CreateContainerIfNotExistsAsync(new ContainerProperties{ Id = containerId, PartitionKeyPath = "/id"});
+            await cosmosClient.GetDatabase(dbName).CreateContainerIfNotExistsAsync(new ContainerProperties { Id = containerId, PartitionKeyPath = "/id" });
         }
 
         public async Task<TDocument> GetDocumentAsync(TDocumentId id)

--- a/Src/WitsmlExplorer.Api/Repositories/IDocumentRepository.cs
+++ b/Src/WitsmlExplorer.Api/Repositories/IDocumentRepository.cs
@@ -12,7 +12,7 @@ namespace WitsmlExplorer.Api.Repositories
         Task<TDocument> CreateDocumentAsync(TDocument document);
         Task<TDocument> UpdateDocumentAsync(TDocumentId id, TDocument document);
         Task DeleteDocumentAsync(TDocumentId id);
-        Task InitClient();
+        Task InitClientAsync();
     }
 
     public abstract class DbDocument<TDocumentId>

--- a/Src/WitsmlExplorer.Api/Repositories/MongoRepository.cs
+++ b/Src/WitsmlExplorer.Api/Repositories/MongoRepository.cs
@@ -20,7 +20,7 @@ namespace WitsmlExplorer.Api.Repositories
             collection = db.GetCollection<TDocument>(collectionName);
         }
 
-        public Task InitClient()
+        public Task InitClientAsync()
         {
             return Task.CompletedTask;
         }

--- a/Src/WitsmlExplorer.Api/Startup.cs
+++ b/Src/WitsmlExplorer.Api/Startup.cs
@@ -3,19 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Reflection;
 using Carter;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NetCore.AutoRegisterDi;
 using Serilog;
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Middleware;
-using WitsmlExplorer.Api.Models;
-using WitsmlExplorer.Api.Repositories;
 using WitsmlExplorer.Api.Services;
 using WitsmlExplorer.Api.Workers;
 
@@ -65,6 +61,7 @@ namespace WitsmlExplorer.Api
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.InitializeRepository();
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
## Fixes
This pull request fixes #834

## Description
1 Moved the resolve of IDocumentRepository instance and call of IDocumentRepository.InitClient() to Startup.Configure()
2 Rename IDocumentRepository.InitClient() to InitClientAsync()
3 Call InitClientAsync() synchronously

## Type of change

* Bugfix


## Impacted Areas in Application
* IDocumentRepository of backend

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation N/A

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests (Manually tested the start up of backend service is still OK)

## Further comments
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
