### PR TITLE
Change of nginx:image to remove CVE vulnerabilities

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -7,7 +7,7 @@ COPY Src/WitsmlExplorer.Frontend  ./
 RUN yarn test && yarn build && npm prune --production
 RUN yarn export
 
-FROM nginx:perl AS final
+FROM nginx:1-alpine AS final
 EXPOSE 3000
 
 COPY --from=builder /app/nginx/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
## Description
A small and quick change of the nginx image to remove 2 CVE´s in `nginx:perl`
[CVE-2022-29155](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-29155)
[CVE-2022-1292](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1292)

`docker scan` of the chosen image `nginx:1-alpine` shows no vulnerabilities