### PR TITLE
bump base image and use aspnet -alpine

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -21,7 +21,7 @@ FROM backend as publish
 WORKDIR /app/Src/WitsmlExplorer.Api
 RUN dotnet publish -c Release -o out --no-restore --no-build --no-dependencies
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 WORKDIR /app
 COPY --from=publish /app/Src/WitsmlExplorer.Api/out .
 ENV ASPNETCORE_URLS=http://+:80

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:16.1 AS builder
+FROM mhart/alpine-node:16.4 AS builder
 WORKDIR /app
 COPY Src/WitsmlExplorer.Frontend/package.json ./
 COPY yarn.lock ./
@@ -6,7 +6,7 @@ RUN yarn install --frozen-lockfile
 COPY Src/WitsmlExplorer.Frontend  ./
 RUN yarn test && yarn build && npm prune --production
 
-FROM mhart/alpine-node:16.1 AS deployment
+FROM mhart/alpine-node:16.4 AS deployment
 WORKDIR /app
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
@@ -14,13 +14,13 @@ COPY --from=builder /app/build ./build
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/next.config.js ./next.config.js
 
-RUN addgroup -S -g 1001 non-root-group
-RUN adduser -S -u 1001 -G non-root-group non-root-user
+RUN addgroup -S -g 1001 deploy && adduser -S -u 1001 -G deploy deploy
 
 ENV NEXT_TELEMETRY_DISABLED=1
-
 ENV NODE_ENV=production
 ENV PORT=3000
 EXPOSE 3000
+
 USER 1001
+
 CMD [ "yarn", "start" ]


### PR DESCRIPTION
## Fixes
This pull request fixes #857 

## Description
This PR will use `aspnet6.0-alpine`, and also bump version numbers to `16.4` on base images used in `witsmlexplorer-frontend` and simplify non-root usernames

## Type of change
* Enhancement of existing functionality

## Impacted Areas in Application
Docker images

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [ ] Code follows the style guidelines
* [ ] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [ ] New code is covered by passing tests
