### PR TITLE
WE-423 add serilog sink to file

### DIFF
--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Witsml\Witsml.csproj" />

--- a/Src/WitsmlExplorer.Api/appsettings.Development.json
+++ b/Src/WitsmlExplorer.Api/appsettings.Development.json
@@ -8,7 +8,18 @@
       }
     },
     "WriteTo": [
-      { "Name": "Console", "Args": {"theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"} }
+      { "Name": "Console", "Args": {"theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"} },
+      {
+        "Name": "File",
+        "Args": {
+          "path": "./logs/api-.log",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message}{NewLine}{Exception}",
+          "rollOnFileSizeLimit": true,
+          "fileSizeLimitBytes": 104857600,
+          "retainedFileCountLimit": 512,
+          "rollingInterval": "Day"
+        }
+      }
     ],
     "Enrich": ["FromLogContext"]
   },

--- a/Src/WitsmlExplorer.Api/appsettings.Development.json
+++ b/Src/WitsmlExplorer.Api/appsettings.Development.json
@@ -8,18 +8,7 @@
       }
     },
     "WriteTo": [
-      { "Name": "Console", "Args": {"theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"} },
-      {
-        "Name": "File",
-        "Args": {
-          "path": "./logs/api-.log",
-          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message}{NewLine}{Exception}",
-          "rollOnFileSizeLimit": true,
-          "fileSizeLimitBytes": 104857600,
-          "retainedFileCountLimit": 512,
-          "rollingInterval": "Day"
-        }
-      }
+      { "Name": "Console", "Args": {"theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"} }
     ],
     "Enrich": ["FromLogContext"]
   },

--- a/Src/WitsmlExplorer.Api/appsettings.Production.json
+++ b/Src/WitsmlExplorer.Api/appsettings.Production.json
@@ -8,8 +8,17 @@
       }
     },
     "WriteTo": [
+      { "Name": "Console", "Args": {"theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"} },
       {
-        "Name": "Console"
+        "Name": "File",
+        "Args": {
+          "path": "/mount/logs/api-.log",
+          "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message}{NewLine}{Exception}",
+          "rollOnFileSizeLimit": true,
+          "fileSizeLimitBytes": 104857600,
+          "retainedFileCountLimit": 512,
+          "rollingInterval": "Day"
+        }
       }
     ],
     "Enrich": [


### PR DESCRIPTION
## Fixes
This pull request partial fixes Issue [#171](https://github.com/equinor/witsml-explorer/issues/171)


## Description
Include logging to file, so that we can export logfiles (on VM)

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application
Configuration, Logging

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
N/A

## Further comments
The change is in configuration only, to be tailored to the need of deployments separately.