### PR TITLE
WE-544 Return worker result on unexpected worker failure

### DIFF
--- a/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
@@ -45,7 +45,7 @@ namespace WitsmlExplorer.Api.Workers
                 job.JobInfo.Status = JobStatus.Failed;
                 job.JobInfo.FailedReason = ex.Message;
                 Logger.LogError("An unexpected exception has occured: {ex}", ex);
-                throw;
+                return (new WorkerResult(new Uri(job.JobInfo.TargetServer), false, $"{job.JobInfo.JobType} failed", ex.Message), null);
             }
         }
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-544

## Description
Return worker result on unexpected worker failure to show notification to the user in frontend.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
