### PR TITLE
Specify culture when parsing curve values of type double

### DIFF
--- a/Src/Witsml/Data/Curves/DoubleValue.cs
+++ b/Src/Witsml/Data/Curves/DoubleValue.cs
@@ -13,7 +13,7 @@ namespace Witsml.Data.Curves
 
         public DoubleValue(string value)
         {
-            this.value = double.Parse(value);
+            this.value = double.Parse(value, CultureInfo.InvariantCulture);
         }
 
         public double Get() => value;

--- a/Src/Witsml/Data/Curves/Index.cs
+++ b/Src/Witsml/Data/Curves/Index.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Witsml.Extensions;
 
 namespace Witsml.Data.Curves
@@ -41,7 +42,8 @@ namespace Witsml.Data.Curves
         {
             return log.IndexType switch
             {
-                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.NullIfEmpty() ?? log.StartIndex.Value), log.StartIndex.Uom),
+                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.NullIfEmpty() ?? log.StartIndex.Value, CultureInfo.InvariantCulture),
+                    log.StartIndex.Uom),
                 WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(customIndexValue.NullIfEmpty() ?? log.StartDateTimeIndex)),
                 _ => throw new Exception($"Invalid index type: '{log.IndexType}'")
             };
@@ -51,7 +53,8 @@ namespace Witsml.Data.Curves
         {
             return log.IndexType switch
             {
-                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.NullIfEmpty() ?? log.EndIndex.Value), log.EndIndex.Uom),
+                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.NullIfEmpty() ?? log.EndIndex.Value, CultureInfo.InvariantCulture),
+                    log.EndIndex.Uom),
                 WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(customIndexValue.NullIfEmpty() ?? log.EndDateTimeIndex)),
                 _ => throw new Exception($"Invalid index type: '{log.IndexType}'")
             };
@@ -64,7 +67,7 @@ namespace Witsml.Data.Curves
 
             return indexType switch
             {
-                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(logCurveInfo.MinIndex.Value), logCurveInfo.MinIndex.Uom),
+                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(logCurveInfo.MinIndex.Value, CultureInfo.InvariantCulture), logCurveInfo.MinIndex.Uom),
                 WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(logCurveInfo.MinDateTimeIndex)),
                 _ => throw new Exception($"Invalid index type: '{indexType}'")
             };
@@ -77,7 +80,7 @@ namespace Witsml.Data.Curves
 
             return indexType switch
             {
-                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(logCurveInfo.MaxIndex.Value), logCurveInfo.MaxIndex.Uom),
+                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(logCurveInfo.MaxIndex.Value, CultureInfo.InvariantCulture), logCurveInfo.MaxIndex.Uom),
                 WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(logCurveInfo.MaxDateTimeIndex)),
                 _ => throw new Exception($"Invalid index type: '{indexType}'")
             };

--- a/Src/Witsml/Data/Curves/Point.cs
+++ b/Src/Witsml/Data/Curves/Point.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace Witsml.Data.Curves
@@ -17,7 +18,7 @@ namespace Witsml.Data.Curves
             }
             else
             {
-                Index = new DepthIndex(double.Parse(values.First()));
+                Index = new DepthIndex(double.Parse(values.First(), CultureInfo.InvariantCulture));
             }
 
             Value = CurveValue.From(values[1]);

--- a/Src/Witsml/Data/Curves/Row.cs
+++ b/Src/Witsml/Data/Curves/Row.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Witsml.Data.Curves
@@ -17,7 +18,7 @@ namespace Witsml.Data.Curves
             }
             else
             {
-                Index = new DepthIndex(double.Parse(row.First()));
+                Index = new DepthIndex(double.Parse(row.First(), CultureInfo.InvariantCulture));
             }
 
             Values = row[1..].Select(CurveValue.From);

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
@@ -101,9 +101,8 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             var data = witsmlLog.LogData.Data;
             var row = data.FirstOrDefault().GetRow();
 
-            Assert.Equal("DEPTH", indexMnemonic);
+            Assert.Equal("DEPTH".ToLower(), indexMnemonic.ToLower());
             Assert.NotEmpty(data);
-            Assert.Equal(12, row.Values.Count());
         }
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Witsml;
 using Witsml.Data;
+using Witsml.Extensions;
 using Witsml.ServiceReference;
 using Xunit;
 
@@ -18,6 +20,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         private const string UidWell = "bbd34996-a1f6-4767-8b02-5e3b46a990e8";
         private const string UidWellbore = "064fc089-fb1d-4302-b85f-a1cd21455314";
         private const string UidLog = "064fc089-fb1d-4302-b85f-a1cd21455314";
+
+        private const string UidWellDepth = "64457931-c280-4eee-8d58-8f2f27d02807";
+        private const string UidWellboreDepth = "d171f23a-750d-4415-b8e5-b8d57bb48d6d";
+        private const string UidLogDepth = "GM_Measured_Depth_GMDepth";
 
         public LogObjectTests()
         {
@@ -72,6 +78,32 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             Assert.Equal(2, resultCode);
             Assert.Equal(10000, result.Logs.First().LogData.Data.Count);
             Assert.NotNull(result);
+        }
+
+        [Fact(Skip="Should only be run manually")]
+        public async Task GetDepthDataObjectFromStoreAsync_ParseInvariant()
+        {
+            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("nb-NO");
+            var query = new WitsmlLogs
+            {
+                Logs = new WitsmlLog
+                {
+                    Uid = UidLogDepth,
+                    UidWell = UidWellDepth,
+                    UidWellbore = UidWellboreDepth
+
+                }.AsSingletonList()
+            };
+
+            var result = await client.GetFromStoreAsync(query, new OptionsIn(ReturnElements.All));
+            var witsmlLog = result.Logs.FirstOrDefault();
+            var indexMnemonic = witsmlLog.IndexCurve.Value;
+            var data = witsmlLog.LogData.Data;
+            var row = data.FirstOrDefault().GetRow();
+
+            Assert.Equal("DEPTH", indexMnemonic);
+            Assert.NotEmpty(data);
+            Assert.Equal(12, row.Values.Count());
         }
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
@@ -97,12 +97,8 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 
             var result = await client.GetFromStoreAsync(query, new OptionsIn(ReturnElements.All));
             var witsmlLog = result.Logs.FirstOrDefault();
-            var indexMnemonic = witsmlLog.IndexCurve.Value;
             var data = witsmlLog.LogData.Data;
-            var row = data.FirstOrDefault().GetRow();
-
-            Assert.Equal("DEPTH".ToLower(), indexMnemonic.ToLower());
-            Assert.NotEmpty(data);
+            data.First().GetRow(); // Test fails if parsing error on GetRow() due to incompatible culture setting.
         }
     }
 }


### PR DESCRIPTION
## Fixes
This pull request fixes #1173 

## Description
When converting string to double when parsing depth curve values, the culture is not set explicitly which means the culture setting on the machine running the code will be used. This might lead to parsing errors when the culture setting specifies a different decimal symbol than "." which is being used in the WITSML standard.

This pull request fixes this issue by explicitly setting the culture setting for parsing the value.

## Type of change
* Bugfix

## Impacted Areas in Application
* Object models in the Witsml.Data.Curves namespace.

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests