### PR TITLE
FIX-WF remove pull target and bump versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,17 @@ on:
   pull_request:
     branches:
       - main
-  pull_request_target:
 
 jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 6.0.x
       - name: Build with dotnet
         run: dotnet build /warnaserror --configuration Release
       - name: Test with dotnet
@@ -24,10 +23,10 @@ jobs:
     name: Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install dependencies
         run: yarn
         working-directory: ./Src/WitsmlExplorer.Frontend

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
     name: Package and publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup .NET 6
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.100
+          dotnet-version: 6.0.x
           source-url: https://nuget.pkg.github.com/equinor/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Description
CICD update for workflows. Update versions and remove pull_request_target

## Further comments
This is a revert of https://github.com/equinor/witsml-explorer/pull/54 and minor updates