### PR TITLE
fix #944 - console, show log on depth logs

### DIFF
--- a/Src/WitsmlExplorer.Console/ShowCommands/ShowLogHeaderCommand.cs
+++ b/Src/WitsmlExplorer.Console/ShowCommands/ShowLogHeaderCommand.cs
@@ -52,8 +52,8 @@ namespace WitsmlExplorer.Console.ShowCommands
 
                         table.AddRow(
                             logCurveInfo.Mnemonic,
-                            logCurveInfo.MinDateTimeIndex,
-                            logCurveInfo.MaxDateTimeIndex
+                            logCurveInfo.MinDateTimeIndex ?? $"{logCurveInfo.MinIndex.Value}{logCurveInfo.MinIndex.Uom}",
+                            logCurveInfo.MaxDateTimeIndex ?? $"{logCurveInfo.MaxIndex.Value}{logCurveInfo.MaxIndex.Uom}"
                         );
                     }
                 });


### PR DESCRIPTION
## Fixes
This pull request fixes #944

## Description
Use depth index for curves when executing `show log` on a depth based log


## Type of change
* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application
Console

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [n/a] Existing tests pass
* [n/a] New code is covered by passing tests

## Further comments
Minor patch