### PR TITLE
WE-424 add application insights to project

### DIFF
--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Fixes
This pull request partially fixes # 171 

## Description
Add application insights to project so that any deployment can add instrumentation if needed

## Type of change
package added

*Communication*
* [x] PR is related to an issue

## Further comments
Actual use of Application Insight in WitsmlExplorer will have to be added to the CICD setup when deploying the application.