### PR TITLE
WE-530 Reset checked items on viewing different log group

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -15,6 +15,7 @@ export const LogsListView = (): React.ReactElement => {
   const { selectedWellbore, selectedLogTypeGroup, selectedServer, servers } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [logs, setLogs] = useState<LogObject[]>([]);
+  const [resetCheckedItems, setResetCheckedItems] = useState(false);
 
   useEffect(() => {
     if (selectedWellbore && selectedWellbore.logs) {
@@ -47,7 +48,17 @@ export const LogsListView = (): React.ReactElement => {
     { property: "uid", label: "UID", type: ContentType.String }
   ];
 
-  return selectedWellbore ? <ContentTable columns={columns} data={getTableData()} onContextMenu={onContextMenu} checkableRows /> : <></>;
+  useEffect(() => {
+    if (resetCheckedItems) {
+      setResetCheckedItems(false);
+    }
+  }, [resetCheckedItems]);
+
+  useEffect(() => {
+    setResetCheckedItems(true);
+  }, [selectedWellbore, selectedLogTypeGroup]);
+
+  return selectedWellbore && !resetCheckedItems ? <ContentTable columns={columns} data={getTableData()} onContextMenu={onContextMenu} checkableRows /> : <></>;
 };
 
 export default LogsListView;


### PR DESCRIPTION
## Fixes
This pull request fixes WE-530

## Description
Reset checked items on viewing different log group (time/depth) or wellbore to avoid executing operations on logs that are no longer showing in the content view.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated