### PR TITLE
WE-553 Use ContextMenu in TopRightCornerMenu

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenu.tsx
@@ -14,7 +14,7 @@ export const preventContextMenuPropagation = (event: React.MouseEvent<HTMLLIElem
   return false;
 };
 
-export const getContextMenuPosition = (event: React.MouseEvent<HTMLLIElement | HTMLDivElement>): MousePosition => {
+export const getContextMenuPosition = (event: React.MouseEvent<HTMLLIElement | HTMLDivElement | HTMLButtonElement>): MousePosition => {
   return { mouseX: event.clientX - 2, mouseY: event.clientY - 2 };
 };
 

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -1,11 +1,13 @@
-import { Button, Menu, Typography } from "@equinor/eds-core-react";
-import React, { MouseEvent, useContext, useEffect, useState } from "react";
+import { Button, Typography } from "@equinor/eds-core-react";
+import { MenuItem } from "@material-ui/core";
+import React, { ReactElement, useContext, useEffect } from "react";
 import styled from "styled-components";
 import OperationContext from "../contexts/operationContext";
 import { UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
 import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
 import Icon from "../styles/Icons";
+import ContextMenu from "./ContextMenus/ContextMenu";
 import JobsButton from "./JobsButton";
 
 const TopRightCornerMenu = (): React.ReactElement => {
@@ -13,10 +15,6 @@ const TopRightCornerMenu = (): React.ReactElement => {
     operationState: { theme },
     dispatchOperation
   } = useContext(OperationContext);
-  const [anchorThemeEl, setAnchorThemeEl] = useState(null);
-  const [anchorAccountEl, setAnchorAccountEl] = useState(null);
-  const openTheme = Boolean(anchorThemeEl);
-  const openAccount = Boolean(anchorAccountEl);
 
   useEffect(() => {
     let localStorageTheme;
@@ -26,52 +24,61 @@ const TopRightCornerMenu = (): React.ReactElement => {
     }
   }, []);
 
-  const onToggleThemeMenu = (event: MouseEvent<HTMLButtonElement>) => {
-    setAnchorThemeEl(openTheme ? null : event.currentTarget);
-    setAnchorAccountEl(null);
-  };
-
-  const onToggleAccountMenu = (event: MouseEvent<HTMLButtonElement>) => {
-    setAnchorThemeEl(null);
-    setAnchorAccountEl(openAccount ? null : event.currentTarget);
-  };
-
   const onSelectTheme = (selectedTheme: UserTheme) => {
     localStorage.setItem("selectedTheme", selectedTheme);
     dispatchOperation({ type: OperationType.SetTheme, payload: selectedTheme });
-    setAnchorThemeEl(null);
+    dispatchOperation({ type: OperationType.HideContextMenu });
+  };
+
+  const themeMenu = (
+    <ContextMenu
+      menuItems={[
+        <StyledMenuItem key={"comfortable"} onClick={() => onSelectTheme(UserTheme.Comfortable)}>
+          <SelectTypography selected={theme === UserTheme.Comfortable}>Comfortable </SelectTypography>
+          {theme === UserTheme.Comfortable && <Icon name="check" />}
+        </StyledMenuItem>,
+        <StyledMenuItem key={"compact"} onClick={() => onSelectTheme(UserTheme.Compact)}>
+          <SelectTypography selected={theme === UserTheme.Compact}>Compact</SelectTypography>
+          {theme === UserTheme.Compact && <Icon name="check" />}
+        </StyledMenuItem>
+      ]}
+    />
+  );
+
+  const accountMenu = (
+    <ContextMenu
+      menuItems={[
+        <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>,
+        <StyledMenuItem
+          key={"signout"}
+          onClick={() => {
+            signOut();
+            dispatchOperation({ type: OperationType.HideContextMenu });
+          }}
+        >
+          Logout
+        </StyledMenuItem>
+      ]}
+    />
+  );
+
+  const onOpenMenu = (event: React.MouseEvent<HTMLButtonElement>, menu: ReactElement) => {
+    const position = { mouseX: event.currentTarget.getBoundingClientRect().left, mouseY: event.currentTarget.getBoundingClientRect().bottom };
+    dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: menu, position } });
   };
 
   return (
     <Layout>
       <JobsButton />
-      <Button variant="ghost" onClick={(event) => onToggleThemeMenu(event)}>
+      <Button variant="ghost" onClick={(event) => onOpenMenu(event, themeMenu)}>
         <Icon name="accessible" />
         Theme
       </Button>
-      <Menu id="ThemeMenu" anchorEl={anchorThemeEl} open={openTheme}>
-        <StyledMenuItem key={"comfortable"} onClick={() => onSelectTheme(UserTheme.Comfortable)}>
-          <SelectTypography selected={theme === UserTheme.Comfortable}>Comfortable </SelectTypography>
-          {theme === UserTheme.Comfortable && <Icon name="check" />}
-        </StyledMenuItem>
-        <StyledMenuItem key={"compact"} onClick={() => onSelectTheme(UserTheme.Compact)}>
-          <SelectTypography selected={theme === UserTheme.Compact}>Compact</SelectTypography>
-          {theme === UserTheme.Compact && <Icon name="check" />}
-        </StyledMenuItem>
-      </Menu>
       {msalEnabled && (
-        <>
-          <Button variant="ghost" onClick={(event) => onToggleAccountMenu(event)}>
-            <Icon name="accountCircle" />
-            Account
-          </Button>
-          <Menu id="AccountMenu" anchorEl={anchorAccountEl} open={openAccount}>
-            <StyledMenuItem key={"account"}>{getAccountInfo()?.name}</StyledMenuItem>
-            <StyledMenuItem key={"signout"} onClick={() => signOut()}>
-              Logout
-            </StyledMenuItem>
-          </Menu>
-        </>
+        <Button variant="ghost" onClick={(event) => onOpenMenu(event, accountMenu)}>
+          <Icon name="accountCircle" />
+          Account
+        </Button>
       )}
     </Layout>
   );
@@ -91,7 +98,7 @@ const SelectTypography = styled(Typography)<{ selected: boolean }>`
   }
 `;
 
-const StyledMenuItem = styled(Menu.Item)`
+const StyledMenuItem = styled(MenuItem)`
   && {
     width: 13rem;
     display: flex;


### PR DESCRIPTION
## Fixes
This pull request fixes WE-553

## Description
Use ContextMenu in TopRightCornerMenu to automatically hide the menus on losing focus.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
