### PR TITLE
WE-441 copy between servers

### DIFF
--- a/Src/WitsmlExplorer.Api/Jobs/Common/TubularComponentsReference.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/Common/TubularComponentsReference.cs
@@ -4,7 +4,6 @@ namespace WitsmlExplorer.Api.Jobs.Common
 {
     public class TubularComponentsReference
     {
-        public string ServerUrl { get; set; }
         public TubularReference TubularReference { get; set; }
         public IEnumerable<string> TubularComponentUids { get; set; } = new List<string>();
     }

--- a/Src/WitsmlExplorer.Api/Workers/CopyTubularComponentsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyTubularComponentsWorker.cs
@@ -29,8 +29,8 @@ namespace WitsmlExplorer.Api.Workers
         public override async Task<(WorkerResult, RefreshAction)> Execute(CopyTubularComponentsJob job)
         {
             var (targetTubular, componentsToCopy) = await FetchData(job);
-            var tubularcomponentToCopy = TubularQueries.CopyTubularComponents(targetTubular, componentsToCopy);
-            var copyResult = await witsmlClient.UpdateInStoreAsync(tubularcomponentToCopy);
+            var updatedTubularQuery = TubularQueries.CopyTubularComponents(targetTubular, componentsToCopy);
+            var copyResult = await witsmlClient.UpdateInStoreAsync(updatedTubularQuery);
             var tubularComponentsString = string.Join(", ", job.Source.TubularComponentUids);
             if (!copyResult.IsSuccessful)
             {
@@ -54,12 +54,12 @@ namespace WitsmlExplorer.Api.Workers
 
         private async Task<Tuple<WitsmlTubular, IEnumerable<WitsmlTubularComponent>>> FetchData(CopyTubularComponentsJob job)
         {
-            var tubularQuery = GetTubular(witsmlSourceClient, job.Target);
-            var tubularComponentsQuery = GetTubularComponents(witsmlClient, job.Source.TubularReference, job.Source.TubularComponentUids);
-            await Task.WhenAll(tubularQuery, tubularComponentsQuery);
-            var tubular = await tubularQuery;
-            var tubularComponents = await tubularComponentsQuery;
-            return Tuple.Create(tubular, tubularComponents);
+            var targetTubularQuery = GetTubular(witsmlClient, job.Target);
+            var sourceTubularComponentsQuery = GetTubularComponents(witsmlSourceClient, job.Source.TubularReference, job.Source.TubularComponentUids);
+            await Task.WhenAll(targetTubularQuery, sourceTubularComponentsQuery);
+            var targetTubular = targetTubularQuery.Result;
+            var sourceTubularComponents = sourceTubularComponentsQuery.Result;
+            return Tuple.Create(targetTubular, sourceTubularComponents);
         }
 
         private static async Task<WitsmlTubular> GetTubular(IWitsmlClient client, TubularReference tubularReference)

--- a/Src/WitsmlExplorer.Api/Workers/CopyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyTubularWorker.cs
@@ -52,12 +52,12 @@ namespace WitsmlExplorer.Api.Workers
 
         private async Task<Tuple<WitsmlTubular, WitsmlWellbore>> FetchData(CopyTubularJob job)
         {
-            var tubularQuery = GetTubular(witsmlSourceClient, job.Source);
-            var wellboreQuery = GetWellbore(witsmlClient, job.Target);
-            await Task.WhenAll(tubularQuery, wellboreQuery);
-            var tubular = await tubularQuery;
-            var targetWellbore = await wellboreQuery;
-            return Tuple.Create(tubular, targetWellbore);
+            var sourceTubularQuery = GetTubular(witsmlSourceClient, job.Source);
+            var targetWellboreQuery = GetWellbore(witsmlClient, job.Target);
+            await Task.WhenAll(sourceTubularQuery, targetWellboreQuery);
+            var sourceTubular = sourceTubularQuery.Result;
+            var targetWellbore = targetWellboreQuery.Result;
+            return Tuple.Create(sourceTubular, targetWellbore);
         }
 
         private static async Task<WitsmlTubular> GetTubular(IWitsmlClient client, TubularReference tubularReference)


### PR DESCRIPTION
## Fixes
This pull request fixes WE-441

## Description
Fix use of clients in copyTubularComponentsWorker and use explicit naming.

## Type of change

* Bugfix

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
