### PR TITLE
WE-535 TopRightCornerMenu with jobs button and labels

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/JobsButton.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/JobsButton.tsx
@@ -1,8 +1,9 @@
-import { Button } from "@material-ui/core";
+import { Button } from "@equinor/eds-core-react";
 import React, { useContext } from "react";
 import NavigationContext from "../contexts/navigationContext";
 import NavigationType from "../contexts/navigationType";
 import CredentialsService from "../services/credentialsService";
+import Icon from "../styles/Icons";
 
 const JobsButton = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
@@ -13,10 +14,12 @@ const JobsButton = (): React.ReactElement => {
     dispatchNavigation({ type: NavigationType.SelectJobs, payload: {} });
   };
 
-  const currentPassword = CredentialsService.getCredentials().find((cred) => cred.server.id == selectedServer.id)?.password;
+  const currentPassword = CredentialsService.getCredentials().find((cred) => cred.server.id == selectedServer?.id)?.password;
+  const disabled = !selectedServer || !currentPassword;
 
   return (
-    <Button onClick={onClick} disabled={!selectedServer || !currentPassword}>
+    <Button variant="ghost" onClick={onClick} disabled={disabled}>
+      <Icon name="assignment" />
       Jobs
     </Button>
   );

--- a/Src/WitsmlExplorer.Frontend/components/JobsButton.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/JobsButton.tsx
@@ -2,6 +2,7 @@ import { Button } from "@equinor/eds-core-react";
 import React, { useContext } from "react";
 import NavigationContext from "../contexts/navigationContext";
 import NavigationType from "../contexts/navigationType";
+import { msalEnabled } from "../msal/MsalAuthProvider";
 import CredentialsService from "../services/credentialsService";
 import Icon from "../styles/Icons";
 
@@ -15,7 +16,7 @@ const JobsButton = (): React.ReactElement => {
   };
 
   const currentPassword = CredentialsService.getCredentials().find((cred) => cred.server.id == selectedServer?.id)?.password;
-  const disabled = !selectedServer || !currentPassword;
+  const disabled = !selectedServer || (!msalEnabled && !currentPassword);
 
   return (
     <Button variant="ghost" onClick={onClick} disabled={disabled}>

--- a/Src/WitsmlExplorer.Frontend/components/Nav.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Nav.tsx
@@ -30,7 +30,6 @@ import Trajectory from "../models/trajectory";
 import Tubular from "../models/tubular";
 import Well from "../models/well";
 import Wellbore, { calculateLogGroupId, calculateLogTypeDepthId, calculateTrajectoryGroupId, calculateTubularGroupId } from "../models/wellbore";
-import JobsButton from "./JobsButton";
 import TopRightCornerMenu from "./TopRightCornerMenu";
 
 const Nav = (): React.ReactElement => {
@@ -86,7 +85,6 @@ const Nav = (): React.ReactElement => {
     <nav>
       <Layout>
         <Title>WITSML Explorer</Title>
-        <JobsButton />
         <StyledBreadcrumbs color="inherit" aria-label="breadcrumb">
           {breadcrumbContent.map((breadCrumb, index) => (
             <Breadcrumbs.Breadcrumb key={index} href="#" onClick={breadCrumb.onClick}>

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -85,7 +85,7 @@ const Layout = styled.div`
   width: 20rem;
 `;
 
-const SelectTypography = styled(Typography) <{ selected: boolean }>`
+const SelectTypography = styled(Typography)<{ selected: boolean }>`
   && {
     font-family: ${(props) => (props.selected ? "EquinorBold" : "EquinorRegular")};
   }

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -1,12 +1,12 @@
-import { Menu, Typography } from "@equinor/eds-core-react";
+import { Button, Menu, Typography } from "@equinor/eds-core-react";
 import React, { MouseEvent, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import OperationContext from "../contexts/operationContext";
 import { UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
 import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
-import { colors } from "../styles/Colors";
 import Icon from "../styles/Icons";
+import JobsButton from "./JobsButton";
 
 const TopRightCornerMenu = (): React.ReactElement => {
   const {
@@ -26,12 +26,12 @@ const TopRightCornerMenu = (): React.ReactElement => {
     }
   }, []);
 
-  const onToggleThemeMenu = (event: MouseEvent<SVGSVGElement>) => {
+  const onToggleThemeMenu = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorThemeEl(openTheme ? null : event.currentTarget);
     setAnchorAccountEl(null);
   };
 
-  const onToggleAccountMenu = (event: MouseEvent<SVGSVGElement>) => {
+  const onToggleAccountMenu = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorThemeEl(null);
     setAnchorAccountEl(openAccount ? null : event.currentTarget);
   };
@@ -44,9 +44,11 @@ const TopRightCornerMenu = (): React.ReactElement => {
 
   return (
     <Layout>
-      <Pointer>
-        <Icon name="accessible" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleThemeMenu(event)} size={24} color={colors.interactive.primaryResting} />
-      </Pointer>
+      <JobsButton />
+      <Button variant="ghost" onClick={(event) => onToggleThemeMenu(event)}>
+        <Icon name="accessible" />
+        Theme
+      </Button>
       <Menu id="ThemeMenu" anchorEl={anchorThemeEl} open={openTheme}>
         <StyledMenuItem key={"comfortable"} onClick={() => onSelectTheme(UserTheme.Comfortable)}>
           <SelectTypography selected={theme === UserTheme.Comfortable}>Comfortable </SelectTypography>
@@ -59,9 +61,10 @@ const TopRightCornerMenu = (): React.ReactElement => {
       </Menu>
       {msalEnabled && (
         <>
-          <Pointer>
-            <Icon name="accountCircle" onClick={(event: MouseEvent<SVGSVGElement>) => onToggleAccountMenu(event)} size={24} color={colors.interactive.primaryResting} />
-          </Pointer>
+          <Button variant="ghost" onClick={(event) => onToggleAccountMenu(event)}>
+            <Icon name="accountCircle" />
+            Account
+          </Button>
           <Menu id="AccountMenu" anchorEl={anchorAccountEl} open={openAccount}>
             <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
             <StyledMenuItem key={"signout"} onClick={() => signOut()}>
@@ -82,7 +85,7 @@ const Layout = styled.div`
   width: 20rem;
 `;
 
-const SelectTypography = styled(Typography)<{ selected: boolean }>`
+const SelectTypography = styled(Typography) <{ selected: boolean }>`
   && {
     font-family: ${(props) => (props.selected ? "EquinorBold" : "EquinorRegular")};
   }
@@ -98,10 +101,6 @@ const StyledMenuItem = styled(Menu.Item)`
       outline: 0;
     }
   }
-`;
-
-const Pointer = styled.div`
-  cursor: pointer;
 `;
 
 export default TopRightCornerMenu;

--- a/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
+++ b/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
@@ -3,6 +3,7 @@ import {
   accessible,
   account_circle as accountCircle,
   add,
+  assignment,
   check,
   chevron_down as chevronDown,
   chevron_right as chevronRight,
@@ -35,7 +36,8 @@ const icons = {
   edit,
   folderOpen,
   deleteToTrash,
-  moreVertical
+  moreVertical,
+  assignment
 };
 
 Icon.add(icons);


### PR DESCRIPTION
## Fixes
This pull request fixes WE-535

## Description
Moved jobs button to topRightCornerMenu and added labels. Used EDS way of implementing buttons.
![image](https://user-images.githubusercontent.com/66632214/190992394-32a6501c-5c74-438e-9beb-4cb803a4fb37.png)

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
