### PR TITLE
WE-353 MSAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/.ignore*
 **/.dccache
 # Rider settings
 .idea/
@@ -5,6 +6,7 @@
 # VS Code settings
 .vs/
 .vscode/
+!.vscode/settings.json
 
 # User-specific files
 *.rsuser

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ var newServer = new Server
 Then run the test from the commandline `dotnet test` or from your IDE. The server is now added to your mongoDB. Repeat this for all your servers.
 After adding your servers, reset file `MongoDbRepositoryTests.cs`.
 
-## Swashbuckle
+### Swashbuckle 
 In developer environment, [Swashbuckle](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0&tabs=visual-studio-code) should make `SwaggerUI` available at the local url: `http(s)://localhost:<port>/swagger`. 
 
 ### Basic authentication

--- a/Src/WitsmlExplorer.Frontend/.env.development
+++ b/Src/WitsmlExplorer.Frontend/.env.development
@@ -1,0 +1,6 @@
+# To disable MSAL, leave NEXT_PUBLIC_MSALENABLED empty
+# To override this file locally, create a ".env.development.local" duplicate
+NEXT_PUBLIC_MSALENABLED=
+NEXT_PUBLIC_AZURE_AD_TENANT_ID=<tenant>
+NEXT_PUBLIC_AZURE_AD_CLIENT_ID=<client_id>
+NEXT_PUBLIC_AZURE_AD_URL_WITSMLEXPLORER=http://localhost:3000/

--- a/Src/WitsmlExplorer.Frontend/.gitignore
+++ b/Src/WitsmlExplorer.Frontend/.gitignore
@@ -17,7 +17,7 @@
 
 # misc
 .DS_Store
-.env*
+.env*.local
 
 # debug
 npm-debug.log*

--- a/Src/WitsmlExplorer.Frontend/components/Nav.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Nav.tsx
@@ -1,10 +1,7 @@
+import { Breadcrumbs } from "@equinor/eds-core-react";
 import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
-import { Breadcrumbs } from "@equinor/eds-core-react";
 import NavigationContext from "../contexts/navigationContext";
-import NavigationType from "../contexts/navigationType";
-import Wellbore, { calculateLogGroupId, calculateLogTypeDepthId, calculateTrajectoryGroupId, calculateTubularGroupId } from "../models/wellbore";
-import { Server } from "../models/server";
 import {
   SelectBhaRunGroupAction,
   SelectLogGroupAction,
@@ -12,8 +9,8 @@ import {
   SelectLogTypeAction,
   SelectMessageGroupAction,
   SelectMessageObjectAction,
-  SelectRiskGroupAction,
   SelectRigGroupAction,
+  SelectRiskGroupAction,
   SelectServerAction,
   SelectTrajectoryAction,
   SelectTrajectoryGroupAction,
@@ -23,12 +20,15 @@ import {
   SelectWellAction,
   SelectWellboreAction
 } from "../contexts/navigationStateReducer";
-import Well from "../models/well";
+import NavigationType from "../contexts/navigationType";
 import LogObject from "../models/logObject";
 import MessageObject from "../models/messageObject";
+import { Server } from "../models/server";
 import Trajectory from "../models/trajectory";
-import ThemeMenu from "./ThemeMenu";
 import Tubular from "../models/tubular";
+import Well from "../models/well";
+import Wellbore, { calculateLogGroupId, calculateLogTypeDepthId, calculateTrajectoryGroupId, calculateTubularGroupId } from "../models/wellbore";
+import TopRightCornerMenu from "./TopRightCornerMenu";
 
 const Nav = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
@@ -89,7 +89,7 @@ const Nav = (): React.ReactElement => {
             </Breadcrumbs.Breadcrumb>
           ))}
         </StyledBreadcrumbs>
-        <ThemeMenu />
+        <TopRightCornerMenu />
       </Layout>
     </nav>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ThemeMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ThemeMenu.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import OperationContext from "../contexts/operationContext";
 import { UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
-import { getAccountInfo, signOut } from "../msal/MsalAuthProvider";
+import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
 import { colors } from "../styles/Colors";
 import Icon from "../styles/Icons";
 
@@ -58,16 +58,20 @@ const ThemeMenu = (): React.ReactElement => {
           {theme === UserTheme.Compact && <Icon name="check" />}
         </StyledMenuItem>
       </Menu>
-      <Pointer>
-        <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
-      </Pointer>
-      <Menu id="ThemeMenu" anchorEl={anchorAccountEl} open={openAccount}>
-        <ThemeLabel key={"text"}>Account</ThemeLabel>
-        <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
-        <StyledMenuItem key={"signout"} onClick={() => signOut()}>
-          Logout
-        </StyledMenuItem>
-      </Menu>
+      {msalEnabled && (
+        <Pointer>
+          <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
+        </Pointer>
+      )}
+      {msalEnabled && (
+        <Menu id="ThemeMenu" anchorEl={anchorAccountEl} open={openAccount}>
+          <ThemeLabel key={"text"}>Account</ThemeLabel>
+          <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
+          <StyledMenuItem key={"signout"} onClick={() => signOut()}>
+            Logout
+          </StyledMenuItem>
+        </Menu>
+      )}
     </>
   );
 };

--- a/Src/WitsmlExplorer.Frontend/components/ThemeMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ThemeMenu.tsx
@@ -1,19 +1,22 @@
+import { Menu, Typography } from "@equinor/eds-core-react";
 import React, { MouseEvent, useContext, useEffect, useState } from "react";
-import Icon from "../styles/Icons";
-import { colors } from "../styles/Colors";
+import styled from "styled-components";
 import OperationContext from "../contexts/operationContext";
 import { UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
-import { Menu, Typography } from "@equinor/eds-core-react";
-import styled from "styled-components";
+import { getAccountInfo, signOut } from "../msal/MsalAuthProvider";
+import { colors } from "../styles/Colors";
+import Icon from "../styles/Icons";
 
 const ThemeMenu = (): React.ReactElement => {
   const {
     operationState: { theme },
     dispatchOperation
   } = useContext(OperationContext);
-  const [anchorEl, setAnchorEl] = useState(null);
-  const open = Boolean(anchorEl);
+  const [anchorThemeEl, setAnchorThemeEl] = useState(null);
+  const [anchorAccountEl, setAnchorAccountEl] = useState(null);
+  const openTheme = Boolean(anchorThemeEl);
+  const openAccount = Boolean(anchorAccountEl);
 
   useEffect(() => {
     let localStorageTheme;
@@ -23,23 +26,29 @@ const ThemeMenu = (): React.ReactElement => {
     }
   }, []);
 
-  const onToggleMenu = (event: MouseEvent<SVGSVGElement>) => {
-    anchorEl != null ? setAnchorEl(null) : setAnchorEl(event.currentTarget);
+  const onToggleThemeMenu = (event: MouseEvent<SVGSVGElement>) => {
+    setAnchorThemeEl(openTheme ? null : event.currentTarget);
+    setAnchorAccountEl(null);
+  };
+
+  const onToggleAccountMenu = (event: MouseEvent<SVGSVGElement>) => {
+    setAnchorThemeEl(null);
+    setAnchorAccountEl(openAccount ? null : event.currentTarget);
   };
 
   const onSelectTheme = (selectedTheme: UserTheme) => {
     localStorage.setItem("selectedTheme", selectedTheme);
     dispatchOperation({ type: OperationType.SetTheme, payload: selectedTheme });
-    setAnchorEl(null);
+    setAnchorThemeEl(null);
   };
 
   return (
     <>
       <Pointer>
-        <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleMenu(event)} size={24} color={colors.interactive.primaryResting} />
+        <Icon name="moreVertical" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleThemeMenu(event)} size={24} color={colors.interactive.primaryResting} />
       </Pointer>
-      <Menu id="ThemeMenu" anchorEl={anchorEl} open={open}>
-        <ThemeLabel key={"text"}>Display density:</ThemeLabel>
+      <Menu id="ThemeMenu" anchorEl={anchorThemeEl} open={openTheme}>
+        <ThemeLabel key={"text"}>Theme</ThemeLabel>
         <StyledMenuItem key={"comfortable"} onClick={() => onSelectTheme(UserTheme.Comfortable)}>
           <SelectTypography selected={theme === UserTheme.Comfortable}>Comfortable </SelectTypography>
           {theme === UserTheme.Comfortable && <Icon name="check" />}
@@ -47,6 +56,16 @@ const ThemeMenu = (): React.ReactElement => {
         <StyledMenuItem key={"compact"} onClick={() => onSelectTheme(UserTheme.Compact)}>
           <SelectTypography selected={theme === UserTheme.Compact}>Compact</SelectTypography>
           {theme === UserTheme.Compact && <Icon name="check" />}
+        </StyledMenuItem>
+      </Menu>
+      <Pointer>
+        <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
+      </Pointer>
+      <Menu id="ThemeMenu" anchorEl={anchorAccountEl} open={openAccount}>
+        <ThemeLabel key={"text"}>Account</ThemeLabel>
+        <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
+        <StyledMenuItem key={"signout"} onClick={() => signOut()}>
+          Logout
         </StyledMenuItem>
       </Menu>
     </>

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -8,7 +8,7 @@ import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
 import { colors } from "../styles/Colors";
 import Icon from "../styles/Icons";
 
-const ThemeMenu = (): React.ReactElement => {
+const TopRightCornerMenu = (): React.ReactElement => {
   const {
     operationState: { theme },
     dispatchOperation
@@ -59,18 +59,18 @@ const ThemeMenu = (): React.ReactElement => {
         </StyledMenuItem>
       </Menu>
       {msalEnabled && (
-        <Pointer>
-          <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
-        </Pointer>
-      )}
-      {msalEnabled && (
-        <Menu id="ThemeMenu" anchorEl={anchorAccountEl} open={openAccount}>
-          <ThemeLabel key={"text"}>Account</ThemeLabel>
-          <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
-          <StyledMenuItem key={"signout"} onClick={() => signOut()}>
-            Logout
-          </StyledMenuItem>
-        </Menu>
+        <>
+          <Pointer>
+            <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
+          </Pointer>
+          <Menu id="ThemeMenu" anchorEl={anchorAccountEl} open={openAccount}>
+            <ThemeLabel key={"text"}>Account</ThemeLabel>
+            <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
+            <StyledMenuItem key={"signout"} onClick={() => signOut()}>
+              Logout
+            </StyledMenuItem>
+          </Menu>
+        </>
       )}
     </>
   );
@@ -104,4 +104,4 @@ const Pointer = styled.div`
   cursor: pointer;
 `;
 
-export default ThemeMenu;
+export default TopRightCornerMenu;

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -48,7 +48,7 @@ const TopRightCornerMenu = (): React.ReactElement => {
         <Icon name="moreVertical" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleThemeMenu(event)} size={24} color={colors.interactive.primaryResting} />
       </Pointer>
       <Menu id="ThemeMenu" anchorEl={anchorThemeEl} open={openTheme}>
-        <ThemeLabel key={"text"}>Theme</ThemeLabel>
+        <MenuLabel key={"text"}>Theme</MenuLabel>
         <StyledMenuItem key={"comfortable"} onClick={() => onSelectTheme(UserTheme.Comfortable)}>
           <SelectTypography selected={theme === UserTheme.Comfortable}>Comfortable </SelectTypography>
           {theme === UserTheme.Comfortable && <Icon name="check" />}
@@ -63,8 +63,8 @@ const TopRightCornerMenu = (): React.ReactElement => {
           <Pointer>
             <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
           </Pointer>
-          <Menu id="ThemeMenu" anchorEl={anchorAccountEl} open={openAccount}>
-            <ThemeLabel key={"text"}>Account</ThemeLabel>
+          <Menu id="AccountMenu" anchorEl={anchorAccountEl} open={openAccount}>
+            <MenuLabel key={"text"}>Account</MenuLabel>
             <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
             <StyledMenuItem key={"signout"} onClick={() => signOut()}>
               Logout
@@ -94,7 +94,7 @@ const StyledMenuItem = styled(Menu.Item)`
   }
 `;
 
-const ThemeLabel = styled.p`
+const MenuLabel = styled.p`
   font-family: inherit;
   font-size: 0.75rem;
   margin: 0.5rem 1.5rem 0.5rem 1.5rem;

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -5,6 +5,8 @@ export const authRequest: RedirectRequest = {
   scopes: ["openid"]
 };
 
+export const msalEnabled = process.env.NEXT_PUBLIC_MSALENABLED;
+
 const msalConfig: Configuration = {
   auth: {
     authority: `https://login.microsoftonline.com/${process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID}`,

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -1,0 +1,74 @@
+import { AccountInfo, Configuration, InteractionRequiredAuthError, PublicClientApplication, RedirectRequest, SilentRequest } from "@azure/msal-browser";
+import { AuthenticationResult } from "@azure/msal-common";
+
+export const authRequest: RedirectRequest = {
+  scopes: ["openid"]
+};
+
+const msalConfig: Configuration = {
+  auth: {
+    authority: `https://login.microsoftonline.com/${process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID}`,
+    clientId: process.env.NEXT_PUBLIC_AZURE_AD_CLIENT_ID,
+    redirectUri: `${process.env.NEXT_PUBLIC_AZURE_AD_URL_WITSMLEXPLORER}`
+  },
+  cache: {
+    cacheLocation: "sessionStorage",
+    storeAuthStateInCookie: false
+  }
+};
+
+export const msalInstance: PublicClientApplication = new PublicClientApplication(msalConfig);
+
+export async function getAccessToken(scopes: string[]): Promise<string | null> {
+  const accounts = msalInstance.getAllAccounts();
+  let accessToken = null;
+
+  if (accounts.length > 0) {
+    const request: SilentRequest & RedirectRequest = {
+      scopes: scopes,
+      account: accounts[0]
+    };
+
+    await msalInstance
+      .acquireTokenSilent(request)
+      .then((response: AuthenticationResult) => {
+        accessToken = response.accessToken;
+      })
+      .catch((error) => {
+        // acquireTokenSilent can fail for a number of reasons, fallback to interaction
+        if (error instanceof InteractionRequiredAuthError) {
+          msalInstance.acquireTokenRedirect(request);
+        }
+      });
+  }
+  return accessToken;
+}
+
+export const getAccountInfo = (): AccountInfo | null => {
+  let activeAccount = null;
+  const allAccounts = msalInstance.getAllAccounts();
+
+  if (allAccounts.length < 1) {
+    return null;
+  } else if (allAccounts.length > 1) {
+    activeAccount = msalInstance.getActiveAccount();
+  } else if (allAccounts.length === 1) {
+    activeAccount = allAccounts[0];
+  }
+  return activeAccount;
+};
+
+export async function signOut(): Promise<void> {
+  type TokenClaims = {
+    login_hint: string;
+  };
+  const activeAccount = getAccountInfo();
+  if (!activeAccount) return;
+
+  const logoutRequest = {
+    account: activeAccount,
+    logoutHint: activeAccount ? (activeAccount.idTokenClaims as TokenClaims).login_hint : undefined
+  };
+
+  msalInstance.logoutRedirect(logoutRequest);
+}

--- a/Src/WitsmlExplorer.Frontend/package.json
+++ b/Src/WitsmlExplorer.Frontend/package.json
@@ -30,6 +30,8 @@
     ]
   },
   "dependencies": {
+    "@azure/msal-browser": "^2.28.1",
+    "@azure/msal-react": "^1.4.5",
     "@date-io/moment": "^1.3.13",
     "@equinor/eds-core-react": "^0.20.4",
     "@equinor/eds-tokens": "^0.7.1",

--- a/Src/WitsmlExplorer.Frontend/pages/index.tsx
+++ b/Src/WitsmlExplorer.Frontend/pages/index.tsx
@@ -1,28 +1,41 @@
-import React, { useRef, useState } from "react";
-import Head from "next/head";
-import Nav from "../components/Nav";
-import Sidebar from "../components/Sidebar/Sidebar";
-import ContentView from "../components/ContentView";
-import styled from "styled-components";
-import GlobalStyles from "../components/GlobalStyles";
-import { getTheme } from "../styles/material-eds";
-import { ThemeProvider } from "@material-ui/core";
-import ModalPresenter from "../components/Modals/ModalPresenter";
-import ContextMenuPresenter from "../components/ContextMenus/ContextMenuPresenter";
+import { AuthenticatedTemplate, MsalProvider, UnauthenticatedTemplate, useMsal } from "@azure/msal-react";
 import MomentUtils from "@date-io/moment";
+import { ThemeProvider } from "@material-ui/core";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
-import NavigationContext from "../contexts/navigationContext";
-import OperationContext from "../contexts/operationContext";
-import { initNavigationStateReducer } from "../contexts/navigationStateReducer";
-import { initOperationStateReducer } from "../contexts/operationStateReducer";
+import Head from "next/head";
 import { SnackbarProvider } from "notistack";
-import Snackbar from "../components/Snackbar";
+import React, { useRef, useState } from "react";
+import styled from "styled-components";
 import Alerts from "../components/Alerts";
-import { preventContextMenuPropagation } from "../components/ContextMenus/ContextMenu";
-import RefreshHandler from "../components/RefreshHandler";
-import { colors } from "../styles/Colors";
-import Routing from "../components/Routing";
 import { AssetsLoader } from "../components/AssetsLoader";
+import ContentView from "../components/ContentView";
+import { preventContextMenuPropagation } from "../components/ContextMenus/ContextMenu";
+import ContextMenuPresenter from "../components/ContextMenus/ContextMenuPresenter";
+import GlobalStyles from "../components/GlobalStyles";
+import ModalPresenter from "../components/Modals/ModalPresenter";
+import Nav from "../components/Nav";
+import RefreshHandler from "../components/RefreshHandler";
+import Routing from "../components/Routing";
+import Sidebar from "../components/Sidebar/Sidebar";
+import Snackbar from "../components/Snackbar";
+import NavigationContext from "../contexts/navigationContext";
+import { initNavigationStateReducer } from "../contexts/navigationStateReducer";
+import OperationContext from "../contexts/operationContext";
+import { initOperationStateReducer } from "../contexts/operationStateReducer";
+import { msalInstance } from "../msal/MsalAuthProvider";
+import { colors } from "../styles/Colors";
+import { getTheme } from "../styles/material-eds";
+
+function SignInButton() {
+  const { instance } = useMsal();
+  return <button onClick={() => instance.loginRedirect()}>Sign In</button>;
+}
+
+function WelcomeUser() {
+  const { accounts } = useMsal();
+  const username = accounts[0].username;
+  return <p>Welcome, {username}</p>;
+}
 
 const Home = (): React.ReactElement => {
   const [operationState, dispatchOperation] = initOperationStateReducer();
@@ -61,39 +74,48 @@ const Home = (): React.ReactElement => {
   }, [resize, stopResizing]);
 
   return (
-    <MuiPickersUtilsProvider utils={MomentUtils}>
-      <OperationContext.Provider value={{ operationState, dispatchOperation }}>
-        <ThemeProvider theme={getTheme(operationState.theme)}>
-          <GlobalStyles />
-          <Head>
-            <title>WITSML Explorer</title>
-            <link rel="icon" href={AssetsLoader.getAssetsRoot() + "/favicon.ico"} />
-          </Head>
-          <NavigationContext.Provider value={{ navigationState, dispatchNavigation }}>
-            <Routing />
-            <RefreshHandler />
-            <SnackbarProvider>
-              <Snackbar />
-            </SnackbarProvider>
-            <Layout onContextMenu={preventContextMenuPropagation}>
-              <NavLayout>
-                <Nav />
-              </NavLayout>
-              <SidebarLayout ref={sidebarRef} style={{ width: sidebarWidth }}>
-                <Sidebar />
-              </SidebarLayout>
-              <Divider onMouseDown={startResizing} />
-              <ContentViewLayout>
-                <Alerts />
-                <ContentView />
-              </ContentViewLayout>
-            </Layout>
-          </NavigationContext.Provider>
-          <ContextMenuPresenter />
-          <ModalPresenter />
-        </ThemeProvider>
-      </OperationContext.Provider>
-    </MuiPickersUtilsProvider>
+    <MsalProvider instance={msalInstance}>
+      <MuiPickersUtilsProvider utils={MomentUtils}>
+        <OperationContext.Provider value={{ operationState, dispatchOperation }}>
+          <ThemeProvider theme={getTheme(operationState.theme)}>
+            <GlobalStyles />
+            <Head>
+              <title>WITSML Explorer</title>
+              <link rel="icon" href={AssetsLoader.getAssetsRoot() + "/favicon.ico"} />
+            </Head>
+            <NavigationContext.Provider value={{ navigationState, dispatchNavigation }}>
+              <Routing />
+              <RefreshHandler />
+              <SnackbarProvider>
+                <Snackbar />
+              </SnackbarProvider>
+              <Layout onContextMenu={preventContextMenuPropagation}>
+                <NavLayout>
+                  <Nav />
+                </NavLayout>
+                <SidebarLayout ref={sidebarRef} style={{ width: sidebarWidth }}>
+                  <Sidebar />
+                </SidebarLayout>
+                <Divider onMouseDown={startResizing} />
+                <ContentViewLayout>
+                  <AuthenticatedTemplate>
+                    <WelcomeUser />
+                  </AuthenticatedTemplate>
+                  <UnauthenticatedTemplate>
+                    <p>This will only render if a user is not signed-in.</p>
+                    <SignInButton />
+                  </UnauthenticatedTemplate>
+                  <Alerts />
+                  <ContentView />
+                </ContentViewLayout>
+              </Layout>
+            </NavigationContext.Provider>
+            <ContextMenuPresenter />
+            <ModalPresenter />
+          </ThemeProvider>
+        </OperationContext.Provider>
+      </MuiPickersUtilsProvider>
+    </MsalProvider>
   );
 };
 
@@ -129,7 +151,6 @@ const Divider = styled.div`
   margin-right: 0.6rem;
   background: ${colors.interactive.primaryResting};
   border-radius: 0px 5px 5px 0px;
-
   &:hover {
     background: ${colors.interactive.primaryHover};
     width: 0.6rem;
@@ -141,6 +162,7 @@ const ContentViewLayout = styled.div`
   grid-area: content;
   overflow-y: auto;
   overflow-x: auto;
+  word-wrap: wrap;
   height: 93vh;
   width: 100vw;
 `;

--- a/Src/WitsmlExplorer.Frontend/pages/index.tsx
+++ b/Src/WitsmlExplorer.Frontend/pages/index.tsx
@@ -1,4 +1,5 @@
-import { AuthenticatedTemplate, MsalProvider, UnauthenticatedTemplate, useMsal } from "@azure/msal-react";
+import { InteractionType } from "@azure/msal-browser";
+import { MsalAuthenticationTemplate, MsalProvider } from "@azure/msal-react";
 import MomentUtils from "@date-io/moment";
 import { ThemeProvider } from "@material-ui/core";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
@@ -22,20 +23,9 @@ import NavigationContext from "../contexts/navigationContext";
 import { initNavigationStateReducer } from "../contexts/navigationStateReducer";
 import OperationContext from "../contexts/operationContext";
 import { initOperationStateReducer } from "../contexts/operationStateReducer";
-import { msalInstance } from "../msal/MsalAuthProvider";
+import { authRequest, msalEnabled, msalInstance } from "../msal/MsalAuthProvider";
 import { colors } from "../styles/Colors";
 import { getTheme } from "../styles/material-eds";
-
-function SignInButton() {
-  const { instance } = useMsal();
-  return <button onClick={() => instance.loginRedirect()}>Sign In</button>;
-}
-
-function WelcomeUser() {
-  const { accounts } = useMsal();
-  const username = accounts[0].username;
-  return <p>Welcome, {username}</p>;
-}
 
 const Home = (): React.ReactElement => {
   const [operationState, dispatchOperation] = initOperationStateReducer();
@@ -75,6 +65,7 @@ const Home = (): React.ReactElement => {
 
   return (
     <MsalProvider instance={msalInstance}>
+      {msalEnabled && <MsalAuthenticationTemplate interactionType={InteractionType.Redirect} authenticationRequest={authRequest} />}
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <OperationContext.Provider value={{ operationState, dispatchOperation }}>
           <ThemeProvider theme={getTheme(operationState.theme)}>
@@ -98,13 +89,6 @@ const Home = (): React.ReactElement => {
                 </SidebarLayout>
                 <Divider onMouseDown={startResizing} />
                 <ContentViewLayout>
-                  <AuthenticatedTemplate>
-                    <WelcomeUser />
-                  </AuthenticatedTemplate>
-                  <UnauthenticatedTemplate>
-                    <p>This will only render if a user is not signed-in.</p>
-                    <SignInButton />
-                  </UnauthenticatedTemplate>
                   <Alerts />
                   <ContentView />
                 </ContentViewLayout>

--- a/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
+++ b/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
@@ -1,20 +1,21 @@
 import { Icon } from "@equinor/eds-core-react";
 import {
-  chevron_right as chevronRight,
-  chevron_down as chevronDown,
-  trending_up as isActive,
-  launch,
-  format_line_spacing as formatLine,
-  refresh,
-  paste,
-  add,
-  settings,
   accessible,
+  add,
   check,
+  chevron_down as chevronDown,
+  chevron_right as chevronRight,
   copy,
-  edit,
   delete_to_trash as deleteToTrash,
-  folder_open as folderOpen
+  edit,
+  folder_open as folderOpen,
+  format_line_spacing as formatLine,
+  launch,
+  more_vertical as moreVertical,
+  paste,
+  refresh,
+  settings,
+  trending_up as isActive
 } from "@equinor/eds-icons";
 const icons = {
   chevronRight,
@@ -31,7 +32,8 @@ const icons = {
   copy,
   edit,
   folderOpen,
-  deleteToTrash
+  deleteToTrash,
+  moreVertical
 };
 
 Icon.add(icons);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,23 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
+"@azure/msal-browser@^2.28.1":
+  version "2.28.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-2.28.1.tgz#68432ba789f1d2e7a67a38743fbbbb3fbbc5430b"
+  integrity sha512-5uAfwpNGBSRzBGTSS+5l4Zw6msPV7bEmq99n0U3n/N++iTcha+nIp1QujxTPuOLHmTNCeySdMx9qzGqWuy22zQ==
+  dependencies:
+    "@azure/msal-common" "^7.3.0"
+
+"@azure/msal-common@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-7.3.0.tgz#63778ca00a41e3160842b0ee2134cfa92b524820"
+  integrity sha512-revxB3z+QLjwAtU1d04nC1voFr+i3LfqTpUfgrWZVqKh/sSgg0mZZUvw4vKVWB57qtL95sul06G+TfdFZny1Xw==
+
+"@azure/msal-react@^1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@azure/msal-react/-/msal-react-1.4.5.tgz#b99abd425af9c253acd2cd06fc08b671c5c7e3ad"
+  integrity sha512-nvg9OQDiSFX+DGoyxnctbv1MwCZrln2svUjwO9zFWOB1KdmLclgrsA9/G1krbbupRO5WFBF6u/VzidHO4V2WEQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"


### PR DESCRIPTION
## Fixes
This pull request fixes `WE-353`

## Description
Adding MSAL to witsml-explorer.

The following environment variables need to be set:
```sh
NEXT_PUBLIC_AZURE_AD_TENANT_ID=<tenant>
NEXT_PUBLIC_AZURE_AD_CLIENT_ID=<client_id>
NEXT_PUBLIC_AZURE_AD_URL_WITSMLEXPLORER=http://localhost:3000/
NEXT_PUBLIC_MSALENABLED=<OAuth2Enabled>
```

Should only be used if `OAuth2Enabled` in `appsettings.json`. Setting OAuth2Enabled=false in backend and leaving NEXT_PUBLIC_MSALENABLED empty in frontend will bypass


## Type of change
* Enhancement of existing functionality
* This change requires a documentation update

## Impacted Areas in Application
Frontend

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
...