### PR TITLE
WE-398 Checkable tubular rows

### DIFF
--- a/Src/WitsmlExplorer.Api/Jobs/Common/TubularComponentReferences.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/Common/TubularComponentReferences.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace WitsmlExplorer.Api.Jobs.Common
 {
-    public class TubularComponentsReference
+    public class TubularComponentReferences
     {
         public TubularReference TubularReference { get; set; }
         public IEnumerable<string> TubularComponentUids { get; set; } = new List<string>();

--- a/Src/WitsmlExplorer.Api/Jobs/Common/TubularReferences.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/Common/TubularReferences.cs
@@ -1,6 +1,6 @@
 namespace WitsmlExplorer.Api.Jobs.Common
 {
-    public class TubularsReference
+    public class TubularReferences
     {
         public string WellUid { get; set; }
         public string WellboreUid { get; set; }

--- a/Src/WitsmlExplorer.Api/Jobs/Common/TubularsReference.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/Common/TubularsReference.cs
@@ -1,0 +1,9 @@
+namespace WitsmlExplorer.Api.Jobs.Common
+{
+    public class TubularsReference
+    {
+        public string WellUid { get; set; }
+        public string WellboreUid { get; set; }
+        public string[] TubularUids { get; set; }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Jobs/CopyTubularComponentsJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyTubularComponentsJob.cs
@@ -4,7 +4,7 @@ namespace WitsmlExplorer.Api.Jobs
 {
     public record CopyTubularComponentsJob
     {
-        public TubularComponentsReference Source { get; init; }
+        public TubularComponentReferences Source { get; init; }
         public TubularReference Target { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CopyTubularJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyTubularJob.cs
@@ -4,7 +4,7 @@ namespace WitsmlExplorer.Api.Jobs
 {
     public record CopyTubularJob
     {
-        public TubularReference Source { get; init; }
+        public TubularsReference Source { get; init; }
         public WellboreReference Target { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/CopyTubularJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyTubularJob.cs
@@ -4,7 +4,7 @@ namespace WitsmlExplorer.Api.Jobs
 {
     public record CopyTubularJob
     {
-        public TubularsReference Source { get; init; }
+        public TubularReferences Source { get; init; }
         public WellboreReference Target { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteTubularJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteTubularJob.cs
@@ -4,6 +4,6 @@ namespace WitsmlExplorer.Api.Jobs
 {
     public record DeleteTubularJob
     {
-        public TubularReference TubularReference { get; init; }
+        public TubularsReference TubularsReference { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/DeleteTubularJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/DeleteTubularJob.cs
@@ -4,6 +4,6 @@ namespace WitsmlExplorer.Api.Jobs
 {
     public record DeleteTubularJob
     {
-        public TubularsReference TubularsReference { get; init; }
+        public TubularReferences TubularReferences { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Query/TubularQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/TubularQueries.cs
@@ -41,14 +41,47 @@ namespace WitsmlExplorer.Api.Query
             };
         }
 
-        public static WitsmlTubulars CopyWitsmlTubular(WitsmlTubular tubular, WitsmlWellbore targetWellbore)
+        public static WitsmlTubulars GetWitsmlTubularsById(string wellUid, string wellboreUid, string[] tubularUids)
         {
-            tubular.UidWell = targetWellbore.UidWell;
-            tubular.NameWell = targetWellbore.NameWell;
-            tubular.UidWellbore = targetWellbore.Uid;
-            tubular.NameWellbore = targetWellbore.Name;
-            var copyTubularQuery = new WitsmlTubulars { Tubulars = new List<WitsmlTubular> { tubular } };
-            return copyTubularQuery;
+            return new WitsmlTubulars
+            {
+                Tubulars = tubularUids.Select((tubularUid) => new WitsmlTubular
+                {
+                    Uid = tubularUid,
+                    UidWell = wellUid,
+                    UidWellbore = wellboreUid
+                }).ToList()
+            };
+        }
+
+        public static IEnumerable<WitsmlTubulars> DeleteWitsmlTubulars(string wellUid, string wellboreUid, string[] tubularUids)
+        {
+            return tubularUids.Select((tubularUid) =>
+                new WitsmlTubulars
+                {
+                    Tubulars = new WitsmlTubular
+                    {
+                        Uid = tubularUid,
+                        UidWell = wellUid,
+                        UidWellbore = wellboreUid
+                    }.AsSingletonList()
+                }
+            );
+        }
+
+        public static IEnumerable<WitsmlTubulars> CopyWitsmlTubulars(WitsmlTubulars tubulars, WitsmlWellbore targetWellbore)
+        {
+            return tubulars.Tubulars.Select((tubular) =>
+            {
+                tubular.UidWell = targetWellbore.UidWell;
+                tubular.NameWell = targetWellbore.NameWell;
+                tubular.UidWellbore = targetWellbore.Uid;
+                tubular.NameWellbore = targetWellbore.Name;
+                return new WitsmlTubulars
+                {
+                    Tubulars = tubular.AsSingletonList()
+                };
+            });
         }
 
         public static WitsmlTubulars CopyTubularComponents(WitsmlTubular tubular, IEnumerable<WitsmlTubularComponent> tubularComponents)

--- a/Src/WitsmlExplorer.Api/Workers/CopyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyTubularWorker.cs
@@ -86,9 +86,9 @@ namespace WitsmlExplorer.Api.Workers
             return Tuple.Create(tubulars, targetWellbore);
         }
 
-        private static async Task<WitsmlTubulars> GetTubulars(IWitsmlClient client, TubularsReference tubularsReference)
+        private static async Task<WitsmlTubulars> GetTubulars(IWitsmlClient client, TubularReferences tubularReferences)
         {
-            var witsmlTubular = TubularQueries.GetWitsmlTubularsById(tubularsReference.WellUid, tubularsReference.WellboreUid, tubularsReference.TubularUids);
+            var witsmlTubular = TubularQueries.GetWitsmlTubularsById(tubularReferences.WellUid, tubularReferences.WellboreUid, tubularReferences.TubularUids);
             return await client.GetFromStoreAsync(witsmlTubular, new OptionsIn(ReturnElements.All));
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/CopyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CopyTubularWorker.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
@@ -28,43 +29,67 @@ namespace WitsmlExplorer.Api.Workers
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(CopyTubularJob job)
         {
-            var (tubular, targetWellbore) = await FetchData(job);
-            var tubularToCopy = TubularQueries.CopyWitsmlTubular(tubular, targetWellbore);
-            var copyLogResult = await witsmlClient.AddToStoreAsync(tubularToCopy);
-            if (!copyLogResult.IsSuccessful)
+            var (tubulars, targetWellbore) = await FetchData(job);
+            var queries = TubularQueries.CopyWitsmlTubulars(tubulars, targetWellbore);
+
+            bool error = false;
+            var successUids = new List<string>();
+            var errorReasons = new List<string>();
+            var errorEnitities = new List<EntityDescription>();
+            var results = await Task.WhenAll(queries.Select(async (query) =>
             {
-                var errorMessage = "Failed to copy tubular.";
-                Log.Error(
-                    "{ErrorMessage} Source: UidWell: {SourceWellUid}, UidWellbore: {SourceWellboreUid}, Uid: {SourceTubularUid}. " +
+                var result = await witsmlClient.AddToStoreAsync(query);
+                var tubular = query.Tubulars.First();
+                if (result.IsSuccessful)
+                {
+                    Log.Information("{JobType} - Job successful", GetType().Name);
+                    successUids.Add(tubular.Uid);
+                }
+                else
+                {
+                    var errorMessage = "Failed to copy tubular.";
+                    Log.Error(
+                    "{ErrorMessage} Source: UidWell: {SourceWellUid}, UidWellbore: {SourceWellboreUid}, TubularUid: {SourceTubularUid}. " +
                     "Target: UidWell: {TargetWellUid}, UidWellbore: {TargetWellboreUid}",
                     errorMessage,
-                    job.Source.WellUid, job.Source.WellboreUid, job.Source.TubularUid,
+                    job.Source.WellUid, job.Source.WellboreUid, tubular.Uid,
                     job.Target.WellUid, job.Target.WellboreUid);
-                return (new WorkerResult(witsmlClient.GetServerHostname(), false, errorMessage, copyLogResult.Reason), null);
+                    error = true;
+                    errorReasons.Add(result.Reason);
+                    errorEnitities.Add(new EntityDescription
+                    {
+                        WellName = tubular.NameWell,
+                        WellboreName = tubular.NameWellbore,
+                        ObjectName = tubular.Name
+                    });
+                }
+                return result;
+            }));
+
+            var refreshAction = new RefreshWellbore(witsmlClient.GetServerHostname(), targetWellbore.UidWell, targetWellbore.Uid, RefreshType.Update);
+            var successString = successUids.Count > 0 ? $"Copied tubulars: {string.Join(", ", successUids)}." : "";
+            if (!error)
+            {
+                return (new WorkerResult(witsmlClient.GetServerHostname(), true, successString), refreshAction);
             }
 
-            Log.Information("{JobType} - Job successful. Tubular copied", GetType().Name);
-            var refreshAction = new RefreshWellbore(witsmlClient.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
-            var workerResult = new WorkerResult(witsmlClient.GetServerHostname(), true, $"Tubular {tubular.Name} copied to: {targetWellbore.Name}");
-
-            return (workerResult, refreshAction);
+            return (new WorkerResult(witsmlClient.GetServerHostname(), false, $"{successString} Failed to copy some tubulars", errorReasons.First(), errorEnitities.First()), successUids.Count > 0 ? refreshAction : null);
         }
 
-        private async Task<Tuple<WitsmlTubular, WitsmlWellbore>> FetchData(CopyTubularJob job)
+        private async Task<Tuple<WitsmlTubulars, WitsmlWellbore>> FetchData(CopyTubularJob job)
         {
-            var tubularQuery = GetTubular(witsmlSourceClient, job.Source);
+            var tubularsQuery = GetTubulars(witsmlSourceClient, job.Source);
             var wellboreQuery = GetWellbore(witsmlClient, job.Target);
-            await Task.WhenAll(tubularQuery, wellboreQuery);
-            var tubular = await tubularQuery;
-            var targetWellbore = await wellboreQuery;
-            return Tuple.Create(tubular, targetWellbore);
+            await Task.WhenAll(tubularsQuery, wellboreQuery);
+            var tubulars = tubularsQuery.Result;
+            var targetWellbore = wellboreQuery.Result;
+            return Tuple.Create(tubulars, targetWellbore);
         }
 
-        private static async Task<WitsmlTubular> GetTubular(IWitsmlClient client, TubularReference tubularReference)
+        private static async Task<WitsmlTubulars> GetTubulars(IWitsmlClient client, TubularsReference tubularsReference)
         {
-            var witsmlTubular = TubularQueries.GetWitsmlTubularById(tubularReference.WellUid, tubularReference.WellboreUid, tubularReference.TubularUid);
-            var result = await client.GetFromStoreAsync(witsmlTubular, new OptionsIn(ReturnElements.All));
-            return !result.Tubulars.Any() ? null : result.Tubulars.First();
+            var witsmlTubular = TubularQueries.GetWitsmlTubularsById(tubularsReference.WellUid, tubularsReference.WellboreUid, tubularsReference.TubularUids);
+            return await client.GetFromStoreAsync(witsmlTubular, new OptionsIn(ReturnElements.All));
         }
 
         private static async Task<WitsmlWellbore> GetWellbore(IWitsmlClient client, WellboreReference wellboreReference)

--- a/Src/WitsmlExplorer.Api/Workers/DeleteTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteTubularWorker.cs
@@ -1,10 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using Witsml;
-using Witsml.Data.Tubular;
-using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Query;
@@ -24,6 +23,8 @@ namespace WitsmlExplorer.Api.Workers
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteTubularJob job)
         {
+            Verify(job);
+
             var wellUid = job.TubularReferences.WellUid;
             var wellboreUid = job.TubularReferences.WellboreUid;
             var tubularUids = job.TubularReferences.TubularUids;
@@ -69,6 +70,13 @@ namespace WitsmlExplorer.Api.Workers
             }
 
             return (new WorkerResult(witsmlClient.GetServerHostname(), false, $"{successString} Failed to delete some tubulars", errorReasons.First(), errorEnitities.First()), successUids.Count > 0 ? refreshAction : null);
+        }
+
+        private static void Verify(DeleteTubularJob job)
+        {
+            if (!job.TubularReferences.TubularUids.Any()) throw new ArgumentException("A minimum of one tubular UID is required");
+            if (string.IsNullOrEmpty(job.TubularReferences.WellUid)) throw new ArgumentException("WellUid is required");
+            if (string.IsNullOrEmpty(job.TubularReferences.WellboreUid)) throw new ArgumentException("WellboreUid is required");
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/DeleteTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteTubularWorker.cs
@@ -24,9 +24,9 @@ namespace WitsmlExplorer.Api.Workers
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteTubularJob job)
         {
-            var wellUid = job.TubularsReference.WellUid;
-            var wellboreUid = job.TubularsReference.WellboreUid;
-            var tubularUids = job.TubularsReference.TubularUids;
+            var wellUid = job.TubularReferences.WellUid;
+            var wellboreUid = job.TubularReferences.WellboreUid;
+            var tubularUids = job.TubularReferences.TubularUids;
 
             var queries = TubularQueries.DeleteWitsmlTubulars(wellUid, wellboreUid, tubularUids);
             bool error = false;

--- a/Src/WitsmlExplorer.Api/Workers/DeleteTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DeleteTubularWorker.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using Witsml;
+using Witsml.Data.Tubular;
 using Witsml.ServiceReference;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
@@ -22,39 +24,51 @@ namespace WitsmlExplorer.Api.Workers
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(DeleteTubularJob job)
         {
-            var wellUid = job.TubularReference.WellUid;
-            var wellboreUid = job.TubularReference.WellboreUid;
-            var tubularUid = job.TubularReference.TubularUid;
+            var wellUid = job.TubularsReference.WellUid;
+            var wellboreUid = job.TubularsReference.WellboreUid;
+            var tubularUids = job.TubularsReference.TubularUids;
 
-            var witsmlTubular = TubularQueries.GetWitsmlTubularById(wellUid, wellboreUid, tubularUid);
-            var result = await witsmlClient.DeleteFromStoreAsync(witsmlTubular);
-            if (result.IsSuccessful)
+            var queries = TubularQueries.DeleteWitsmlTubulars(wellUid, wellboreUid, tubularUids);
+            bool error = false;
+            var successUids = new List<string>();
+            var errorReasons = new List<string>();
+            var errorEnitities = new List<EntityDescription>();
+            var results = await Task.WhenAll(queries.Select(async (query) =>
             {
-                Log.Information("{JobType} - Job successful", GetType().Name);
-                var refreshAction = new RefreshWellbore(witsmlClient.GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
-                return (new WorkerResult(witsmlClient.GetServerHostname(), true, $"Deleted tubular: {tubularUid}"), refreshAction);
-            }
-
-            Log.Error("Failed to delete tubular. WellUid: {WellUid}, WellboreUid: {WellboreUid}, Uid: {TubularUid}",
-                wellUid,
-                wellboreUid,
-                tubularUid);
-
-            witsmlTubular = TubularQueries.GetWitsmlTubularById(wellUid, wellboreUid, tubularUid);
-            var queryResult = await witsmlClient.GetFromStoreAsync(witsmlTubular, new OptionsIn(ReturnElements.IdOnly));
-
-            var tubular = queryResult.Tubulars.First();
-            EntityDescription description = null;
-            if (tubular != null)
-            {
-                description = new EntityDescription
+                var result = await witsmlClient.DeleteFromStoreAsync(query);
+                var tubular = query.Tubulars.First();
+                if (result.IsSuccessful)
                 {
-                    WellName = tubular.NameWell,
-                    WellboreName = tubular.NameWellbore,
-                    ObjectName = tubular.Name
-                };
+                    Log.Information("{JobType} - Job successful", GetType().Name);
+                    successUids.Add(tubular.Uid);
+                }
+                else
+                {
+                    Log.Error("Failed to delete tubular. WellUid: {WellUid}, WellboreUid: {WellboreUid}, Uid: {TubularUid}, Reason: {Reason}",
+                    wellUid,
+                    wellboreUid,
+                    query.Tubulars.First().Uid,
+                    result.Reason);
+                    error = true;
+                    errorReasons.Add(result.Reason);
+                    errorEnitities.Add(new EntityDescription
+                    {
+                        WellName = tubular.NameWell,
+                        WellboreName = tubular.NameWellbore,
+                        ObjectName = tubular.Name
+                    });
+                }
+                return result;
+            }));
+
+            var refreshAction = new RefreshWellbore(witsmlClient.GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+            var successString = successUids.Count > 0 ? $"Deleted tubulars: {string.Join(", ", successUids)}." : "";
+            if (!error)
+            {
+                return (new WorkerResult(witsmlClient.GetServerHostname(), true, successString), refreshAction);
             }
-            return (new WorkerResult(witsmlClient.GetServerHostname(), false, "Failed to delete tubular", result.Reason, description), null);
+
+            return (new WorkerResult(witsmlClient.GetServerHostname(), false, $"{successString} Failed to delete some tubulars", errorReasons.First(), errorEnitities.First()), successUids.Count > 0 ? refreshAction : null);
         }
     }
 }

--- a/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
@@ -29,9 +29,9 @@ const Alerts = (): React.ReactElement => {
         const content = (
           <>
             <h4>{notification.message}</h4>
-            {notification.description.wellName && <span>Well: {notification.description.wellName}</span>}
-            {notification.description.wellboreName && <span>Wellbore: {notification.description.wellboreName}</span>}
-            {notification.description.objectName && <span>Name: {notification.description.objectName}</span>}
+            {notification.description.wellName && <span>Well: {notification.description.wellName},</span>}
+            {notification.description.wellboreName && <span> Wellbore: {notification.description.wellboreName},</span>}
+            {notification.description.objectName && <span> Name: {notification.description.objectName}</span>}
             {notification.reason && (
               <>
                 <br />

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -20,8 +20,8 @@ export const TubularsListView = (): React.ReactElement => {
     }
   }, [selectedWellbore?.tubulars]);
 
-  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, tubular: Tubular) => {
-    const contextProps: TubularObjectContextMenuProps = { dispatchNavigation, dispatchOperation, selectedServer, tubular, wellbore: selectedWellbore, servers };
+  const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, tubulars: Tubular[]) => {
+    const contextProps: TubularObjectContextMenuProps = { dispatchNavigation, dispatchOperation, selectedServer, tubulars, wellbore: selectedWellbore, servers };
     const position = getContextMenuPosition(event);
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <TubularObjectContextMenu {...contextProps} />, position } });
   };
@@ -39,7 +39,18 @@ export const TubularsListView = (): React.ReactElement => {
     });
   };
 
-  return selectedWellbore ? <ContentTable columns={columns} data={tubulars} onSelect={onSelect} onContextMenu={onContextMenu} /> : <></>;
+  const tubularRows = tubulars.map((tubular) => {
+    return {
+      ...tubular,
+      id: tubular.uid
+    };
+  });
+
+  return selectedWellbore && tubulars == selectedWellbore.tubulars ? (
+    <ContentTable columns={columns} data={tubularRows} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />
+  ) : (
+    <></>
+  );
 };
 
 export default TubularsListView;

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
@@ -11,9 +11,9 @@ import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../.
 import { Server } from "../../models/server";
 import { Typography } from "@equinor/eds-core-react";
 import styled from "styled-components";
-import { createTubularComponentsReference } from "../../models/jobs/copyTubularComponentJob";
+import { createTubularComponentReferences } from "../../models/jobs/copyTubularComponentJob";
 import Tubular from "../../models/tubular";
-import { onClickPaste, useClipboardTubularComponentsReference } from "./TubularComponentContextMenuUtils";
+import { onClickPaste, useClipboardTubularComponentReferences } from "./TubularComponentContextMenuUtils";
 import TubularComponentPropertiesModal from "../Modals/TubularComponentPropertiesModal";
 import { TubularComponentRow } from "../ContentViews/TubularView";
 
@@ -27,11 +27,11 @@ export interface TubularComponentContextMenuProps {
 
 const TubularComponentContextMenu = (props: TubularComponentContextMenuProps): React.ReactElement => {
   const { checkedTubularComponents, dispatchOperation, tubular, selectedServer, servers } = props;
-  const [tubularComponentsReference] = useClipboardTubularComponentsReference();
+  const [tubularComponentReferences] = useClipboardTubularComponentReferences();
 
   const onClickCopy = async () => {
-    const tubularComponentsReference = createTubularComponentsReference(checkedTubularComponents, tubular, selectedServer.url);
-    await navigator.clipboard.writeText(JSON.stringify(tubularComponentsReference));
+    const tubularComponentReferences = createTubularComponentReferences(checkedTubularComponents, tubular, selectedServer.url);
+    await navigator.clipboard.writeText(JSON.stringify(tubularComponentReferences));
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
 
@@ -80,9 +80,9 @@ const TubularComponentContextMenu = (props: TubularComponentContextMenuProps): R
           <StyledIcon name="copy" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Copy tubular component{checkedTubularComponents?.length > 1 && "s"}</Typography>
         </MenuItem>,
-        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, tubular, tubularComponentsReference)} disabled={tubularComponentsReference === null}>
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, tubular, tubularComponentReferences)} disabled={tubularComponentReferences === null}>
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Paste tubular component{tubularComponentsReference?.tubularComponentUids.length > 1 && "s"}</Typography>
+          <Typography color={"primary"}>Paste tubular component{tubularComponentReferences?.tubularComponentUids.length > 1 && "s"}</Typography>
         </MenuItem>,
         <MenuItem key={"delete"} onClick={onClickDelete} disabled={checkedTubularComponents.length === 0}>
           <ListItemIcon>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenuUtils.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useState, useEffect } from "react";
 import OperationType from "../../contexts/operationType";
-import { parseStringToTubularComponentsReference, TubularComponentsReference } from "../../models/jobs/copyTubularComponentJob";
+import { parseStringToTubularComponentReferences, TubularComponentReferences } from "../../models/jobs/copyTubularComponentJob";
 import { Server } from "../../models/server";
 import JobService, { JobType } from "../../services/jobService";
 import { DispatchOperation } from "./TubularContextMenuUtils";
@@ -10,15 +10,15 @@ import React from "react";
 import TubularReference from "../../models/jobs/tubularReference";
 import Tubular from "../../models/tubular";
 
-export const useClipboardTubularComponentsReference: () => [TubularComponentsReference | null, Dispatch<SetStateAction<TubularComponentsReference>>] = () => {
-  const [tubularComponentsReference, setTubularComponentsReference] = useState<TubularComponentsReference>(null);
+export const useClipboardTubularComponentReferences: () => [TubularComponentReferences | null, Dispatch<SetStateAction<TubularComponentReferences>>] = () => {
+  const [tubularComponentReferences, setTubularComponentReferences] = useState<TubularComponentReferences>(null);
 
   useEffect(() => {
     const tryToParseClipboardContent = async () => {
       try {
         const clipboardText = await navigator.clipboard.readText();
-        const tubularComponentsReference = parseStringToTubularComponentsReference(clipboardText);
-        setTubularComponentsReference(tubularComponentsReference);
+        const tubularComponentReferences = parseStringToTubularComponentReferences(clipboardText);
+        setTubularComponentReferences(tubularComponentReferences);
       } catch (e) {
         //Not a valid object on the clipboard? That is fine, we won't use it.
       }
@@ -26,13 +26,13 @@ export const useClipboardTubularComponentsReference: () => [TubularComponentsRef
     tryToParseClipboardContent();
   }, []);
 
-  return [tubularComponentsReference, setTubularComponentsReference];
+  return [tubularComponentReferences, setTubularComponentReferences];
 };
 
-export const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, tubular: Tubular, tubularComponentsReference: TubularComponentsReference) => {
+export const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, tubular: Tubular, tubularComponentReferences: TubularComponentReferences) => {
   const onConnectionVerified = async (credentials: ServerCredentials) => {
     await CredentialsService.saveCredentials(credentials);
-    orderCopyJob(tubular, tubularComponentsReference, dispatchOperation);
+    orderCopyJob(tubular, tubularComponentReferences, dispatchOperation);
     dispatchOperation({ type: OperationType.HideModal });
   };
 
@@ -48,27 +48,27 @@ export const showCredentialsModal = (server: Server, dispatchOperation: Dispatch
   dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });
 };
 
-export const orderCopyJob = (tubular: Tubular, tubularComponentsReference: TubularComponentsReference, dispatchOperation: DispatchOperation) => {
+export const orderCopyJob = (tubular: Tubular, tubularComponentReferences: TubularComponentReferences, dispatchOperation: DispatchOperation) => {
   const tubularReference: TubularReference = {
     wellUid: tubular.wellUid,
     wellboreUid: tubular.wellboreUid,
     tubularUid: tubular.uid
   };
 
-  const copyJob = { source: tubularComponentsReference, target: tubularReference };
+  const copyJob = { source: tubularComponentReferences, target: tubularReference };
   JobService.orderJob(JobType.CopyTubularComponents, copyJob);
   dispatchOperation({ type: OperationType.HideContextMenu });
 };
 
-export const onClickPaste = async (servers: Server[], dispatchOperation: DispatchOperation, tubular: Tubular, tubularComponentsReference: TubularComponentsReference) => {
-  const sourceServer = servers.find((server) => server.url === tubularComponentsReference.serverUrl);
+export const onClickPaste = async (servers: Server[], dispatchOperation: DispatchOperation, tubular: Tubular, tubularComponentReferences: TubularComponentReferences) => {
+  const sourceServer = servers.find((server) => server.url === tubularComponentReferences.serverUrl);
   if (sourceServer !== null) {
     CredentialsService.setSourceServer(sourceServer);
     const hasPassword = CredentialsService.hasPasswordForServer(sourceServer);
     if (!hasPassword) {
-      showCredentialsModal(sourceServer, dispatchOperation, tubular, tubularComponentsReference);
+      showCredentialsModal(sourceServer, dispatchOperation, tubular, tubularComponentReferences);
     } else {
-      orderCopyJob(tubular, tubularComponentsReference, dispatchOperation);
+      orderCopyJob(tubular, tubularComponentReferences, dispatchOperation);
     }
   }
 };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularContextMenuUtils.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import OperationType from "../../contexts/operationType";
-import { parseStringToTubularReference } from "../../models/jobs/copyTubularJob";
-import TubularReference from "../../models/jobs/tubularReference";
+import { parseStringToTubularsReference } from "../../models/jobs/copyTubularJob";
 import { Server } from "../../models/server";
 import CredentialsService, { ServerCredentials } from "../../services/credentialsService";
 import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
@@ -15,18 +14,19 @@ import Tubular from "../../models/tubular";
 import { UpdateWellboreTubularAction } from "../../contexts/navigationStateReducer";
 import ModificationType from "../../contexts/modificationType";
 import ConfirmModal from "../Modals/ConfirmModal";
+import TubularsReference from "../../models/jobs/tubularsReference";
 
 export type DispatchOperation = (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
 
-export const useClipboardTubularReference: () => [TubularReference | null, Dispatch<SetStateAction<TubularReference>>] = () => {
-  const [tubularReference, setTubularReference] = useState<TubularReference>(null);
+export const useClipboardTubularsReference: () => [TubularsReference | null, Dispatch<SetStateAction<TubularsReference>>] = () => {
+  const [tubularsReference, setTubularsReference] = useState<TubularsReference>(null);
 
   useEffect(() => {
     const tryToParseClipboardContent = async () => {
       try {
         const clipboardText = await navigator.clipboard.readText();
-        const tubularReference = parseStringToTubularReference(clipboardText);
-        setTubularReference(tubularReference);
+        const tubularsReference = parseStringToTubularsReference(clipboardText);
+        setTubularsReference(tubularsReference);
       } catch (e) {
         //Not a valid object on the clipboard? That is fine, we won't use it.
       }
@@ -34,13 +34,13 @@ export const useClipboardTubularReference: () => [TubularReference | null, Dispa
     tryToParseClipboardContent();
   }, []);
 
-  return [tubularReference, setTubularReference];
+  return [tubularsReference, setTubularsReference];
 };
 
-export const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, wellbore: Wellbore, tubularReference: TubularReference) => {
+export const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, wellbore: Wellbore, tubularsReference: TubularsReference) => {
   const onConnectionVerified = async (credentials: ServerCredentials) => {
     await CredentialsService.saveCredentials(credentials);
-    orderCopyJob(wellbore, tubularReference, dispatchOperation);
+    orderCopyJob(wellbore, tubularsReference, dispatchOperation);
     dispatchOperation({ type: OperationType.HideModal });
   };
 
@@ -56,73 +56,73 @@ export const showCredentialsModal = (server: Server, dispatchOperation: Dispatch
   dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });
 };
 
-export const orderCopyJob = (wellbore: Wellbore, tubularReference: TubularReference, dispatchOperation: DispatchOperation) => {
+export const orderCopyJob = (wellbore: Wellbore, tubularsReference: TubularsReference, dispatchOperation: DispatchOperation) => {
   const wellboreReference: WellboreReference = {
     wellUid: wellbore.wellUid,
     wellboreUid: wellbore.uid
   };
 
-  const copyJob = { source: tubularReference, target: wellboreReference };
+  const copyJob = { source: tubularsReference, target: wellboreReference };
   JobService.orderJob(JobType.CopyTubular, copyJob);
   dispatchOperation({ type: OperationType.HideContextMenu });
 };
 
-export const onClickPaste = async (servers: Server[], dispatchOperation: DispatchOperation, wellbore: Wellbore, tubularReference: TubularReference) => {
-  const sourceServer = servers.find((server) => server.url === tubularReference.serverUrl);
+export const onClickPaste = async (servers: Server[], dispatchOperation: DispatchOperation, wellbore: Wellbore, tubularsReference: TubularsReference) => {
+  const sourceServer = servers.find((server) => server.url === tubularsReference.serverUrl);
   if (sourceServer !== null) {
     CredentialsService.setSourceServer(sourceServer);
     const hasPassword = CredentialsService.hasPasswordForServer(sourceServer);
     if (!hasPassword) {
-      showCredentialsModal(sourceServer, dispatchOperation, wellbore, tubularReference);
+      showCredentialsModal(sourceServer, dispatchOperation, wellbore, tubularsReference);
     } else {
-      orderCopyJob(wellbore, tubularReference, dispatchOperation);
+      orderCopyJob(wellbore, tubularsReference, dispatchOperation);
     }
   }
 };
 
-export const deleteTubular = async (tubular: Tubular, dispatchOperation: DispatchOperation, dispatchNavigation: (action: UpdateWellboreTubularAction) => void) => {
+export const deleteTubular = async (tubulars: Tubular[], dispatchOperation: DispatchOperation, dispatchNavigation: (action: UpdateWellboreTubularAction) => void) => {
   dispatchOperation({ type: OperationType.HideModal });
   const job = {
-    tubularReference: {
-      wellUid: tubular.wellUid,
-      wellboreUid: tubular.wellboreUid,
-      tubularUid: tubular.uid
+    tubularsReference: {
+      tubularUids: tubulars.map((tubular) => tubular.uid),
+      wellUid: tubulars[0].wellUid,
+      wellboreUid: tubulars[0].wellboreUid
     }
   };
   await JobService.orderJob(JobType.DeleteTubular, job);
-  const freshTubulars = await TubularService.getTubulars(job.tubularReference.wellUid, job.tubularReference.wellboreUid);
+  const freshTubulars = await TubularService.getTubulars(job.tubularsReference.wellUid, job.tubularsReference.wellboreUid);
   dispatchNavigation({
     type: ModificationType.UpdateTubularsOnWellbore,
     payload: {
-      wellUid: job.tubularReference.wellUid,
-      wellboreUid: job.tubularReference.wellboreUid,
+      wellUid: job.tubularsReference.wellUid,
+      wellboreUid: job.tubularsReference.wellboreUid,
       tubulars: freshTubulars
     }
   });
   dispatchOperation({ type: OperationType.HideContextMenu });
 };
 
-export const onClickCopy = async (selectedServer: Server, tubular: Tubular, dispatchOperation: DispatchOperation) => {
-  const tubularReference: TubularReference = {
+export const onClickCopy = async (selectedServer: Server, tubulars: Tubular[], dispatchOperation: DispatchOperation) => {
+  const tubularsReference: TubularsReference = {
     serverUrl: selectedServer.url,
-    tubularUid: tubular.uid,
-    wellUid: tubular.wellUid,
-    wellboreUid: tubular.wellboreUid
+    tubularUids: tubulars.map((tubular) => tubular.uid),
+    wellUid: tubulars[0].wellUid,
+    wellboreUid: tubulars[0].wellboreUid
   };
-  await navigator.clipboard.writeText(JSON.stringify(tubularReference));
+  await navigator.clipboard.writeText(JSON.stringify(tubularsReference));
   dispatchOperation({ type: OperationType.HideContextMenu });
 };
 
-export const onClickDelete = async (tubular: Tubular, dispatchOperation: DispatchOperation, dispatchNavigation: (action: UpdateWellboreTubularAction) => void) => {
+export const onClickDelete = async (tubulars: Tubular[], dispatchOperation: DispatchOperation, dispatchNavigation: (action: UpdateWellboreTubularAction) => void) => {
   const confirmation = (
     <ConfirmModal
       heading={"Delete tubular?"}
       content={
         <span>
-          This will permanently delete <strong>{tubular.name}</strong>
+          This will permanently delete tubulars: <strong>{tubulars.map((item) => item.uid).join(", ")}</strong>
         </span>
       }
-      onConfirm={() => deleteTubular(tubular, dispatchOperation, dispatchNavigation)}
+      onConfirm={() => deleteTubular(tubulars, dispatchOperation, dispatchNavigation)}
       confirmColor={"secondary"}
       switchButtonPlaces={true}
     />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
@@ -11,25 +11,25 @@ import { Typography } from "@equinor/eds-core-react";
 import styled from "styled-components";
 import Wellbore from "../../models/wellbore";
 import { UpdateWellboreTubularAction } from "../../contexts/navigationStateReducer";
-import { onClickCopy, onClickDelete, onClickPaste, useClipboardTubularReference } from "./TubularContextMenuUtils";
+import { onClickCopy, onClickDelete, onClickPaste, useClipboardTubularsReference } from "./TubularContextMenuUtils";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import TubularPropertiesModal from "../Modals/TubularPropertiesModal";
 
 export interface TubularObjectContextMenuProps {
   dispatchNavigation: (action: UpdateWellboreTubularAction) => void;
   dispatchOperation: (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
-  tubular: Tubular;
+  tubulars: Tubular[];
   selectedServer: Server;
   wellbore: Wellbore;
   servers: Server[];
 }
 
 const TubularObjectContextMenu = (props: TubularObjectContextMenuProps): React.ReactElement => {
-  const { dispatchNavigation, dispatchOperation, tubular, selectedServer, wellbore, servers } = props;
-  const [tubularReference] = useClipboardTubularReference();
+  const { dispatchNavigation, dispatchOperation, tubulars, selectedServer, wellbore, servers } = props;
+  const [tubularsReference] = useClipboardTubularsReference();
 
   const onClickProperties = async () => {
-    const tubularPropertiesModalProps = { mode: PropertiesModalMode.Edit, tubular, dispatchOperation };
+    const tubularPropertiesModalProps = { mode: PropertiesModalMode.Edit, tubular: tubulars[0], dispatchOperation };
     dispatchOperation({ type: OperationType.DisplayModal, payload: <TubularPropertiesModal {...tubularPropertiesModalProps} /> });
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
@@ -37,20 +37,20 @@ const TubularObjectContextMenu = (props: TubularObjectContextMenuProps): React.R
   return (
     <ContextMenu
       menuItems={[
-        <MenuItem key={"copy"} onClick={() => onClickCopy(selectedServer, tubular, dispatchOperation)}>
+        <MenuItem key={"copy"} onClick={() => onClickCopy(selectedServer, tubulars, dispatchOperation)} disabled={tubulars.length === 0}>
           <StyledIcon name="copy" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Copy tubular</Typography>
+          <Typography color={"primary"}>Copy tubular{tubulars?.length > 1 && "s"}</Typography>
         </MenuItem>,
-        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularReference)} disabled={tubularReference === null}>
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularsReference)} disabled={tubularsReference === null}>
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Paste tubular</Typography>
+          <Typography color={"primary"}>Paste tubular{tubularsReference?.tubularUids.length > 1 && "s"}</Typography>
         </MenuItem>,
-        <MenuItem key={"delete"} onClick={() => onClickDelete(tubular, dispatchOperation, dispatchNavigation)}>
+        <MenuItem key={"delete"} onClick={() => onClickDelete(tubulars, dispatchOperation, dispatchNavigation)} disabled={tubulars.length === 0}>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Delete tubular</Typography>
+          <Typography color={"primary"}>Delete tubular{tubulars?.length > 1 && "s"}</Typography>
         </MenuItem>,
         <Divider key={"divider"} />,
-        <MenuItem key={"properties"} onClick={onClickProperties}>
+        <MenuItem key={"properties"} onClick={onClickProperties} disabled={tubulars.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Properties</Typography>
         </MenuItem>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
@@ -11,7 +11,7 @@ import { Typography } from "@equinor/eds-core-react";
 import styled from "styled-components";
 import Wellbore from "../../models/wellbore";
 import { UpdateWellboreTubularAction } from "../../contexts/navigationStateReducer";
-import { onClickCopy, onClickDelete, onClickPaste, useClipboardTubularsReference } from "./TubularContextMenuUtils";
+import { onClickCopy, onClickDelete, onClickPaste, useClipboardTubularReferences } from "./TubularContextMenuUtils";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import TubularPropertiesModal from "../Modals/TubularPropertiesModal";
 
@@ -26,7 +26,7 @@ export interface TubularObjectContextMenuProps {
 
 const TubularObjectContextMenu = (props: TubularObjectContextMenuProps): React.ReactElement => {
   const { dispatchNavigation, dispatchOperation, tubulars, selectedServer, wellbore, servers } = props;
-  const [tubularsReference] = useClipboardTubularsReference();
+  const [tubularReferences] = useClipboardTubularReferences();
 
   const onClickProperties = async () => {
     const tubularPropertiesModalProps = { mode: PropertiesModalMode.Edit, tubular: tubulars[0], dispatchOperation };
@@ -41,9 +41,9 @@ const TubularObjectContextMenu = (props: TubularObjectContextMenuProps): React.R
           <StyledIcon name="copy" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Copy tubular{tubulars?.length > 1 && "s"}</Typography>
         </MenuItem>,
-        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularsReference)} disabled={tubularsReference === null}>
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularReferences)} disabled={tubularReferences === null}>
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Paste tubular{tubularsReference?.tubularUids.length > 1 && "s"}</Typography>
+          <Typography color={"primary"}>Paste tubular{tubularReferences?.tubularUids.length > 1 && "s"}</Typography>
         </MenuItem>,
         <MenuItem key={"delete"} onClick={() => onClickDelete(tubulars, dispatchOperation, dispatchNavigation)} disabled={tubulars.length === 0}>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
@@ -13,7 +13,7 @@ import { onClickCopy, onClickDelete } from "./TubularContextMenuUtils";
 import TubularPropertiesModal from "../Modals/TubularPropertiesModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import OperationType from "../../contexts/operationType";
-import { onClickPaste, useClipboardTubularComponentsReference } from "./TubularComponentContextMenuUtils";
+import { onClickPaste, useClipboardTubularComponentReferences } from "./TubularComponentContextMenuUtils";
 
 export interface TubularSidebarContextMenuProps {
   dispatchNavigation: (action: UpdateWellboreTubularAction) => void;
@@ -25,7 +25,7 @@ export interface TubularSidebarContextMenuProps {
 
 const TubularSidebarContextMenu = (props: TubularSidebarContextMenuProps): React.ReactElement => {
   const { dispatchNavigation, dispatchOperation, tubular, selectedServer, servers } = props;
-  const [tubularComponentsReference] = useClipboardTubularComponentsReference();
+  const [tubularComponentReferences] = useClipboardTubularComponentReferences();
 
   const onClickProperties = async () => {
     const tubularPropertiesModalProps = { mode: PropertiesModalMode.Edit, tubular, dispatchOperation };
@@ -40,9 +40,9 @@ const TubularSidebarContextMenu = (props: TubularSidebarContextMenuProps): React
           <StyledIcon name="copy" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Copy tubular</Typography>
         </MenuItem>,
-        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, tubular, tubularComponentsReference)} disabled={tubularComponentsReference === null}>
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, tubular, tubularComponentReferences)} disabled={tubularComponentReferences === null}>
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Paste tubular component{tubularComponentsReference?.tubularComponentUids.length > 1 && "s"}</Typography>
+          <Typography color={"primary"}>Paste tubular component{tubularComponentReferences?.tubularComponentUids.length > 1 && "s"}</Typography>
         </MenuItem>,
         <MenuItem key={"delete"} onClick={() => onClickDelete([tubular], dispatchOperation, dispatchNavigation)}>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
@@ -36,7 +36,7 @@ const TubularSidebarContextMenu = (props: TubularSidebarContextMenuProps): React
   return (
     <ContextMenu
       menuItems={[
-        <MenuItem key={"copy"} onClick={() => onClickCopy(selectedServer, tubular, dispatchOperation)}>
+        <MenuItem key={"copy"} onClick={() => onClickCopy(selectedServer, [tubular], dispatchOperation)}>
           <StyledIcon name="copy" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Copy tubular</Typography>
         </MenuItem>,
@@ -44,7 +44,7 @@ const TubularSidebarContextMenu = (props: TubularSidebarContextMenuProps): React
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Paste tubular component{tubularComponentsReference?.tubularComponentUids.length > 1 && "s"}</Typography>
         </MenuItem>,
-        <MenuItem key={"delete"} onClick={() => onClickDelete(tubular, dispatchOperation, dispatchNavigation)}>
+        <MenuItem key={"delete"} onClick={() => onClickDelete([tubular], dispatchOperation, dispatchNavigation)}>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Delete tubular</Typography>
         </MenuItem>,

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularsContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularsContextMenu.tsx
@@ -8,7 +8,7 @@ import { Server } from "../../models/server";
 import { Typography } from "@equinor/eds-core-react";
 import styled from "styled-components";
 import Wellbore from "../../models/wellbore";
-import { onClickPaste, useClipboardTubularsReference } from "./TubularContextMenuUtils";
+import { onClickPaste, useClipboardTubularReferences } from "./TubularContextMenuUtils";
 
 export interface TubularsContextMenuProps {
   dispatchOperation: (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
@@ -18,14 +18,14 @@ export interface TubularsContextMenuProps {
 
 const TubularsContextMenu = (props: TubularsContextMenuProps): React.ReactElement => {
   const { dispatchOperation, wellbore, servers } = props;
-  const [tubularsReference] = useClipboardTubularsReference();
+  const [tubularReferences] = useClipboardTubularReferences();
 
   return (
     <ContextMenu
       menuItems={[
-        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularsReference)} disabled={tubularsReference === null}>
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularReferences)} disabled={tubularReferences === null}>
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Paste tubular{tubularsReference?.tubularUids.length > 1 && "s"}</Typography>
+          <Typography color={"primary"}>Paste tubular{tubularReferences?.tubularUids.length > 1 && "s"}</Typography>
         </MenuItem>
       ]}
     />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularsContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularsContextMenu.tsx
@@ -8,7 +8,7 @@ import { Server } from "../../models/server";
 import { Typography } from "@equinor/eds-core-react";
 import styled from "styled-components";
 import Wellbore from "../../models/wellbore";
-import { onClickPaste, useClipboardTubularReference } from "./TubularContextMenuUtils";
+import { onClickPaste, useClipboardTubularsReference } from "./TubularContextMenuUtils";
 
 export interface TubularsContextMenuProps {
   dispatchOperation: (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
@@ -18,14 +18,14 @@ export interface TubularsContextMenuProps {
 
 const TubularsContextMenu = (props: TubularsContextMenuProps): React.ReactElement => {
   const { dispatchOperation, wellbore, servers } = props;
-  const [tubularReference] = useClipboardTubularReference();
+  const [tubularsReference] = useClipboardTubularsReference();
 
   return (
     <ContextMenu
       menuItems={[
-        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularReference)} disabled={tubularReference === null}>
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, dispatchOperation, wellbore, tubularsReference)} disabled={tubularsReference === null}>
           <StyledIcon name="paste" color={colors.interactive.primaryResting} />
-          <Typography color={"primary"}>Paste tubular</Typography>
+          <Typography color={"primary"}>Paste tubular{tubularsReference?.tubularUids.length > 1 && "s"}</Typography>
         </MenuItem>
       ]}
     />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -27,7 +27,7 @@ import TrajectoryReference from "../../models/jobs/trajectoryReference";
 import { parseStringToTrajectoryReference } from "../../models/jobs/copyTrajectoryJob";
 import LogReferences from "../../models/jobs/logReferences";
 import { Typography } from "@equinor/eds-core-react";
-import { useClipboardTubularsReference } from "./TubularContextMenuUtils";
+import { useClipboardTubularReferences } from "./TubularContextMenuUtils";
 
 export interface WellboreContextMenuProps {
   dispatchNavigation: (action: UpdateWellboreAction) => void;
@@ -40,7 +40,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
   const { dispatchNavigation, dispatchOperation, wellbore, servers } = props;
   const [logReferences, setLogReferences] = useState<LogReferences>(null);
   const [trajectoryReference, setTrajectoryReference] = useState<TrajectoryReference>(null);
-  const [tubularsReference] = useClipboardTubularsReference();
+  const [tubularReferences] = useClipboardTubularReferences();
 
   useEffect(() => {
     const tryToParseClipboardContent = async () => {
@@ -125,7 +125,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
     const sourceServerUrl =
       (jobType === JobType.CopyLog && logReferences.serverUrl) ||
       (jobType === JobType.CopyTrajectory && trajectoryReference.serverUrl) ||
-      (jobType === JobType.CopyTubular && tubularsReference.serverUrl);
+      (jobType === JobType.CopyTubular && tubularReferences.serverUrl);
     const sourceServer = servers.find((server) => server.url === sourceServerUrl);
     if (sourceServer !== null) {
       CredentialsService.setSourceServer(sourceServer);
@@ -151,7 +151,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
     const copyJob =
       (jobType === JobType.CopyLog && { source: logReferences, target: wellboreReference }) ||
       (jobType === JobType.CopyTrajectory && { source: trajectoryReference, target: wellboreReference }) ||
-      (jobType === JobType.CopyTubular && { source: tubularsReference, target: wellboreReference });
+      (jobType === JobType.CopyTubular && { source: tubularReferences, target: wellboreReference });
     JobService.orderJob(jobType, copyJob);
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
@@ -242,11 +242,11 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
           </ListItemIcon>
           <Typography color={"primary"}>Paste trajectory</Typography>
         </MenuItem>,
-        <MenuItem key={"pasteTubular"} onClick={() => onClickPaste(JobType.CopyTubular)} disabled={tubularsReference === null}>
+        <MenuItem key={"pasteTubular"} onClick={() => onClickPaste(JobType.CopyTubular)} disabled={tubularReferences === null}>
           <ListItemIcon>
             <Icon name="paste" color={colors.interactive.primaryResting} />
           </ListItemIcon>
-          <Typography color={"primary"}>Paste tubular{tubularsReference?.tubularUids.length > 1 && "s"}</Typography>
+          <Typography color={"primary"}>Paste tubular{tubularReferences?.tubularUids.length > 1 && "s"}</Typography>
         </MenuItem>,
         <MenuItem key={"deletelogobject"} onClick={onClickDelete}>
           <ListItemIcon>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -27,7 +27,7 @@ import TrajectoryReference from "../../models/jobs/trajectoryReference";
 import { parseStringToTrajectoryReference } from "../../models/jobs/copyTrajectoryJob";
 import LogReferences from "../../models/jobs/logReferences";
 import { Typography } from "@equinor/eds-core-react";
-import { useClipboardTubularReference } from "./TubularContextMenuUtils";
+import { useClipboardTubularsReference } from "./TubularContextMenuUtils";
 
 export interface WellboreContextMenuProps {
   dispatchNavigation: (action: UpdateWellboreAction) => void;
@@ -40,7 +40,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
   const { dispatchNavigation, dispatchOperation, wellbore, servers } = props;
   const [logReferences, setLogReferences] = useState<LogReferences>(null);
   const [trajectoryReference, setTrajectoryReference] = useState<TrajectoryReference>(null);
-  const [tubularReference] = useClipboardTubularReference();
+  const [tubularsReference] = useClipboardTubularsReference();
 
   useEffect(() => {
     const tryToParseClipboardContent = async () => {
@@ -125,7 +125,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
     const sourceServerUrl =
       (jobType === JobType.CopyLog && logReferences.serverUrl) ||
       (jobType === JobType.CopyTrajectory && trajectoryReference.serverUrl) ||
-      (jobType === JobType.CopyTubular && tubularReference.serverUrl);
+      (jobType === JobType.CopyTubular && tubularsReference.serverUrl);
     const sourceServer = servers.find((server) => server.url === sourceServerUrl);
     if (sourceServer !== null) {
       CredentialsService.setSourceServer(sourceServer);
@@ -151,7 +151,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
     const copyJob =
       (jobType === JobType.CopyLog && { source: logReferences, target: wellboreReference }) ||
       (jobType === JobType.CopyTrajectory && { source: trajectoryReference, target: wellboreReference }) ||
-      (jobType === JobType.CopyTubular && { source: tubularReference, target: wellboreReference });
+      (jobType === JobType.CopyTubular && { source: tubularsReference, target: wellboreReference });
     JobService.orderJob(jobType, copyJob);
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
@@ -242,11 +242,11 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
           </ListItemIcon>
           <Typography color={"primary"}>Paste trajectory</Typography>
         </MenuItem>,
-        <MenuItem key={"pasteTubular"} onClick={() => onClickPaste(JobType.CopyTubular)} disabled={tubularReference === null}>
+        <MenuItem key={"pasteTubular"} onClick={() => onClickPaste(JobType.CopyTubular)} disabled={tubularsReference === null}>
           <ListItemIcon>
             <Icon name="paste" color={colors.interactive.primaryResting} />
           </ListItemIcon>
-          <Typography color={"primary"}>Paste tubular</Typography>
+          <Typography color={"primary"}>Paste tubular{tubularsReference?.tubularUids.length > 1 && "s"}</Typography>
         </MenuItem>,
         <MenuItem key={"deletelogobject"} onClick={onClickDelete}>
           <ListItemIcon>

--- a/Src/WitsmlExplorer.Frontend/models/jobs/copyTubularComponentJob.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/copyTubularComponentJob.ts
@@ -3,18 +3,18 @@ import Tubular from "../tubular";
 import TubularReference from "./tubularReference";
 
 export interface CopyTubularComponentJob {
-  sourceTubularComponentsReference: TubularComponentsReference;
+  sourceTubularComponentReferences: TubularComponentReferences;
   targetTubularReference: TubularReference;
 }
 
-export interface TubularComponentsReference {
+export interface TubularComponentReferences {
   serverUrl: string;
   tubularReference: TubularReference;
   tubularComponentUids: string[];
 }
 
-export function parseStringToTubularComponentsReference(input: string): TubularComponentsReference {
-  let jsonObject: TubularComponentsReference;
+export function parseStringToTubularComponentReferences(input: string): TubularComponentReferences {
+  let jsonObject: TubularComponentReferences;
   try {
     jsonObject = JSON.parse(input);
   } catch (error) {
@@ -29,7 +29,7 @@ export function parseStringToTubularComponentsReference(input: string): TubularC
   };
 }
 
-function verifyRequiredProperties(jsonObject: TubularComponentsReference) {
+function verifyRequiredProperties(jsonObject: TubularComponentReferences) {
   const requiredProps = ["serverUrl", "tubularReference", "tubularComponentUids"];
   const hasRequiredProperties = requiredProps.every((prop) => Object.prototype.hasOwnProperty.call(jsonObject, prop));
   if (!hasRequiredProperties) {
@@ -37,7 +37,7 @@ function verifyRequiredProperties(jsonObject: TubularComponentsReference) {
   }
 }
 
-export function createTubularComponentsReference(tubularComponents: TubularComponentRow[], source: Tubular, serverUrl: string): TubularComponentsReference {
+export function createTubularComponentReferences(tubularComponents: TubularComponentRow[], source: Tubular, serverUrl: string): TubularComponentReferences {
   return {
     serverUrl: serverUrl,
     tubularReference: {
@@ -49,9 +49,9 @@ export function createTubularComponentsReference(tubularComponents: TubularCompo
   };
 }
 
-export function createCopyTubularComponentJob(sourceTubularComponentsReference: TubularComponentsReference, target: Tubular): CopyTubularComponentJob {
+export function createCopyTubularComponentJob(sourceTubularComponentReferences: TubularComponentReferences, target: Tubular): CopyTubularComponentJob {
   return {
-    sourceTubularComponentsReference,
+    sourceTubularComponentReferences,
     targetTubularReference: {
       wellUid: target.wellUid,
       wellboreUid: target.wellboreUid,

--- a/Src/WitsmlExplorer.Frontend/models/jobs/copyTubularJob.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/copyTubularJob.ts
@@ -1,21 +1,21 @@
-import TubularReference from "./tubularReference";
+import TubularsReference from "./tubularsReference";
 import WellboreReference from "./wellboreReference";
 
 export default interface CopyTubularJob {
-  source: TubularReference;
+  source: TubularsReference;
   target: WellboreReference;
 }
 
-function verifyRequiredProperties(jsonObject: TubularReference) {
-  const requiredProps = ["serverUrl", "wellUid", "wellboreUid", "tubularUid"];
+function verifyRequiredProperties(jsonObject: TubularsReference) {
+  const requiredProps = ["serverUrl", "wellUid", "wellboreUid", "tubularUids"];
   const hasRequiredProperties = requiredProps.every((prop) => Object.prototype.hasOwnProperty.call(jsonObject, prop));
   if (!hasRequiredProperties) {
     throw new Error("Missing required fields.");
   }
 }
 
-export function parseStringToTubularReference(input: string): TubularReference {
-  let jsonObject: TubularReference;
+export function parseStringToTubularsReference(input: string): TubularsReference {
+  let jsonObject: TubularsReference;
   try {
     jsonObject = JSON.parse(input);
   } catch (error) {

--- a/Src/WitsmlExplorer.Frontend/models/jobs/copyTubularJob.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/copyTubularJob.ts
@@ -1,12 +1,12 @@
-import TubularsReference from "./tubularsReference";
+import TubularReferences from "./tubularReferences";
 import WellboreReference from "./wellboreReference";
 
 export default interface CopyTubularJob {
-  source: TubularsReference;
+  source: TubularReferences;
   target: WellboreReference;
 }
 
-function verifyRequiredProperties(jsonObject: TubularsReference) {
+function verifyRequiredProperties(jsonObject: TubularReferences) {
   const requiredProps = ["serverUrl", "wellUid", "wellboreUid", "tubularUids"];
   const hasRequiredProperties = requiredProps.every((prop) => Object.prototype.hasOwnProperty.call(jsonObject, prop));
   if (!hasRequiredProperties) {
@@ -14,8 +14,8 @@ function verifyRequiredProperties(jsonObject: TubularsReference) {
   }
 }
 
-export function parseStringToTubularsReference(input: string): TubularsReference {
-  let jsonObject: TubularsReference;
+export function parseStringToTubularReferences(input: string): TubularReferences {
+  let jsonObject: TubularReferences;
   try {
     jsonObject = JSON.parse(input);
   } catch (error) {

--- a/Src/WitsmlExplorer.Frontend/models/jobs/tubularReferences.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/tubularReferences.ts
@@ -1,4 +1,4 @@
-export default interface TubularsReference {
+export default interface TubularReferences {
   serverUrl?: string;
   tubularUids: string[];
   wellUid: string;

--- a/Src/WitsmlExplorer.Frontend/models/jobs/tubularsReference.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/tubularsReference.ts
@@ -1,0 +1,6 @@
+export default interface TubularsReference {
+  serverUrl?: string;
+  tubularUids: string[];
+  wellUid: string;
+  wellboreUid: string;
+}

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularComponentTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularComponentTests.cs
@@ -70,7 +70,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             return new CopyTubularComponentsJob
             {
-                Source = new TubularComponentsReference
+                Source = new TubularComponentReferences
                 {
                     TubularReference = new TubularReference
                     {

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
@@ -77,7 +77,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             return new CopyTubularJob
             {
-                Source = new TubularsReference
+                Source = new TubularReferences
                 {
                     WellUid = WellUid,
                     WellboreUid = SourceWellboreUid,

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
@@ -77,11 +77,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             return new CopyTubularJob
             {
-                Source = new TubularReference
+                Source = new TubularsReference
                 {
                     WellUid = WellUid,
                     WellboreUid = SourceWellboreUid,
-                    TubularUid = TubularUid
+                    TubularUids = new string[] { TubularUid }
                 },
                 Target = new WellboreReference
                 {

--- a/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/CopyTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/CopyTubularWorkerTests.cs
@@ -23,11 +23,11 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
         {
             var job = new CopyTubularJob
             {
-                Source = new TubularReference
+                Source = new TubularsReference
                 {
                     WellUid = "f661ed9c-b3ec-46ef-a37b-8ab78f04c142",
                     WellboreUid = "51d8256d-55c6-4eac-9e8f-a801026de278",
-                    TubularUid = "2YA2M49"
+                    TubularUids = new string[] { "2YA2M49" }
                 },
                 Target = new WellboreReference
                 {

--- a/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/CopyTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/CopyTubularWorkerTests.cs
@@ -23,7 +23,7 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
         {
             var job = new CopyTubularJob
             {
-                Source = new TubularsReference
+                Source = new TubularReferences
                 {
                     WellUid = "f661ed9c-b3ec-46ef-a37b-8ab78f04c142",
                     WellboreUid = "51d8256d-55c6-4eac-9e8f-a801026de278",

--- a/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/DeleteTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/DeleteTubularWorkerTests.cs
@@ -23,11 +23,11 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
         {
             var job = new DeleteTubularJob
             {
-                TubularReference = new TubularReference
+                TubularsReference = new TubularsReference
                 {
                     WellUid = "8c77de13-4fad-4b2e-ba3d-7e6b0e35a394",
                     WellboreUid = "44e7a064-c2f2-4a3a-9259-5ab92085e110",
-                    TubularUid = "2YA2M49"
+                    TubularUids = new string[] { "2YA2M49" }
                 }
             };
             await worker.Execute(job);

--- a/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/DeleteTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Api/Workers/DeleteTubularWorkerTests.cs
@@ -23,7 +23,7 @@ namespace WitsmlExplorer.IntegrationTests.Api.Workers
         {
             var job = new DeleteTubularJob
             {
-                TubularsReference = new TubularsReference
+                TubularReferences = new TubularReferences
                 {
                     WellUid = "8c77de13-4fad-4b2e-ba3d-7e6b0e35a394",
                     WellboreUid = "44e7a064-c2f2-4a3a-9259-5ab92085e110",


### PR DESCRIPTION
## Fixes
This pull request fixes WE-398

## Description
Add checkable rows to TubularsListView and rewrite copy and delete workers to support operations on multiple tubulars

## Type of change
* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
Due to Witsml not supporting adding or deleting multiple tubulars with the same query, multiple queries had to be used per job. This causes problems for current way of giving feedback to the user, as some tubulars might be copied/deleted correctly, whilst other may fail. The error/success notifications do not support partially successful jobs.