### PR TITLE
WE-505 swagger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,9 @@ After adding your servers, reset file `MongoDbRepositoryTests.cs`.
 In developer environment, [Swashbuckle](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0&tabs=visual-studio-code) should make `SwaggerUI` available at the local url: `http(s)://localhost:<port>/swagger`. 
 
 ### Basic authentication
-`Basic` authentication is available by default. `username`/`password` should be used to get an encrypted token from the `/authorize` endpoint along with information about the server as json in the body.
+The `/witsml-servers` endpoint can be used to get a list of witsml servers in json format.
+
+`Basic` authentication is available by default and `username`/`password` should be used to get an encrypted token from the `/authorize` endpoint along with information about the server as json in the body.
 
 After aquiring this token, you should use the authorize button again (Basic), but this time with your `username`/`token`. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,41 @@ var newServer = new Server
 Then run the test from the commandline `dotnet test` or from your IDE. The server is now added to your mongoDB. Repeat this for all your servers.
 After adding your servers, reset file `MongoDbRepositoryTests.cs`.
 
+## Swashbuckle
+In developer environment, [Swashbuckle](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0&tabs=visual-studio-code) should make `SwaggerUI` available at the local url: `http(s)://localhost:<port>/swagger`. 
+
+### Basic authentication
+`Basic` authentication is available by default. `username`/`password` should be used to get an encrypted token from the `/authorize` endpoint along with information about the server as json in the body.
+
+After aquiring this token, you should use the authorize button again (Basic), but this time with your `username`/`token`. 
+
+This will make sure to include the `Authorization` header for basic authentication in your successive calls to other endpoints that need this. The header value `Witsml-ServerUrl` for the same server you got the token also needs to be filled out.
+
+### OAuth2 authentication
+`OAuth2` authentication is turned off by default through appsettings property `OAuth2Enabled`
+If you want to add this to SwaggerUI, you need to add the following info for your Azure app in the `mysettings.json` file:
+```json
+    "OAuth2Enabled": true,
+    "AzureAd": {
+        "AppName": "miniapp",
+        "Instance": "https://login.microsoftonline.com/",
+        "Domain": "qualified.domain.name",
+        "TenantId": "b3edbf8f-e8b2-4c4e-96fc-c86cdd7ed55f",
+        "ClientId": "109e12e2-4ca7-48d0-af05-c834c884322c",
+        "Scopes": "User.Read 109e12e2-4ca7-48d0-af05-c834c884322c/access_as_user",
+        "TokenValidationParameters": {
+            "ValidateAudience": false
+        },
+        "Swagger": {
+            "AuthorizationUrl": "https://login.microsoftonline.com/b3edbf8f-e8b2-4c4e-96fc-c86cdd7ed55f/oauth2/v2.0/authorize",
+            "TokenUrl": "https://login.microsoftonline.com/b3edbf8f-e8b2-4c4e-96fc-c86cdd7ed55f/oauth2/v2.0/token"
+        }
+    }
+``` 
+You should then find a new entry: `AuthorizationCode with PKCE` available in the UI.
+
+If successful authorization, the accesstoken will be included in successive calls as an `Authorization` header bearer token.
+
 ## Running
 The database, backend and frontend must be running at the same time for WE to work properly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ If you want to add this to SwaggerUI, you need to add the following info for you
         "Domain": "qualified.domain.name",
         "TenantId": "b3edbf8f-e8b2-4c4e-96fc-c86cdd7ed55f",
         "ClientId": "109e12e2-4ca7-48d0-af05-c834c884322c",
-        "Scopes": "User.Read 109e12e2-4ca7-48d0-af05-c834c884322c/access_as_user",
+        "Scopes": "openid profile 109e12e2-4ca7-48d0-af05-c834c884322c/access_as_user",
         "TokenValidationParameters": {
             "ValidateAudience": false
         },

--- a/Src/WitsmlExplorer.Api/HttpHandlers/BhaRunHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/BhaRunHandler.cs
@@ -1,18 +1,22 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class BhaRunHandler
 {
+    [Produces(typeof(IEnumerable<BhaRun>))]
     public static async Task<IResult> GetBhaRuns(string wellUid, string wellboreUid, IBhaRunService bhaRunService)
     {
         return Results.Ok(await bhaRunService.GetBhaRuns(wellUid, wellboreUid));
     }
+    [Produces(typeof(BhaRun))]
     public static async Task<IResult> GetBhaRun(string wellUid, string wellboreUid, string bhaRunUid, IBhaRunService bhaRunService)
     {
         return Results.Ok(await bhaRunService.GetBhaRun(wellUid, wellboreUid, bhaRunUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
@@ -7,7 +6,6 @@ using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
-
 public static class JobHandler
 {
     public static async Task<IResult> CreateJob(JobType jobType, HttpRequest httpRequest, IJobService jobService)

--- a/Src/WitsmlExplorer.Api/HttpHandlers/LogHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/LogHandler.cs
@@ -5,27 +5,29 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
-
-
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class LogHandler
 {
+    [Produces(typeof(IEnumerable<LogObject>))]
     public static async Task<IResult> GetLogs(string wellUid, string wellboreUid, ILogObjectService logObjectService)
     {
         return Results.Ok(await logObjectService.GetLogs(wellUid, wellboreUid));
     }
+    [Produces(typeof(LogObject))]
     public static async Task<IResult> GetLog(string wellUid, string wellboreUid, string logUid, ILogObjectService logObjectService)
     {
         return Results.Ok(await logObjectService.GetLog(wellUid, wellboreUid, logUid));
     }
+    [Produces(typeof(IEnumerable<LogCurveInfo>))]
     public static async Task<IResult> GetLogCurveInfo(string wellUid, string wellboreUid, string logUid, ILogObjectService logObjectService)
     {
         return Results.Ok(await logObjectService.GetLogCurveInfo(wellUid, wellboreUid, logUid));
     }
-
+    [Produces(typeof(LogData))]
     public static async Task<IResult> GetLogData(
         string wellUid,
         string wellboreUid,

--- a/Src/WitsmlExplorer.Api/HttpHandlers/MessageHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/MessageHandler.cs
@@ -1,18 +1,23 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class MessageHandler
+
 {
+    [Produces(typeof(IEnumerable<MessageObject>))]
     public static async Task<IResult> GetMessages(string wellUid, string wellboreUid, IMessageObjectService messageService)
     {
         return Results.Ok(await messageService.GetMessageObjects(wellUid, wellboreUid));
     }
+    [Produces(typeof(MessageObject))]
     public static async Task<IResult> GetMessage(string wellUid, string wellboreUid, string messageUid, IMessageObjectService messageService)
     {
         return Results.Ok(await messageService.GetMessageObject(wellUid, wellboreUid, messageUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/MudLogHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/MudLogHandler.cs
@@ -1,18 +1,21 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
-
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class MudLogHandler
 {
+    [Produces(typeof(IEnumerable<MudLog>))]
     public static async Task<IResult> GetMudLogs(string wellUid, string wellboreUid, IMudLogService mudLogService)
     {
         return Results.Ok(await mudLogService.GetMudLogs(wellUid, wellboreUid));
     }
+    [Produces(typeof(MudLog))]
     public static async Task<IResult> GetMudLog(string wellUid, string wellboreUid, string mudlogUid, IMudLogService mudLogService)
     {
         return Results.Ok(await mudLogService.GetMudLog(wellUid, wellboreUid, mudlogUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/RigHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/RigHandler.cs
@@ -1,18 +1,22 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class RigHandler
 {
+    [Produces(typeof(IEnumerable<Rig>))]
     public static async Task<IResult> GetRigs(string wellUid, string wellboreUid, IRigService rigService)
     {
         return Results.Ok(await rigService.GetRigs(wellUid, wellboreUid));
     }
+    [Produces(typeof(Rig))]
     public static async Task<IResult> GetRig(string wellUid, string wellboreUid, string rigUid, IRigService rigService)
     {
         return Results.Ok(await rigService.GetRig(wellUid, wellboreUid, rigUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/RiskHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/RiskHandler.cs
@@ -1,14 +1,16 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
-
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class RiskHandler
 {
+    [Produces(typeof(IEnumerable<Risk>))]
     public static async Task<IResult> GetRisks(string wellUid, string wellboreUid, IRiskService riskService)
     {
         return Results.Ok(await riskService.GetRisks(wellUid, wellboreUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/TrajectoryHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/TrajectoryHandler.cs
@@ -1,22 +1,27 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
-
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class TrajectoryHandler
 {
+    [Produces(typeof(IEnumerable<Trajectory>))]
     public static async Task<IResult> GetTrajectories(string wellUid, string wellboreUid, ITrajectoryService trajectoryService)
     {
         return Results.Ok(await trajectoryService.GetTrajectories(wellUid, wellboreUid));
+
     }
+    [Produces(typeof(Trajectory))]
     public static async Task<IResult> GetTrajectory(string wellUid, string wellboreUid, string trajectoryUid, ITrajectoryService trajectoryService)
     {
         return Results.Ok(await trajectoryService.GetTrajectory(wellUid, wellboreUid, trajectoryUid));
     }
+    [Produces(typeof(IEnumerable<TrajectoryStation>))]
     public static async Task<IResult> GetTrajectoryStations(string wellUid, string wellboreUid, string trajectoryUid, ITrajectoryService trajectoryService)
     {
         return Results.Ok(await trajectoryService.GetTrajectoryStations(wellUid, wellboreUid, trajectoryUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/TubularHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/TubularHandler.cs
@@ -1,22 +1,27 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class TubularHandler
 {
+    [Produces(typeof(IEnumerable<Tubular>))]
     public static async Task<IResult> GetTubulars(string wellUid, string wellboreUid, ITubularService tubularService)
     {
         return Results.Ok(await tubularService.GetTubulars(wellUid, wellboreUid));
     }
+    [Produces(typeof(IEnumerable<Tubular>))]
     public static async Task<IResult> GetTubular(string wellUid, string wellboreUid, string tubularUid, ITubularService tubularService)
     {
         return Results.Ok(await tubularService.GetTubular(wellUid, wellboreUid, tubularUid));
     }
+    [Produces(typeof(IEnumerable<TubularComponent>))]
     public static async Task<IResult> GetTubularComponents(string wellUid, string wellboreUid, string tubularUid, ITubularService tubularService)
     {
         return Results.Ok(await tubularService.GetTubularComponents(wellUid, wellboreUid, tubularUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/WbGeometryHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WbGeometryHandler.cs
@@ -1,14 +1,17 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class WbGeometryHandler
 {
+    [Produces(typeof(IEnumerable<WbGeometry>))]
     public static async Task<IResult> GetWbGeometries(string wellUid, string wellboreUid, IWbGeometryService wbGeometryService)
     {
         return Results.Ok(await wbGeometryService.GetWbGeometrys(wellUid, wellboreUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/WellHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WellHandler.cs
@@ -1,7 +1,10 @@
-using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using WitsmlExplorer.Api.Models;
 
 using WitsmlExplorer.Api.Services;
 
@@ -9,11 +12,13 @@ namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class WellHandler
 {
+    [Produces(typeof(IEnumerable<Well>))]
     public static async Task<IResult> GetAllWells(IWellService wellService)
     {
         return Results.Ok(await wellService.GetWells());
     }
 
+    [Produces(typeof(Well))]
     public static async Task<IResult> GetWell(string wellUid, IWellService wellService)
     {
         return Results.Ok(await wellService.GetWell(wellUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/WellHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WellHandler.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using WitsmlExplorer.Api.Models;
-
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;

--- a/Src/WitsmlExplorer.Api/HttpHandlers/WellboreHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WellboreHandler.cs
@@ -1,14 +1,16 @@
-using System;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class WellboreHandler
 {
+    [Produces(typeof(Wellbore))]
     public static async Task<IResult> GetWellbore(string wellUid, string wellboreUid, IWellboreService wellboreService)
     {
         return Results.Ok(await wellboreService.GetWellbore(wellUid, wellboreUid));

--- a/Src/WitsmlExplorer.Api/HttpHandlers/WitsmlServer.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WitsmlServer.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Repositories;
@@ -10,23 +12,27 @@ namespace WitsmlExplorer.Api.HttpHandler;
 
 public static class WitsmlServerHandler
 {
+    [Produces(typeof(IEnumerable<Server>))]
     public static async Task<IResult> GetWitsmlServers(IDocumentRepository<Server, Guid> witsmlServerRepository)
     {
         var servers = await witsmlServerRepository.GetDocumentsAsync();
         return Results.Ok(servers);
     }
+    [Produces(typeof(Server))]
     public static async Task<IResult> CreateWitsmlServer(Server witsmlServer, IDocumentRepository<Server, Guid> witsmlServerRepository)
     {
         var inserted = await witsmlServerRepository.CreateDocumentAsync(witsmlServer);
         return Results.Ok(inserted);
     }
 
+    [Produces(typeof(Server))]
     public static async Task<IResult> UpdateWitsmlServer(Guid witsmlServerId, Server witsmlServer, IDocumentRepository<Server, Guid> witsmlServerRepository)
     {
         var updatedServer = await witsmlServerRepository.UpdateDocumentAsync(witsmlServerId, witsmlServer);
         return Results.Ok(updatedServer);
     }
 
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public static async Task<IResult> DeleteWitsmlServer(Guid witsmlServerId, IDocumentRepository<Server, Guid> witsmlServerRepository)
     {
         await witsmlServerRepository.DeleteDocumentAsync(witsmlServerId);

--- a/Src/WitsmlExplorer.Api/Program.cs
+++ b/Src/WitsmlExplorer.Api/Program.cs
@@ -1,4 +1,3 @@
-
 using System.IO;
 
 using Microsoft.AspNetCore.Builder;
@@ -34,4 +33,5 @@ var app = builder.Build();
 app.ConfigureApi();
 
 startup.Configure(app, app.Environment);
+
 app.Run();

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -12,47 +12,47 @@ public static class Api
 {
     public static void ConfigureApi(this WebApplication app)
     {
-        app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers).Produces<IEnumerable<Server>>();
-        app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer).Produces<Server>();
-        app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer);
-        app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer).Produces(StatusCodes.Status204NoContent);
+        app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers).Produces<IEnumerable<Server>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer).Produces<Server>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer).Produces(StatusCodes.Status500InternalServerError);
+        app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer).Produces(StatusCodes.Status204NoContent).Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells", WellHandler.GetAllWells).Produces<IEnumerable<Well>>();
-        app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell).Produces<Well>();
+        app.MapGet("/api/wells", WellHandler.GetAllWells).Produces<IEnumerable<Well>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell).Produces<Well>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore).Produces<Wellbore>(); ;
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore).Produces<Wellbore>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries).Produces<IEnumerable<WbGeometry>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries).Produces<IEnumerable<WbGeometry>>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks).Produces<IEnumerable<Risk>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks).Produces<IEnumerable<Risk>>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars).Produces<IEnumerable<Tubular>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular).Produces<Tubular>(); ;
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents).Produces<IEnumerable<TubularComponent>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars).Produces<IEnumerable<Tubular>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular).Produces<Tubular>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents).Produces<IEnumerable<TubularComponent>>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages).Produces<IEnumerable<MessageObject>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage).Produces<MessageObject>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages).Produces<IEnumerable<MessageObject>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage).Produces<MessageObject>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns).Produces<IEnumerable<BhaRun>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun).Produces<BhaRun>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns).Produces<IEnumerable<BhaRun>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun).Produces<BhaRun>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs).Produces<IEnumerable<Rig>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig).Produces<Rig>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs).Produces<IEnumerable<Rig>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig).Produces<Rig>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs).Produces<IEnumerable<LogObject>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog).Produces<LogObject>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo).Produces<IEnumerable<LogCurveInfo>>();
-        app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData).Produces<LogData>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs).Produces<IEnumerable<LogObject>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog).Produces<LogObject>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo).Produces<IEnumerable<LogCurveInfo>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData).Produces<LogData>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs).Produces<IEnumerable<MudLog>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog).Produces<MudLog>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs).Produces<IEnumerable<MudLog>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog).Produces<MudLog>().Produces(StatusCodes.Status500InternalServerError);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories).Produces<IEnumerable<Trajectory>>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory).Produces<Trajectory>();
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations).Produces<IEnumerable<TrajectoryStation>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories).Produces<IEnumerable<Trajectory>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory).Produces<Trajectory>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations).Produces<IEnumerable<TrajectoryStation>>().Produces(StatusCodes.Status500InternalServerError);
 
         app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob).Produces<string>();
 
-        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).Produces<string>();
+        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).RequireAuthorization().Produces<string>().Produces(StatusCodes.Status500InternalServerError);
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -1,7 +1,10 @@
+using System.Collections.Generic;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
 using WitsmlExplorer.Api.HttpHandler;
+using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api;
 
@@ -9,47 +12,47 @@ public static class Api
 {
     public static void ConfigureApi(this WebApplication app)
     {
-        app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers);
-        app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer);
+        app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers).Produces<IEnumerable<Server>>();
+        app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer).Produces<Server>();
         app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer);
-        app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer);
+        app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer).Produces(StatusCodes.Status204NoContent);
 
-        app.MapGet("/api/wells", WellHandler.GetAllWells);
-        app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell);
+        app.MapGet("/api/wells", WellHandler.GetAllWells).Produces<IEnumerable<Well>>();
+        app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell).Produces<Well>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore).Produces<Wellbore>(); ;
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries).Produces<IEnumerable<WbGeometry>>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks).Produces<IEnumerable<Risk>>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars).Produces<IEnumerable<Tubular>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular).Produces<Tubular>(); ;
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents).Produces<IEnumerable<TubularComponent>>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages).Produces<IEnumerable<MessageObject>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage).Produces<MessageObject>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns).Produces<IEnumerable<BhaRun>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun).Produces<BhaRun>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs).Produces<IEnumerable<Rig>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig).Produces<Rig>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo);
-        app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs).Produces<IEnumerable<LogObject>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog).Produces<LogObject>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo).Produces<IEnumerable<LogCurveInfo>>();
+        app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData).Produces<LogData>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs).Produces<IEnumerable<MudLog>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog).Produces<MudLog>();
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories).Produces<IEnumerable<Trajectory>>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory).Produces<Trajectory>();
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations).Produces<IEnumerable<TrajectoryStation>>();
 
-        app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob);
+        app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob).Produces<string>();
 
-        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize);
+        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).Produces<string>();
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -1,10 +1,7 @@
-using System.Collections.Generic;
-
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
 using WitsmlExplorer.Api.HttpHandler;
-using WitsmlExplorer.Api.Models;
 
 namespace WitsmlExplorer.Api;
 
@@ -20,40 +17,40 @@ public static class Api
         app.MapGet("/api/wells", WellHandler.GetAllWells);
         app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore).Produces<Wellbore>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries).Produces<IEnumerable<WbGeometry>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks).Produces<IEnumerable<Risk>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars).Produces<IEnumerable<Tubular>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular).Produces<Tubular>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents).Produces<IEnumerable<TubularComponent>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages).Produces<IEnumerable<MessageObject>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage).Produces<MessageObject>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns).Produces<IEnumerable<BhaRun>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun).Produces<BhaRun>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs).Produces<IEnumerable<Rig>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig).Produces<Rig>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs).Produces<IEnumerable<LogObject>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog).Produces<LogObject>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo).Produces<IEnumerable<LogCurveInfo>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData).Produces<LogData>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo);
+        app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs).Produces<IEnumerable<MudLog>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog).Produces<MudLog>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog);
 
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories).Produces<IEnumerable<Trajectory>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory).Produces<Trajectory>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations).Produces<IEnumerable<TrajectoryStation>>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory);
+        app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations);
 
-        app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob).Produces<string>();
+        app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob);
 
-        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).Produces<string>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize);
 
         if (app.Environment.EnvironmentName == "Development")
         {

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -12,13 +12,13 @@ public static class Api
 {
     public static void ConfigureApi(this WebApplication app)
     {
-        app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers).Produces<IEnumerable<Server>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer).Produces<Server>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer).Produces(StatusCodes.Status500InternalServerError);
-        app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer).Produces(StatusCodes.Status204NoContent).Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers);
+        app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer);
+        app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer);
+        app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer);
 
-        app.MapGet("/api/wells", WellHandler.GetAllWells).Produces<IEnumerable<Well>>().Produces(StatusCodes.Status500InternalServerError);
-        app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell).Produces<Well>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapGet("/api/wells", WellHandler.GetAllWells);
+        app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell);
 
         app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore).Produces<Wellbore>().Produces(StatusCodes.Status500InternalServerError);
 

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -53,6 +53,11 @@ public static class Api
 
         app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob).Produces<string>();
 
-        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).RequireAuthorization().Produces<string>().Produces(StatusCodes.Status500InternalServerError);
+        app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).Produces<string>().Produces(StatusCodes.Status500InternalServerError);
+
+        if (app.Environment.EnvironmentName == "Development")
+        {
+            app.MapFallback(() => Results.Redirect("/swagger"));
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Startup.cs
+++ b/Src/WitsmlExplorer.Api/Startup.cs
@@ -57,6 +57,8 @@ namespace WitsmlExplorer.Api
             services.ConfigureDependencies(Configuration);
             services.AddHostedService<BackgroundWorkerService>();
             services.AddScoped<ICopyLogDataWorker, CopyLogDataWorker>();
+            services.AddEndpointsApiExplorer();
+            services.AddSwaggerGen();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -77,6 +79,8 @@ namespace WitsmlExplorer.Api
             app.UseCors(_myAllowSpecificOrigins);
             app.UseRouting();
             app.UseEndpoints(builder => builder.MapHub<NotificationsHub>("notifications"));
+            app.UseSwagger();
+            app.UseSwaggerUI();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Startup.cs
+++ b/Src/WitsmlExplorer.Api/Startup.cs
@@ -74,6 +74,31 @@ namespace WitsmlExplorer.Api
                 {
                     {basicSecurityScheme, Array.Empty<string>()}
                 });
+                var oAuth2scheme = new OpenApiSecurityScheme
+                {
+                    In = ParameterLocation.Header,
+                    Name = "Authorization",
+                    Flows = new OpenApiOAuthFlows
+                    {
+                        AuthorizationCode = new OpenApiOAuthFlow
+                        {
+                            AuthorizationUrl = new Uri("https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize"),
+                            TokenUrl = new Uri("https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token")
+                        }
+                    },
+                    Type = SecuritySchemeType.OAuth2
+                };
+                options.AddSecurityDefinition("OAuth2", oAuth2scheme);
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference { Id = "OAuth2", Type = ReferenceType.SecurityScheme },
+                            Type = SecuritySchemeType.OAuth2,
+                        },
+                        new List<string> { }
+                    }
+                });
             });
         }
 
@@ -84,6 +109,16 @@ namespace WitsmlExplorer.Api
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(
+                    options =>
+                    {
+                        options.OAuthAppName("<appname>");
+                        options.OAuthClientId("<clientId>");
+                        options.OAuthScopes("<clientId>/access_as_user");
+                        options.OAuthUsePkce();
+                    }
+                );
             }
             else
             {
@@ -95,8 +130,6 @@ namespace WitsmlExplorer.Api
             app.UseCors(_myAllowSpecificOrigins);
             app.UseRouting();
             app.UseEndpoints(builder => builder.MapHub<NotificationsHub>("notifications"));
-            app.UseSwagger();
-            app.UseSwaggerUI();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Startup.cs
+++ b/Src/WitsmlExplorer.Api/Startup.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+
+using Microsoft.OpenApi.Models;
 
 using Serilog;
 
@@ -58,7 +61,20 @@ namespace WitsmlExplorer.Api
             services.AddHostedService<BackgroundWorkerService>();
             services.AddScoped<ICopyLogDataWorker, CopyLogDataWorker>();
             services.AddEndpointsApiExplorer();
-            services.AddSwaggerGen();
+            services.AddSwaggerGen(options =>
+            {
+                var basicSecurityScheme = new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "basic",
+                    Reference = new OpenApiReference { Id = "BasicAuth", Type = ReferenceType.SecurityScheme }
+                };
+                options.AddSecurityDefinition(basicSecurityScheme.Reference.Id, basicSecurityScheme);
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {basicSecurityScheme, Array.Empty<string>()}
+                });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Src/WitsmlExplorer.Api/Swagger/SwaggerGen.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/SwaggerGen.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Identity.Web;
+using Microsoft.OpenApi.Models;
+
+using Serilog;
+
+using Witsml.Data;
+
+using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Middleware;
+using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Swagger;
+using WitsmlExplorer.Api.Workers;
+
+
+
+namespace WitsmlExplorer.Api.Swagger;
+
+public static class SwaggerGen
+{
+    public static void ConfigureAddSwaggerGen(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSwaggerGen(options =>
+        {
+            options.OperationFilter<WitsmlHeaderFilter>();
+            var basicSecurityScheme = new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.Http,
+                Scheme = "Basic",
+                Reference = new OpenApiReference { Id = "BasicAuth", Type = ReferenceType.SecurityScheme }
+            };
+            options.AddSecurityDefinition(basicSecurityScheme.Reference.Id, basicSecurityScheme);
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                    {basicSecurityScheme, Array.Empty<string>()}
+            });
+            var oAuth2scheme = new OpenApiSecurityScheme
+            {
+                In = ParameterLocation.Header,
+                Name = "Authorization",
+                Flows = new OpenApiOAuthFlows
+                {
+                    AuthorizationCode = new OpenApiOAuthFlow
+                    {
+                        AuthorizationUrl = new Uri(configuration["AzureAd:Swagger:AuthorizationUrl"]),
+                        TokenUrl = new Uri(configuration["AzureAd:Swagger:TokenUrl"])
+                    }
+                },
+                Type = SecuritySchemeType.OAuth2
+            };
+            options.AddSecurityDefinition("OAuth2", oAuth2scheme);
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference { Id = "OAuth2", Type = ReferenceType.SecurityScheme },
+                            Type = SecuritySchemeType.OAuth2,
+                        },
+                        new List<string> { }
+                    }
+            });
+        });
+    }
+
+    public static void ConfigureUseSwaggerUI(this IApplicationBuilder app, IConfiguration configuration)
+    {
+        app.UseSwaggerUI(
+            options =>
+            {
+                options.OAuthAppName(configuration["AzureAd:AppName"]);
+                options.OAuthClientId(configuration["AzureAd:ClientId"]);
+                options.OAuthScopes(configuration["AzureAd:Scopes"]);
+                options.OAuthUsePkce();
+            }
+        );
+    }
+}

--- a/Src/WitsmlExplorer.Api/Swagger/SwaggerGen.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/SwaggerGen.cs
@@ -1,85 +1,82 @@
 using System;
 using System.Collections.Generic;
 
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
-
-using Serilog;
-
-using Witsml.Data;
-
-using WitsmlExplorer.Api.Configuration;
-using WitsmlExplorer.Api.Middleware;
-using WitsmlExplorer.Api.Services;
-using WitsmlExplorer.Api.Swagger;
-using WitsmlExplorer.Api.Workers;
-
-
 
 namespace WitsmlExplorer.Api.Swagger;
 
 public static class SwaggerGen
 {
-    public static void ConfigureAddSwaggerGen(this IServiceCollection services, IConfiguration configuration)
+    public static void ConfigureSwaggerGen(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddSwaggerGen(options =>
-        {
-            options.OperationFilter<WitsmlHeaderFilter>();
-            var basicSecurityScheme = new OpenApiSecurityScheme
             {
-                Type = SecuritySchemeType.Http,
-                Scheme = "Basic",
-                Reference = new OpenApiReference { Id = "BasicAuth", Type = ReferenceType.SecurityScheme }
-            };
-            options.AddSecurityDefinition(basicSecurityScheme.Reference.Id, basicSecurityScheme);
-            options.AddSecurityRequirement(new OpenApiSecurityRequirement
-            {
-                    {basicSecurityScheme, Array.Empty<string>()}
-            });
-            var oAuth2scheme = new OpenApiSecurityScheme
-            {
-                In = ParameterLocation.Header,
-                Name = "Authorization",
-                Flows = new OpenApiOAuthFlows
-                {
-                    AuthorizationCode = new OpenApiOAuthFlow
-                    {
-                        AuthorizationUrl = new Uri(configuration["AzureAd:Swagger:AuthorizationUrl"]),
-                        TokenUrl = new Uri(configuration["AzureAd:Swagger:TokenUrl"])
-                    }
-                },
-                Type = SecuritySchemeType.OAuth2
-            };
-            options.AddSecurityDefinition("OAuth2", oAuth2scheme);
-            options.AddSecurityRequirement(new OpenApiSecurityRequirement {
-                    {
-                        new OpenApiSecurityScheme
-                        {
-                            Reference = new OpenApiReference { Id = "OAuth2", Type = ReferenceType.SecurityScheme },
-                            Type = SecuritySchemeType.OAuth2,
-                        },
-                        new List<string> { }
-                    }
-            });
-        });
-    }
+                options.OperationFilter<WitsmlHeaderFilter>();
 
-    public static void ConfigureUseSwaggerUI(this IApplicationBuilder app, IConfiguration configuration)
-    {
-        app.UseSwaggerUI(
-            options =>
-            {
-                options.OAuthAppName(configuration["AzureAd:AppName"]);
-                options.OAuthClientId(configuration["AzureAd:ClientId"]);
-                options.OAuthScopes(configuration["AzureAd:Scopes"]);
-                options.OAuthUsePkce();
+                var basicSecurityScheme = new OpenApiSecurityScheme
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "Basic",
+                    Reference = new OpenApiReference { Id = "BasicAuth", Type = ReferenceType.SecurityScheme }
+                };
+                options.AddSecurityDefinition(basicSecurityScheme.Reference.Id, basicSecurityScheme);
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {basicSecurityScheme, Array.Empty<string>()}
+                });
+                if (configuration["OAuth2Enabled"] == "True")
+                {
+                    var oAuth2scheme = new OpenApiSecurityScheme
+                    {
+                        In = ParameterLocation.Header,
+                        Name = "Authorization",
+                        Flows = new OpenApiOAuthFlows
+                        {
+                            AuthorizationCode = new OpenApiOAuthFlow
+                            {
+                                AuthorizationUrl = new Uri(configuration["AzureAd:Swagger:AuthorizationUrl"]),
+                                TokenUrl = new Uri(configuration["AzureAd:Swagger:TokenUrl"])
+                            }
+                        },
+                        Type = SecuritySchemeType.OAuth2
+                    };
+                    options.AddSecurityDefinition("OAuth2", oAuth2scheme);
+                    options.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                        {
+                            new OpenApiSecurityScheme
+                            {
+                                Reference = new OpenApiReference { Id = "OAuth2", Type = ReferenceType.SecurityScheme },
+                                Type = SecuritySchemeType.OAuth2,
+                            },
+                            new List<string> { }
+                        }
+                    });
+                }
             }
         );
+    }
+
+    public static void ConfigureSwagger(this IApplicationBuilder app, IConfiguration configuration)
+    {
+        app.UseSwagger();
+        if (configuration["OAuth2Enabled"] == "True")
+        {
+            app.UseSwaggerUI(
+                options =>
+                {
+                    options.OAuthAppName(configuration["AzureAd:AppName"]);
+                    options.OAuthClientId(configuration["AzureAd:ClientId"]);
+                    options.OAuthScopes(configuration["AzureAd:Scopes"]);
+                    options.OAuthUsePkce();
+                }
+            );
+        }
+        else
+        {
+            app.UseSwaggerUI();
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.OpenApi.Models;
 
@@ -7,6 +6,9 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace WitsmlExplorer.Api.Swagger;
 
+/// <summary>
+/// This class will add a Required HTTP Header `Witsml-ServerUrl` to SwaggerUI for all endpoints except where it is not needed
+/// </summary>
 public class WitsmlHeaderFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.OpenApi.Models;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace WitsmlExplorer.Api.Swagger;
+
+public class WitsmlHeaderFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var noHeader = new List<string>() { "WitsmlExplorer.Api.HttpHandler.AuthorizeHandler", "WitsmlExplorer.Api.HttpHandler.WitsmlServerHandler" };
+        if (operation.Parameters == null)
+            operation.Parameters = new List<OpenApiParameter>();
+
+        if (!noHeader.Contains(context.MethodInfo.DeclaringType.FullName))
+        {
+            operation.Parameters.Add(new OpenApiParameter
+            {
+                Name = "Witsml-ServerUrl",
+                In = ParameterLocation.Header,
+                Schema = new OpenApiSchema { Type = "string" },
+                Required = true
+            });
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Witsml\Witsml.csproj" />

--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -9,7 +9,9 @@
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.8" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.29.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.17.1" />
     <PackageReference Include="NetCore.AutoRegisterDi" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.11.0" />

--- a/Src/WitsmlExplorer.Api/appsettings.json
+++ b/Src/WitsmlExplorer.Api/appsettings.json
@@ -7,5 +7,6 @@
       "Name": "Witsml Explorer",
       "Description": "Browser interface for Witsml servers"
     }
-  }
+  },
+  "OAuth2Enabled": false
 }


### PR DESCRIPTION
## Further comments
This is a follow up for https://github.com/equinor/witsml-explorer/pull/1338 with swagger UI generation

Needs additional settings in `mysettings.json` for the Oauth2 part to work

```json
{
    "AzureAd": {
        "AppName": "<appname>",
        "Instance": "https://login.microsoftonline.com/",
        "Domain": "qualified.domain.name",
        "TenantId": "<tenant>",
        "ClientId": "<client>",
        "Scopes": "User.Read <client>/access_as_user",
        "TokenValidationParameters": {
            "ValidateAudience": false
        },
        "Swagger": {
            "AuthorizationUrl": "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/authorize",
            "TokenUrl": "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token"
        }
    }
}
````

