### PR TITLE
Fix server name overflowing icons

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
@@ -133,7 +133,9 @@ const ServerManager = (): React.ReactElement => {
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((server: Server) => (
               <MenuItem value={server.id} key={server.id} onClick={() => onSelectItem(server)}>
-                <Typography color={"initial"}>{server.name}</Typography>
+                <Typography style={{ marginRight: 20 * +isOpen, overflow: "hidden" }} color={"initial"}>
+                  {server.name}
+                </Typography>
                 {isOpen && (
                   <ListItemSecondaryAction onClick={() => onEditItem(server)}>
                     <Icon name="edit" color={colors.interactive.primaryResting} />


### PR DESCRIPTION
## Description

Fixes server name overflowing select and edit buttons.

**Before:**
![image](https://user-images.githubusercontent.com/1553016/144127250-55622341-f0a5-4851-94cd-c242dba77d25.png)
![image](https://user-images.githubusercontent.com/1553016/144127226-63d47e79-0433-4e6a-b218-43a1c60cb948.png)

**After:**
![image](https://user-images.githubusercontent.com/1553016/144127163-98b067d5-c5c4-47da-ab2a-b9e79c885894.png)
![image](https://user-images.githubusercontent.com/1553016/144127189-114226ba-d167-4962-9fc2-5e8db83183a7.png)

## Type of change

* Bugfix

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* Server manager

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

