### PR TITLE
WE-516 Implement copy trajectory stations

### DIFF
--- a/Src/WitsmlExplorer.Api/Jobs/CopyJobs.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyJobs.cs
@@ -7,6 +7,7 @@ namespace WitsmlExplorer.Api.Jobs
     public record CopyLogJob : ICopyJob<LogReferences, WellboreReference> { }
     public record CopyRigJob : ICopyJob<RigReferences, WellboreReference> { }
     public record CopyRiskJob : ICopyJob<RiskReferences, WellboreReference> { }
+    public record CopyTrajectoryStationsJob : ICopyJob<TrajectoryStationReferences, TrajectoryReference> { }
     public record CopyTrajectoryJob : ICopyJob<TrajectoryReference, WellboreReference> { }
     public record CopyTubularComponentsJob : ICopyJob<TubularComponentReferences, TubularReference> { }
     public record CopyTubularJob : ICopyJob<TubularReferences, WellboreReference> { }

--- a/Src/WitsmlExplorer.Api/Models/JobType.cs
+++ b/Src/WitsmlExplorer.Api/Models/JobType.cs
@@ -8,6 +8,7 @@ namespace WitsmlExplorer.Api.Models
         CopyRig,
         CopyRisk,
         CopyTrajectory,
+        CopyTrajectoryStations,
         CopyTubular,
         CopyTubularComponents,
         ModifyBhaRun,

--- a/Src/WitsmlExplorer.Api/Query/TrajectoryQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/TrajectoryQueries.cs
@@ -56,7 +56,14 @@ namespace WitsmlExplorer.Api.Query
             trajectory.CustomData ??= new WitsmlCustomData();
             trajectory.CommonData.ItemState = string.IsNullOrEmpty(trajectory.CommonData.ItemState) ? null : trajectory.CommonData.ItemState;
             trajectory.CommonData.SourceName = string.IsNullOrEmpty(trajectory.CommonData.SourceName) ? null : trajectory.CommonData.SourceName;
-            var copyTrajectoryQuery = new WitsmlTrajectories { Trajectories = new List<WitsmlTrajectory> { trajectory } };
+            WitsmlTrajectories copyTrajectoryQuery = new() { Trajectories = new List<WitsmlTrajectory> { trajectory } };
+            return copyTrajectoryQuery;
+        }
+
+        public static WitsmlTrajectories CopyTrajectoryStations(WitsmlTrajectory trajectory, IEnumerable<WitsmlTrajectoryStation> trajectoryStations)
+        {
+            trajectory.TrajectoryStations.AddRange(trajectoryStations);
+            WitsmlTrajectories copyTrajectoryQuery = new() { Trajectories = new List<WitsmlTrajectory> { trajectory } };
             return copyTrajectoryQuery;
         }
 
@@ -78,7 +85,7 @@ namespace WitsmlExplorer.Api.Query
         }
         public static WitsmlTrajectories UpdateTrajectoryStation(TrajectoryStation trajectoryStation, TrajectoryReference trajectoryReference)
         {
-            var ts = new WitsmlTrajectoryStation
+            WitsmlTrajectoryStation ts = new()
             {
                 Uid = trajectoryStation.Uid,
                 Md = new WitsmlMeasuredDepthCoord { Uom = trajectoryStation.Md.Uom, Value = trajectoryStation.Md.Value.ToString(CultureInfo.InvariantCulture) },
@@ -86,16 +93,25 @@ namespace WitsmlExplorer.Api.Query
             };
 
             if (!trajectoryStation.Tvd.Equals(null))
+            {
                 ts.Tvd = new WitsmlWellVerticalDepthCoord { Uom = trajectoryStation.Tvd.Uom, Value = trajectoryStation.Tvd.Value.ToString(CultureInfo.InvariantCulture) };
+            }
 
             if (!trajectoryStation.Incl.Equals(null))
+            {
                 ts.Incl = new WitsmlPlaneAngleMeasure { Uom = trajectoryStation.Incl.Uom, Value = trajectoryStation.Incl.Value.ToString(CultureInfo.InvariantCulture) };
+            }
 
             if (!trajectoryStation.Azi.Equals(null))
+            {
                 ts.Azi = new WitsmlPlaneAngleMeasure { Uom = trajectoryStation.Azi.Uom, Value = trajectoryStation.Azi.Value.ToString(CultureInfo.InvariantCulture) };
+            }
 
             if (trajectoryStation.DTimStn != null)
+            {
                 ts.DTimStn = ((DateTime)trajectoryStation.DTimStn).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ");
+            }
+
             return new WitsmlTrajectories
             {
                 Trajectories = new WitsmlTrajectory

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Witsml;
+using Witsml.Data;
+using Witsml.ServiceReference;
+
+using WitsmlExplorer.Api.Jobs;
+using WitsmlExplorer.Api.Jobs.Common;
+using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Query;
+using WitsmlExplorer.Api.Services;
+
+namespace WitsmlExplorer.Api.Workers.Copy
+{
+    public class CopyTrajectoryStationsWorker : BaseWorker<CopyTrajectoryStationsJob>, IWorker
+    {
+        private readonly IWitsmlClient _witsmlClient;
+        private readonly IWitsmlClient _witsmlSourceClient;
+        public JobType JobType => JobType.CopyTrajectoryStations;
+
+        public CopyTrajectoryStationsWorker(ILogger<CopyTrajectoryStationsJob> logger, IWitsmlClientProvider witsmlClientProvider) : base(logger)
+        {
+            _witsmlClient = witsmlClientProvider.GetClient();
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+        }
+
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CopyTrajectoryStationsJob job)
+        {
+            (WitsmlTrajectory targetTrajectory, IEnumerable<WitsmlTrajectoryStation> stationsToCopy) = await FetchData(job);
+            if (stationsToCopy.Count() != job.Source.TrajectoryStationUids.Count())
+            {
+                string errorMessage = "Failed to copy trajectory stations.";
+                string missingUids = string.Join(", ", stationsToCopy.Select((ts) => ts.Uid).Where((uid) => !job.Source.TrajectoryStationUids.Contains(uid)));
+                string reason = $"Could not retrieve all trajectory stations, missing uids: {missingUids}.";
+                Logger.LogError("{errorMessage} {reason} - {description}", errorMessage, reason, job.Description());
+                return (new WorkerResult(_witsmlClient.GetServerHostname(), false, errorMessage, reason), null);
+            }
+            WitsmlTrajectories updatedTrajectoryQuery = TrajectoryQueries.CopyTrajectoryStations(targetTrajectory, stationsToCopy);
+            QueryResult copyResult = await _witsmlClient.UpdateInStoreAsync(updatedTrajectoryQuery);
+            string trajectoryStationsString = string.Join(", ", job.Source.TrajectoryStationUids);
+            if (!copyResult.IsSuccessful)
+            {
+                string errorMessage = "Failed to copy trajectory stations.";
+                Logger.LogError("{errorMessage} {reason} - {description}", errorMessage, copyResult.Reason, job.Description());
+                return (new WorkerResult(_witsmlClient.GetServerHostname(), false, errorMessage, copyResult.Reason), null);
+            }
+
+            Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
+            RefreshTrajectory refreshAction = new(_witsmlClient.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.TrajectoryUid, RefreshType.Update);
+            WorkerResult workerResult = new(_witsmlClient.GetServerHostname(), true, $"TrajectoryStations {trajectoryStationsString} copied to: {targetTrajectory.Name}");
+
+            return (workerResult, refreshAction);
+        }
+
+        private async Task<Tuple<WitsmlTrajectory, IEnumerable<WitsmlTrajectoryStation>>> FetchData(CopyTrajectoryStationsJob job)
+        {
+            Task<WitsmlTrajectory> targetTrajectoryQuery = GetTrajectory(_witsmlClient, job.Target);
+            Task<IEnumerable<WitsmlTrajectoryStation>> sourceTrajectoryStationsQuery = GetTrajectoryStations(_witsmlSourceClient, job.Source.TrajectoryReference, job.Source.TrajectoryStationUids);
+            await Task.WhenAll(targetTrajectoryQuery, sourceTrajectoryStationsQuery);
+            WitsmlTrajectory targetTrajectory = targetTrajectoryQuery.Result;
+            IEnumerable<WitsmlTrajectoryStation> sourceTrajectoryStations = sourceTrajectoryStationsQuery.Result;
+            return Tuple.Create(targetTrajectory, sourceTrajectoryStations);
+        }
+
+        private static async Task<WitsmlTrajectory> GetTrajectory(IWitsmlClient client, TrajectoryReference trajectoryReference)
+        {
+            WitsmlTrajectories witsmlTrajectory = TrajectoryQueries.GetWitsmlTrajectoryById(trajectoryReference.WellUid, trajectoryReference.WellboreUid, trajectoryReference.TrajectoryUid);
+            WitsmlTrajectories result = await client.GetFromStoreAsync(witsmlTrajectory, new OptionsIn(ReturnElements.All));
+            return !result.Trajectories.Any() ? null : result.Trajectories.First();
+        }
+
+        private static async Task<IEnumerable<WitsmlTrajectoryStation>> GetTrajectoryStations(IWitsmlClient client, TrajectoryReference trajectoryReference, IEnumerable<string> trajectoryStationsUids)
+        {
+            WitsmlTrajectory witsmlTrajectory = await GetTrajectory(client, trajectoryReference);
+            return witsmlTrajectory?.TrajectoryStations.FindAll((WitsmlTrajectoryStation tc) => trajectoryStationsUids.Contains(tc.Uid));
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
@@ -62,8 +62,8 @@ namespace WitsmlExplorer.Api.Workers.Copy
             Task<WitsmlTrajectory> targetTrajectoryQuery = GetTrajectory(_witsmlClient, job.Target);
             Task<IEnumerable<WitsmlTrajectoryStation>> sourceTrajectoryStationsQuery = GetTrajectoryStations(_witsmlSourceClient, job.Source.TrajectoryReference, job.Source.TrajectoryStationUids);
             await Task.WhenAll(targetTrajectoryQuery, sourceTrajectoryStationsQuery);
-            WitsmlTrajectory targetTrajectory = targetTrajectoryQuery.Result;
-            IEnumerable<WitsmlTrajectoryStation> sourceTrajectoryStations = sourceTrajectoryStationsQuery.Result;
+            WitsmlTrajectory targetTrajectory = await targetTrajectoryQuery;
+            IEnumerable<WitsmlTrajectoryStation> sourceTrajectoryStations = await sourceTrajectoryStationsQuery;
             return Tuple.Create(targetTrajectory, sourceTrajectoryStations);
         }
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
@@ -1,16 +1,16 @@
 import React, { useContext, useEffect, useState } from "react";
-import { ContentTable, ContentTableColumn, ContentType } from "./table";
-import Trajectory from "../../models/trajectory";
 import NavigationContext from "../../contexts/navigationContext";
 import NavigationType from "../../contexts/navigationType";
-import TrajectoryContextMenu, { TrajectoryContextMenuProps } from "../ContextMenus/TrajectoryContextMenu";
-import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
-import OperationType from "../../contexts/operationType";
 import OperationContext from "../../contexts/operationContext";
+import OperationType from "../../contexts/operationType";
+import Trajectory from "../../models/trajectory";
+import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
+import TrajectoryContextMenu, { TrajectoryContextMenuProps } from "../ContextMenus/TrajectoryContextMenu";
+import { ContentTable, ContentTableColumn, ContentType } from "./table";
 
 export const TrajectoriesListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { selectedServer, selectedWell, selectedWellbore, selectedTrajectoryGroup } = navigationState;
+  const { selectedServer, selectedWell, selectedWellbore, selectedTrajectoryGroup, servers } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [trajectories, setTrajectories] = useState<Trajectory[]>([]);
 
@@ -21,7 +21,7 @@ export const TrajectoriesListView = (): React.ReactElement => {
   }, [selectedWellbore?.trajectories]);
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, trajectory: Trajectory) => {
-    const contextProps: TrajectoryContextMenuProps = { dispatchNavigation, dispatchOperation, selectedServer, trajectory };
+    const contextProps: TrajectoryContextMenuProps = { dispatchNavigation, dispatchOperation, selectedServer, trajectory, servers };
     const position = getContextMenuPosition(event);
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <TrajectoryContextMenu {...contextProps} />, position } });
   };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -1,8 +1,16 @@
-import Icon from "../../styles/Icons";
 import styled from "styled-components";
+import Icon from "../../styles/Icons";
 
 export const StyledIcon = styled(Icon)`
   && {
     margin-right: 5px;
   }
 `;
+
+export const menuItemText = (operation: string, object: string, array: any[] | null) => {
+  const operationUpperCase = operation.charAt(0).toUpperCase() + operation.slice(1);
+  const objectPlural = object.charAt(object.length - 1) == "y" ? object.slice(0, object.length - 2) + "ies" : object + "s";
+  const isPlural = array ? array.length > 1 : false;
+  const count = array && array.length > 0 ? ` ${array.length} ` : " ";
+  return `${operationUpperCase}${count}${isPlural ? objectPlural : object}`;
+};

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -11,6 +11,6 @@ export const menuItemText = (operation: string, object: string, array: any[] | n
   const operationUpperCase = operation.charAt(0).toUpperCase() + operation.slice(1);
   const objectPlural = object.charAt(object.length - 1) == "y" ? object.slice(0, object.length - 2) + "ies" : object + "s";
   const isPlural = array ? array.length > 1 : false;
-  const count = array && array.length > 0 ? ` ${array.length} ` : " ";
+  const count = array?.length > 0 ? ` ${array.length} ` : " ";
   return `${operationUpperCase}${count}${isPlural ? objectPlural : object}`;
 };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
@@ -1,7 +1,7 @@
 import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
-import CredentialsService, { ServerCredentials } from "../../services/credentialsService";
+import CredentialsService, { BasicServerCredentials } from "../../services/credentialsService";
 import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
 
 type DispatchOperation = (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
@@ -20,7 +20,7 @@ export const onClickPaste = async (servers: Server[], serverUrl: string, dispatc
 };
 
 const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, orderCopyJob: () => void) => {
-  const onConnectionVerified = async (credentials: ServerCredentials) => {
+  const onConnectionVerified = async (credentials: BasicServerCredentials) => {
     CredentialsService.saveCredentials(credentials);
     orderCopyJob();
     dispatchOperation({ type: OperationType.HideModal });

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
@@ -1,0 +1,39 @@
+import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
+import OperationType from "../../contexts/operationType";
+import { Server } from "../../models/server";
+import CredentialsService, { ServerCredentials } from "../../services/credentialsService";
+import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
+
+type DispatchOperation = (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
+
+export const onClickPaste = async (servers: Server[], serverUrl: string, dispatchOperation: DispatchOperation, orderCopyJob: () => void) => {
+  const sourceServer = servers.find((server) => server.url === serverUrl);
+  if (sourceServer !== null) {
+    CredentialsService.setSourceServer(sourceServer);
+    const hasPassword = CredentialsService.hasPasswordForServer(sourceServer);
+    if (!hasPassword) {
+      showCredentialsModal(sourceServer, dispatchOperation, () => orderCopyJob());
+    } else {
+      orderCopyJob();
+    }
+  }
+};
+
+const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, orderCopyJob: () => void) => {
+  const onConnectionVerified = async (credentials: ServerCredentials) => {
+    await CredentialsService.saveCredentials(credentials);
+    orderCopyJob();
+    dispatchOperation({ type: OperationType.HideModal });
+  };
+
+  const currentCredentials = CredentialsService.getSourceServerCredentials();
+  const userCredentialsModalProps: UserCredentialsModalProps = {
+    server: server,
+    serverCredentials: currentCredentials,
+    mode: CredentialsMode.TEST,
+    errorMessage: `You are trying to paste an object from a server that you are not logged in to. Please provide username and password for ${server.name}.`,
+    onConnectionVerified,
+    confirmText: "Save"
+  };
+  dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });
+};

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
@@ -21,7 +21,7 @@ export const onClickPaste = async (servers: Server[], serverUrl: string, dispatc
 
 const showCredentialsModal = (server: Server, dispatchOperation: DispatchOperation, orderCopyJob: () => void) => {
   const onConnectionVerified = async (credentials: ServerCredentials) => {
-    await CredentialsService.saveCredentials(credentials);
+    CredentialsService.saveCredentials(credentials);
     orderCopyJob();
     dispatchOperation({ type: OperationType.HideModal });
   };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
@@ -1,7 +1,6 @@
 ﻿import { Typography } from "@equinor/eds-core-react";
 import { Divider, ListItemIcon, MenuItem } from "@material-ui/core";
 import React from "react";
-import styled from "styled-components";
 import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { DeleteRigsJob } from "../../models/jobs/deleteJobs";
@@ -9,12 +8,12 @@ import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
 import JobService, { JobType } from "../../services/jobService";
 import { colors } from "../../styles/Colors";
-import Icon from "../../styles/Icons";
 import { RigRow } from "../ContentViews/RigsListView";
 import ConfirmModal from "../Modals/ConfirmModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import RigPropertiesModal, { RigPropertiesModalProps } from "../Modals/RigPropertiesModal";
 import ContextMenu from "./ContextMenu";
+import { StyledIcon } from "./ContextMenuUtils";
 import { onClickCopy, onClickPaste, useClipboardRigReferences } from "./RigContextMenuUtils";
 
 export interface RigContextMenuProps {
@@ -93,10 +92,5 @@ const RigContextMenu = (props: RigContextMenuProps): React.ReactElement => {
     />
   );
 };
-const StyledIcon = styled(Icon)`
-  && {
-    margin-right: 5px;
-  }
-`;
 
 export default RigContextMenu;

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
@@ -1,30 +1,34 @@
+import { Typography } from "@equinor/eds-core-react";
+import { MenuItem } from "@material-ui/core";
 import React from "react";
-import ContextMenu from "./ContextMenu";
-import { ListItemIcon, MenuItem } from "@material-ui/core";
-import OperationType from "../../contexts/operationType";
-import Trajectory from "../../models/trajectory";
-import ConfirmModal from "../Modals/ConfirmModal";
-import JobService, { JobType } from "../../services/jobService";
-import TrajectoryService from "../../services/trajectoryService";
-import Icon from "../../styles/Icons";
-import { colors } from "../../styles/Colors";
 import ModificationType from "../../contexts/modificationType";
 import { UpdateWellboreTrajectoriesAction } from "../../contexts/navigationStateReducer";
 import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
+import OperationType from "../../contexts/operationType";
+import { DeleteTrajectoryJob } from "../../models/jobs/deleteJobs";
 import TrajectoryReference from "../../models/jobs/trajectoryReference";
 import { Server } from "../../models/server";
-import { Typography } from "@equinor/eds-core-react";
-import { DeleteTrajectoryJob } from "../../models/jobs/deleteJobs";
+import Trajectory from "../../models/trajectory";
+import JobService, { JobType } from "../../services/jobService";
+import TrajectoryService from "../../services/trajectoryService";
+import { colors } from "../../styles/Colors";
+import ConfirmModal from "../Modals/ConfirmModal";
+import ContextMenu from "./ContextMenu";
+import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { onClickPaste } from "./CopyUtils";
+import { orderCopyJob, useClipboardTrajectoryStationReferences } from "./TrajectoryStationContextMenuUtils";
 
 export interface TrajectoryContextMenuProps {
   dispatchNavigation: (action: UpdateWellboreTrajectoriesAction) => void;
   dispatchOperation: (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
   trajectory: Trajectory;
   selectedServer: Server;
+  servers: Server[];
 }
 
 const TrajectoryContextMenu = (props: TrajectoryContextMenuProps): React.ReactElement => {
-  const { dispatchNavigation, dispatchOperation, trajectory, selectedServer } = props;
+  const { dispatchNavigation, dispatchOperation, trajectory, selectedServer, servers } = props;
+  const [trajectoryStationReferences] = useClipboardTrajectoryStationReferences();
 
   const deleteTrajectory = async () => {
     dispatchOperation({ type: OperationType.HideModal });
@@ -76,19 +80,21 @@ const TrajectoryContextMenu = (props: TrajectoryContextMenuProps): React.ReactEl
     dispatchOperation({ type: OperationType.DisplayModal, payload: confirmation });
   };
 
+  const serverUrl = trajectoryStationReferences?.serverUrl;
+  const orderCopy = () => orderCopyJob(trajectory, trajectoryStationReferences, dispatchOperation);
   return (
     <ContextMenu
       menuItems={[
         <MenuItem key={"copy"} onClick={onClickCopy}>
-          <ListItemIcon>
-            <Icon name="copy" color={colors.interactive.primaryResting} />
-          </ListItemIcon>
+          <StyledIcon name="copy" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Copy</Typography>
         </MenuItem>,
+        <MenuItem key={"paste"} onClick={() => onClickPaste(servers, serverUrl, dispatchOperation, orderCopy)} disabled={trajectoryStationReferences === null}>
+          <StyledIcon name="paste" color={colors.interactive.primaryResting} />
+          <Typography color={"primary"}>{menuItemText("paste", "trajectory station", trajectoryStationReferences?.trajectoryStationUids)}</Typography>
+        </MenuItem>,
         <MenuItem key={"delete"} onClick={onClickDelete}>
-          <ListItemIcon>
-            <Icon name="deleteToTrash" color={colors.interactive.primaryResting} />
-          </ListItemIcon>
+          <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Delete</Typography>
         </MenuItem>
       ]}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenuUtils.tsx
@@ -1,0 +1,40 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
+import OperationType from "../../contexts/operationType";
+import { parseStringToTrajectoryStationReferences, TrajectoryStationReferences } from "../../models/jobs/copyTrajectoryStationJob";
+import TrajectoryReference from "../../models/jobs/trajectoryReference";
+import Trajectory from "../../models/trajectory";
+import JobService, { JobType } from "../../services/jobService";
+
+type DispatchOperation = (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
+
+export const useClipboardTrajectoryStationReferences: () => [TrajectoryStationReferences | null, Dispatch<SetStateAction<TrajectoryStationReferences>>] = () => {
+  const [trajectoryStationReferences, setTrajectoryStationReferences] = useState<TrajectoryStationReferences>(null);
+
+  useEffect(() => {
+    const tryToParseClipboardContent = async () => {
+      try {
+        const clipboardText = await navigator.clipboard.readText();
+        const trajectoryStationReferences = parseStringToTrajectoryStationReferences(clipboardText);
+        setTrajectoryStationReferences(trajectoryStationReferences);
+      } catch (e) {
+        //Not a valid object on the clipboard? That is fine, we won't use it.
+      }
+    };
+    tryToParseClipboardContent();
+  }, []);
+
+  return [trajectoryStationReferences, setTrajectoryStationReferences];
+};
+
+export const orderCopyJob = (trajectory: Trajectory, trajectoryStationReferences: TrajectoryStationReferences, dispatchOperation: DispatchOperation) => {
+  const trajectoryReference: TrajectoryReference = {
+    wellUid: trajectory.wellUid,
+    wellboreUid: trajectory.wellboreUid,
+    trajectoryUid: trajectory.uid
+  };
+
+  const copyJob = { source: trajectoryStationReferences, target: trajectoryReference };
+  JobService.orderJob(JobType.CopyTrajectoryStations, copyJob);
+  dispatchOperation({ type: OperationType.HideContextMenu });
+};

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/TrajectoryItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/TrajectoryItem.tsx
@@ -1,14 +1,14 @@
 import React, { useContext } from "react";
-import TreeItem from "./TreeItem";
-import Well from "../../models/well";
-import Wellbore from "../../models/wellbore";
-import Trajectory from "../../models/trajectory";
 import NavigationContext from "../../contexts/navigationContext";
 import NavigationType from "../../contexts/navigationType";
-import { getContextMenuPosition, preventContextMenuPropagation } from "../ContextMenus/ContextMenu";
-import OperationType from "../../contexts/operationType";
-import TrajectoryContextMenu, { TrajectoryContextMenuProps } from "../ContextMenus/TrajectoryContextMenu";
 import OperationContext from "../../contexts/operationContext";
+import OperationType from "../../contexts/operationType";
+import Trajectory from "../../models/trajectory";
+import Well from "../../models/well";
+import Wellbore from "../../models/wellbore";
+import { getContextMenuPosition, preventContextMenuPropagation } from "../ContextMenus/ContextMenu";
+import TrajectoryContextMenu, { TrajectoryContextMenuProps } from "../ContextMenus/TrajectoryContextMenu";
+import TreeItem from "./TreeItem";
 
 interface TrajectoryProps {
   nodeId: string;
@@ -23,14 +23,14 @@ const TrajectoryItem = (props: TrajectoryProps): React.ReactElement => {
   const { trajectory, trajectoryGroup, selected, well, wellbore, nodeId } = props;
   const {
     dispatchNavigation,
-    navigationState: { selectedServer }
+    navigationState: { selectedServer, servers }
   } = useContext(NavigationContext);
 
   const { dispatchOperation } = useContext(OperationContext);
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, trajectory: Trajectory) => {
     preventContextMenuPropagation(event);
-    const contextMenuProps: TrajectoryContextMenuProps = { trajectory, selectedServer, dispatchOperation, dispatchNavigation };
+    const contextMenuProps: TrajectoryContextMenuProps = { trajectory, selectedServer, dispatchOperation, dispatchNavigation, servers };
     const position = getContextMenuPosition(event);
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <TrajectoryContextMenu {...contextMenuProps} />, position } });
   };

--- a/Src/WitsmlExplorer.Frontend/models/jobs/copyTrajectoryStationJob.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/copyTrajectoryStationJob.ts
@@ -1,0 +1,61 @@
+import { TrajectoryStationRow } from "../../components/ContentViews/TrajectoryView";
+import Trajectory from "../trajectory";
+import TrajectoryReference from "./trajectoryReference";
+
+export interface CopyTrajectoryStationJob {
+  source: TrajectoryStationReferences;
+  target: TrajectoryReference;
+}
+
+export interface TrajectoryStationReferences {
+  serverUrl: string;
+  trajectoryReference: TrajectoryReference;
+  trajectoryStationUids: string[];
+}
+
+export function parseStringToTrajectoryStationReferences(input: string): TrajectoryStationReferences {
+  let jsonObject: TrajectoryStationReferences;
+  try {
+    jsonObject = JSON.parse(input);
+  } catch (error) {
+    throw new Error("Invalid input given.");
+  }
+  verifyRequiredProperties(jsonObject);
+
+  return {
+    serverUrl: jsonObject.serverUrl,
+    trajectoryReference: jsonObject.trajectoryReference,
+    trajectoryStationUids: jsonObject.trajectoryStationUids
+  };
+}
+
+function verifyRequiredProperties(jsonObject: TrajectoryStationReferences) {
+  const requiredProps = ["serverUrl", "trajectoryReference", "trajectoryStationUids"];
+  const hasRequiredProperties = requiredProps.every((prop) => Object.prototype.hasOwnProperty.call(jsonObject, prop));
+  if (!hasRequiredProperties) {
+    throw new Error("Missing required fields.");
+  }
+}
+
+export function createTrajectoryStationReferences(trajectoryStations: TrajectoryStationRow[], source: Trajectory, serverUrl: string): TrajectoryStationReferences {
+  return {
+    serverUrl: serverUrl,
+    trajectoryReference: {
+      wellUid: source.wellUid,
+      wellboreUid: source.wellboreUid,
+      trajectoryUid: source.uid
+    },
+    trajectoryStationUids: trajectoryStations.map((component) => component.uid)
+  };
+}
+
+export function createCopyTrajectoryStationJob(sourceTrajectoryStationReferences: TrajectoryStationReferences, target: Trajectory): CopyTrajectoryStationJob {
+  return {
+    source: sourceTrajectoryStationReferences,
+    target: {
+      wellUid: target.wellUid,
+      wellboreUid: target.wellboreUid,
+      trajectoryUid: target.uid
+    }
+  };
+}

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -33,6 +33,7 @@ export enum JobType {
   CopyRig = "CopyRig",
   CopyRisk = "CopyRisk",
   CopyTrajectory = "CopyTrajectory",
+  CopyTrajectoryStations = "CopyTrajectoryStations",
   CopyTubular = "CopyTubular",
   CopyTubularComponents = "CopyTubularComponents",
   CreateWellbore = "CreateWellbore",


### PR DESCRIPTION
## Fixes
This pull request fixes WE-516

## Description
Implement copy trajectory stations.
Check whether we manage to fetch all tubular components during copy, abort if not.
Use StyledIcon in RigContextMenu.
Introduce onClickPaste that can be used by any object. The previous onClickPastes can be replaced with this one to remove duplicated code.
Introduce MenuItemText that specifies how text should be formatted in context menus to ensure consistence.

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
