### PR TITLE
Increase max length for credentials from 64 chars

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -89,8 +89,8 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
             required
             fullWidth
             error={!validText(username)}
-            helperText={username?.length === 0 ? "Username must be 1-64 characters" : ""}
-            inputProps={{ minLength: 1, maxLength: 64 }}
+            helperText={username?.length === 0 ? "Username must be 1-7936 characters" : ""}
+            inputProps={{ minLength: 1, maxLength: 7936 }}
             onChange={(e) => setUsername(e.target.value)}
           />
           <TextField
@@ -99,11 +99,11 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
             label={"Password"}
             defaultValue={password}
             error={!validText(password)}
-            helperText={password?.length === 0 ? "Password must be 1-64 characters" : ""}
+            helperText={password?.length === 0 ? "Password must be 1-7936 characters" : ""}
             fullWidth
             type="password"
             autoComplete="current-password"
-            inputProps={{ minLength: 1, maxLength: 64 }}
+            inputProps={{ minLength: 1, maxLength: 7936 }}
             onChange={(e) => setPassword(e.target.value)}
           />
         </>


### PR DESCRIPTION
# Request Template Witsml Explorer

## Fixes

## Description
For machine-to-machine authentication it is better to use tokens than harcoded passwords. In our stack we pass JWT tokens through the WISTML password field instead of hardcoded passwords. The Witsml Explorer UI caps the length of passwords to 64 characters, even if servers typically excepts authorization headers up to 8k.

This commit changes the max password length to a bit less than the max length of an authorization header for typical servers. This way a JWT token can be used as a password.

## Type of change
* Enhancement of existing functionality

## Impacted Areas in Application
## Checklist:
A very small change. Didn't create issue.

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

Did not find documentation to change, but I updated the error message to correspond to the new max length.

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments

Why 7936? Smallest header limitation I found was 8k. A bit less than 8K provides the space to write "Authorisation: Basic" and the credentials and fit within 8K.