### PR TITLE
Added constructor parameter to WitsmlClient to be able to specify custom request timeout

### DIFF
--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -31,7 +31,7 @@ namespace Witsml
         private readonly Uri serverUrl;
         private Logger queryLogger;
 
-        public WitsmlClient(string hostname, string username, string password, WitsmlClientCapabilities clientCapabilities, bool logQueries = false)
+        public WitsmlClient(string hostname, string username, string password, WitsmlClientCapabilities clientCapabilities, TimeSpan? requestTimeout = null, bool logQueries = false)
         {
             if (string.IsNullOrEmpty(hostname)) throw new ArgumentNullException(nameof(hostname), "Hostname is required");
             if (string.IsNullOrEmpty(username)) throw new ArgumentNullException(nameof(username), "Username is required");
@@ -39,7 +39,7 @@ namespace Witsml
 
             this.clientCapabilities = clientCapabilities.ToXml();
 
-            var serviceBinding = CreateBinding();
+            var serviceBinding = CreateBinding(requestTimeout ?? TimeSpan.FromMinutes(1));
             var endpointAddress = new EndpointAddress(hostname);
 
             client = new StoreSoapPortClient(serviceBinding, endpointAddress);
@@ -59,7 +59,7 @@ namespace Witsml
                 .CreateLogger();
         }
 
-        private static BasicHttpsBinding CreateBinding()
+        private static BasicHttpsBinding CreateBinding(TimeSpan requestTimeout)
         {
             var binding = new BasicHttpsBinding
             {
@@ -71,7 +71,8 @@ namespace Witsml
                         ClientCredentialType = HttpClientCredentialType.Basic
                     }
                 },
-                MaxReceivedMessageSize = int.MaxValue
+                MaxReceivedMessageSize = int.MaxValue,
+                SendTimeout = requestTimeout
             };
             return binding;
         }

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -73,8 +73,7 @@ namespace WitsmlExplorer.Api.Services
 
         private async Task VerifyCredentials(Uri serverUrl, Credentials credentials)
         {
-            var witsmlClient = new WitsmlClient(serverUrl.ToString(), credentials.Username, credentials.Password, clientCapabilities,
-                StringHelpers.ToBoolean(configuration["LogQueries"]));
+            var witsmlClient = new WitsmlClient(serverUrl.ToString(), credentials.Username, credentials.Password, clientCapabilities);
             await witsmlClient.TestConnectionAsync();
         }
     }

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -46,12 +46,12 @@ namespace WitsmlExplorer.Api.Services
             if (!isEncrypted) return;
 
             var logQueries = StringHelpers.ToBoolean(configuration["LogQueries"]);
-            witsmlClient = new WitsmlClient(serverUrl, credentials[0].Username, credentialsService.Decrypt(credentials[0]), clientCapabilities, logQueries);
+            witsmlClient = new WitsmlClient(serverUrl, credentials[0].Username, credentialsService.Decrypt(credentials[0]), clientCapabilities, null, logQueries);
 
             var sourceServerUrl = headers[WitsmlSourceServerUrlHeader];
 
             if (string.IsNullOrEmpty(sourceServerUrl) && credentials.Count == 1) return;
-            witsmlSourceClient = new WitsmlClient(sourceServerUrl, credentials[1].Username, credentialsService.Decrypt(credentials[1]), clientCapabilities, logQueries);
+            witsmlSourceClient = new WitsmlClient(sourceServerUrl, credentials[1].Username, credentialsService.Decrypt(credentials[1]), clientCapabilities, null, logQueries);
         }
 
         private static List<Credentials> ExtractCredentialsFromHeader(IHeaderDictionary headers)
@@ -71,7 +71,7 @@ namespace WitsmlExplorer.Api.Services
         internal WitsmlClientProvider(IConfiguration configuration)
         {
             var (serverUrl, username, password) = GetCredentialsFromConfiguration(configuration);
-            witsmlClient = new WitsmlClient(serverUrl, username, password, clientCapabilities, true);
+            witsmlClient = new WitsmlClient(serverUrl, username, password, clientCapabilities, null, true);
         }
 
         private (string, string, string) GetCredentialsFromConfiguration(IConfiguration configuration)


### PR DESCRIPTION
# Request Template Witsml Explorer
Thank you for contributing to WITSML Explorer!
Before submitting this PR, please fill in the following template.

## Fixes
This pull request fixes #1102 

## Description
This change adds an optional parameter to the `WitsmlClient` constructor that enables setting a custom request timeout. The default value (if not provided) is set to 1 minute like the underlying .NET library.

...

## Type of change
_List the types of change. Remove from the list any points which are not necessary_

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application
_List general components of the application that this PR will affect:_

* WitsmlClient provided by nuget package

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
Unable to provide good tests for the new code since it requires local run with an authenticated witsml server. The code has been manually tested though, both via temporary tests using the integration tests and by breakpoints in debugging to verify input