### PR TITLE
fix#1213, tryparse on depth index curve

### DIFF
--- a/Src/Witsml/Data/Curves/Index.cs
+++ b/Src/Witsml/Data/Curves/Index.cs
@@ -6,22 +6,22 @@ namespace Witsml.Data.Curves
 {
     public abstract class Index : IComparable<Index>
     {
-        public static bool operator < (Index index1, Index index2)
+        public static bool operator <(Index index1, Index index2)
         {
             return index1.CompareTo(index2) < 0;
         }
 
-        public static bool operator <= (Index index1, Index index2)
+        public static bool operator <=(Index index1, Index index2)
         {
             return index1.CompareTo(index2) <= 0;
         }
 
-        public static bool operator > (Index index1, Index index2)
+        public static bool operator >(Index index1, Index index2)
         {
             return index1.CompareTo(index2) > 0;
         }
 
-        public static bool operator >= (Index index1, Index index2)
+        public static bool operator >=(Index index1, Index index2)
         {
             return index1.CompareTo(index2) >= 0;
         }
@@ -42,7 +42,7 @@ namespace Witsml.Data.Curves
         {
             return log.IndexType switch
             {
-                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.NullIfEmpty() ?? log.StartIndex.Value, CultureInfo.InvariantCulture),
+                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.IsNumeric() ? customIndexValue : log.StartIndex.Value, CultureInfo.InvariantCulture),
                     log.StartIndex.Uom),
                 WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(customIndexValue.NullIfEmpty() ?? log.StartDateTimeIndex)),
                 _ => throw new Exception($"Invalid index type: '{log.IndexType}'")
@@ -53,7 +53,7 @@ namespace Witsml.Data.Curves
         {
             return log.IndexType switch
             {
-                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.NullIfEmpty() ?? log.EndIndex.Value, CultureInfo.InvariantCulture),
+                WitsmlLog.WITSML_INDEX_TYPE_MD => (Index) new DepthIndex(double.Parse(customIndexValue.IsNumeric() ? customIndexValue : log.EndIndex.Value, CultureInfo.InvariantCulture),
                     log.EndIndex.Uom),
                 WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(customIndexValue.NullIfEmpty() ?? log.EndDateTimeIndex)),
                 _ => throw new Exception($"Invalid index type: '{log.IndexType}'")


### PR DESCRIPTION
## Fixes
This pull request fixes #1213 

## Description
If `depth curve index !== ""` , `double.Parse` will fail.
`LogObjectServiceTests` with current settings fail.

## Type of change

* Bugfix

## Impacted Areas in Application
Witsml

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [x] Existing LogObjectServiceTests tests pass
* [ ] New code is covered by passing tests

## Further comments
Integration tests in `LogObjectServiceTests` failed, and will now pass.