### PR TITLE
fix #838, Include missing public folder in deploy

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -11,6 +11,7 @@ WORKDIR /app
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/build ./build
+COPY --from=builder /app/public ./public
 COPY --from=builder /app/next.config.js ./next.config.js
 
 RUN addgroup -S -g 1001 non-root-group


### PR DESCRIPTION
## Fixes
This pull request fixes #838  

## Description
`public` folder with fonts has been included in deploy image

## Type of change

* Bugfix

## Impacted Areas in Application
Dockerfile

* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

## Further comments
In the process of trimming down the size of `frontend` dockerfile, the public folder with fonts was forgotten