### PR TITLE
WE-533 Filter unnecessary logs in development

### DIFF
--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="NetCore.AutoRegisterDi" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/Src/WitsmlExplorer.Api/appsettings.Development.json
+++ b/Src/WitsmlExplorer.Api/appsettings.Development.json
@@ -15,7 +15,7 @@
       {
         "Name": "ByExcluding",
         "Args": {
-          "expression": "SourceContext = 'Microsoft.AspNetCore.Http.Result.OkObjectResult' or SourceContext = 'Microsoft.AspNetCore.Cors.Infrastructure.CorsService' or SourceContext = 'Microsoft.AspNetCore.Routing.EndpointMiddleware'"
+          "expression": "SourceContext = 'Microsoft.AspNetCore.Http.Result.OkObjectResult' or SourceContext = 'Microsoft.AspNetCore.Routing.EndpointMiddleware'"
         }
       }
     ],

--- a/Src/WitsmlExplorer.Api/appsettings.Development.json
+++ b/Src/WitsmlExplorer.Api/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "Serilog": {
+    "Using": ["Serilog.Expressions"],
     "MinimumLevel": {
       "Default": "Debug",
       "Override": {
@@ -9,6 +10,14 @@
     },
     "WriteTo": [
       { "Name": "Console", "Args": {"theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"} }
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "SourceContext = 'Microsoft.AspNetCore.Http.Result.OkObjectResult' or SourceContext = 'Microsoft.AspNetCore.Cors.Infrastructure.CorsService' or SourceContext = 'Microsoft.AspNetCore.Routing.EndpointMiddleware'"
+        }
+      }
     ],
     "Enrich": ["FromLogContext"]
   },


### PR DESCRIPTION
## Fixes
This pull request fixes WE-533

## Description
Use Serilog.Expressions to filter out logs in development such as:
"Writing value of type '..."
"Executed endpoint 'HTTP GET..."
Logs such as "Request finished HTTP/1.1 GET..." remain to give relatively same amount of useful information as before, but with less bloat. These can be overridden in mysettings.json.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
