### PR TITLE
change asset prefix to the same as basePath

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/AssetsLoader.ts
+++ b/Src/WitsmlExplorer.Frontend/components/AssetsLoader.ts
@@ -1,6 +1,6 @@
 export class AssetsLoader {
   static getAssetsRoot(): string {
     const wePath = process.env.WITSMLEXPLORER_FRONTEND_URL;
-    return wePath && wePath.length > 0 ? wePath : "";
+    return wePath && wePath.length > 0 ? new URL(wePath).pathname : "";
   }
 }


### PR DESCRIPTION
## Description
Only the relative prefix (which is equivalent to the nextjs basePath) needed when loading the icon and fonts.
With this change, the WITSMLEXPLORER_FRONTEND_URL in .env file can be simplified to, for example

WITSMLEXPLORER_FRONTEND_URL=http://./witsmlexplorer

less frequent code changes will be needed if the application gets deployed in different host addresses
...

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* Enhancement of existing functionality

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* frontend AssetsLoader.ts

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
