### PR TITLE
configure lint-staged for frontend

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,9 @@
 {
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },  
   "env": {
     "browser": true,
     "es2021": true,

--- a/Src/WitsmlExplorer.Frontend/package.json
+++ b/Src/WitsmlExplorer.Frontend/package.json
@@ -7,14 +7,13 @@
     "build": "next build",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
-    "pre-commit": "lint-staged",
     "start": "next start",
     "test": "jest",
     "export": "next export"
   },
   "lint-staged": {
     "**/*.{js,ts,tsx}": [
-      "next lint --fix",
+      "eslint --fix",
       "prettier -w"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -25,17 +25,9 @@
   "lint-staged": {
     "*.{cs,vb}": [
       "dotnet tool run dotnet-format --include"
-    ],
-    "*.{ts,tsx}": [
-      "eslint",
-      "npx prettier -w ."
     ]
   },
   "devDependencies": {
-    "@types/react": "^18.0.9",
-    "@typescript-eslint/eslint-plugin": "^5.25.0",
-    "@typescript-eslint/parser": "^5.25.0",
-    "eslint-config-react": "^1.1.7",
     "husky": "^8.0.1",
     "lint-staged": "^12.4.1"
   }


### PR DESCRIPTION
## Fixes
This pull request fixes #1217 

## Description
- Focus frontend configuration for husky trigger lint-staged in frontend `packages.json`
- Use `eslint` over `next lint`


## Type of change
* Bugfix

## Impacted Areas in Application
Configuration, pre-commit trigger

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

## Further comments
Not code related