### PR TITLE
WE-568 Show on server all objects

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/BhaRunContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/BhaRunContextMenu.tsx
@@ -16,8 +16,9 @@ import BhaRunPropertiesModal, { BhaRunPropertiesModalProps } from "../Modals/Bha
 import ConfirmModal from "../Modals/ConfirmModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste, orderCopyJob } from "./CopyUtils";
+import NestedMenuItem from "./NestedMenuItem";
 import { useClipboardReferencesOfType } from "./UseClipboardReferences";
 
 export interface BhaRunContextMenuProps {
@@ -104,6 +105,17 @@ const BhaRunContextMenu = (props: BhaRunContextMenuProps): React.ReactElement =>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>{menuItemText("delete", "bhaRun", checkedBhaRunRows)}</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedBhaRunRows.length !== 1}>
+          {servers.map((server: Server) => (
+            <MenuItem
+              key={server.name}
+              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedBhaRunRows[0].wellUid, checkedBhaRunRows[0].wellboreUid, checkedBhaRunRows[0].uid, "bhaRunUid")}
+              disabled={checkedBhaRunRows.length !== 1}
+            >
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <Divider key={"divider"} />,
         <MenuItem key={"properties"} onClick={onClickModify} disabled={checkedBhaRunRows.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/BhaRunContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/BhaRunContextMenu.tsx
@@ -107,11 +107,7 @@ const BhaRunContextMenu = (props: BhaRunContextMenuProps): React.ReactElement =>
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedBhaRunRows.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem
-              key={server.name}
-              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedBhaRunRows[0].wellUid, checkedBhaRunRows[0].wellboreUid, checkedBhaRunRows[0].uid, "bhaRunUid")}
-              disabled={checkedBhaRunRows.length !== 1}
-            >
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, checkedBhaRunRows[0], "bhaRunUid")} disabled={checkedBhaRunRows.length !== 1}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
+import ObjectOnWellbore from "../../models/objectOnWellbore";
 import { Server } from "../../models/server";
 import CredentialsService, { BasicServerCredentials } from "../../services/credentialsService";
 import Icon from "../../styles/Icons";
@@ -43,16 +44,9 @@ export const showCredentialsModal = (server: Server, dispatchOperation: Dispatch
   dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });
 };
 
-export const onClickShowOnServer = async (
-  dispatchOperation: DispatchOperation,
-  server: Server,
-  wellUid: string,
-  wellboreUid: string,
-  uid: string,
-  paramName: keyof QueryParams
-) => {
+export const onClickShowOnServer = async (dispatchOperation: DispatchOperation, server: Server, objectOnWellbore: ObjectOnWellbore, paramName: keyof QueryParams) => {
   const host = `${window.location.protocol}//${window.location.host}`;
-  const logUrl = `${host}/?serverUrl=${server.url}&wellUid=${wellUid}&wellboreUid=${wellboreUid}&${paramName}=${uid}`;
+  const logUrl = `${host}/?serverUrl=${server.url}&wellUid=${objectOnWellbore.wellUid}&wellboreUid=${objectOnWellbore.wellboreUid}&${paramName}=${objectOnWellbore.uid}`;
   window.open(logUrl);
   dispatchOperation({ type: OperationType.HideContextMenu });
 };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -5,6 +5,7 @@ import { Server } from "../../models/server";
 import CredentialsService, { BasicServerCredentials } from "../../services/credentialsService";
 import Icon from "../../styles/Icons";
 import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
+import { QueryParams } from "../Routing";
 
 export type DispatchOperation = (action: HideModalAction | HideContextMenuAction | DisplayModalAction) => void;
 
@@ -40,4 +41,18 @@ export const showCredentialsModal = (server: Server, dispatchOperation: Dispatch
     confirmText: "Save"
   };
   dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });
+};
+
+export const onClickShowOnServer = async (
+  dispatchOperation: DispatchOperation,
+  server: Server,
+  wellUid: string,
+  wellboreUid: string,
+  uid: string,
+  paramName: keyof QueryParams
+) => {
+  const host = `${window.location.protocol}//${window.location.host}`;
+  const logUrl = `${host}/?serverUrl=${server.url}&wellUid=${wellUid}&wellboreUid=${wellboreUid}&${paramName}=${uid}`;
+  window.open(logUrl);
+  dispatchOperation({ type: OperationType.HideContextMenu });
 };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
@@ -15,7 +15,7 @@ import ConfirmModal from "../Modals/ConfirmModal";
 import LogCurveInfoPropertiesModal from "../Modals/LogCurveInfoPropertiesModal";
 import SelectIndexToDisplayModal from "../Modals/SelectIndexToDisplayModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickCopyCurveToServer } from "./CopyCurveToServer";
 import NestedMenuItem from "./NestedMenuItem";
 
@@ -114,6 +114,13 @@ const LogCurveInfoContextMenu = (props: LogCurveInfoContextMenuProps): React.Rea
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>{menuItemText("delete", "curve", checkedLogCurveInfoRows)}</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
+          {servers.map((server: Server) => (
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, selectedLog, "logObjectUid")}>
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <MenuItem key={"properties"} onClick={onClickProperties} disabled={checkedLogCurveInfoRows.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Properties</Typography>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -206,9 +206,7 @@ const LogObjectContextMenu = (props: LogObjectContextMenuProps): React.ReactElem
           {servers.map((server: Server) => (
             <MenuItem
               key={server.name}
-              onClick={() =>
-                onClickShowOnServer(dispatchOperation, server, checkedLogObjectRows[0].wellUid, checkedLogObjectRows[0].wellboreUid, checkedLogObjectRows[0].uid, "logObjectUid")
-              }
+              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedLogObjectRows[0], "logObjectUid")}
               disabled={checkedLogObjectRows.length !== 1}
             >
               <Typography color={"primary"}>{server.name}</Typography>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -22,7 +22,7 @@ import LogPropertiesModal from "../Modals/LogPropertiesModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import TrimLogObjectModal, { TrimLogObjectModalProps } from "../Modals/TrimLogObject/TrimLogObjectModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer } from "./ContextMenuUtils";
 import { onClickCopyLogToServer } from "./CopyLogToServer";
 import { onClickPaste } from "./CopyUtils";
 import NestedMenuItem from "./NestedMenuItem";
@@ -59,14 +59,6 @@ const LogObjectContextMenu = (props: LogObjectContextMenuProps): React.ReactElem
     const logObject = checkedLogObjectRows[0];
     const logPropertiesModalProps = { mode: PropertiesModalMode.Edit, logObject, dispatchOperation };
     dispatchOperation({ type: OperationType.DisplayModal, payload: <LogPropertiesModal {...logPropertiesModalProps} /> });
-    dispatchOperation({ type: OperationType.HideContextMenu });
-  };
-
-  const onClickShowOnServer = async (server: Server) => {
-    const logObject = checkedLogObjectRows[0];
-    const host = `${window.location.protocol}//${window.location.host}`;
-    const logUrl = `${host}/?serverUrl=${server.url}&wellUid=${logObject.wellUid}&wellboreUid=${logObject.wellboreUid}&logObjectUid=${logObject.uid}`;
-    window.open(logUrl);
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
 
@@ -212,7 +204,13 @@ const LogObjectContextMenu = (props: LogObjectContextMenuProps): React.ReactElem
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedLogObjectRows.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(server)} disabled={checkedLogObjectRows.length !== 1}>
+            <MenuItem
+              key={server.name}
+              onClick={() =>
+                onClickShowOnServer(dispatchOperation, server, checkedLogObjectRows[0].wellUid, checkedLogObjectRows[0].wellboreUid, checkedLogObjectRows[0].uid, "logObjectUid")
+              }
+              disabled={checkedLogObjectRows.length !== 1}
+            >
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/MessageObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/MessageObjectContextMenu.tsx
@@ -84,16 +84,7 @@ const MessageObjectContextMenu = (props: MessageObjectContextMenuProps): React.R
           {servers.map((server: Server) => (
             <MenuItem
               key={server.name}
-              onClick={() =>
-                onClickShowOnServer(
-                  dispatchOperation,
-                  server,
-                  checkedMessageObjectRows[0].wellUid,
-                  checkedMessageObjectRows[0].wellboreUid,
-                  checkedMessageObjectRows[0].uid,
-                  "messageUid"
-                )
-              }
+              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedMessageObjectRows[0], "messageUid")}
               disabled={checkedMessageObjectRows.length !== 1}
             >
               <Typography color={"primary"}>{server.name}</Typography>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/MessageObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/MessageObjectContextMenu.tsx
@@ -15,7 +15,8 @@ import ConfirmModal from "../Modals/ConfirmModal";
 import MessagePropertiesModal, { MessagePropertiesModalProps } from "../Modals/MessagePropertiesModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
+import NestedMenuItem from "./NestedMenuItem";
 
 export interface MessageObjectContextMenuProps {
   checkedMessageObjectRows: MessageObjectRow[];
@@ -26,7 +27,7 @@ export interface MessageObjectContextMenuProps {
 }
 
 const MessageObjectContextMenu = (props: MessageObjectContextMenuProps): React.ReactElement => {
-  const { checkedMessageObjectRows, dispatchOperation } = props;
+  const { checkedMessageObjectRows, dispatchOperation, servers } = props;
 
   const deleteMessageObjects = async () => {
     dispatchOperation({ type: OperationType.HideModal });
@@ -79,6 +80,26 @@ const MessageObjectContextMenu = (props: MessageObjectContextMenuProps): React.R
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>{menuItemText("delete", "message", checkedMessageObjectRows)}</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedMessageObjectRows.length !== 1}>
+          {servers.map((server: Server) => (
+            <MenuItem
+              key={server.name}
+              onClick={() =>
+                onClickShowOnServer(
+                  dispatchOperation,
+                  server,
+                  checkedMessageObjectRows[0].wellUid,
+                  checkedMessageObjectRows[0].wellboreUid,
+                  checkedMessageObjectRows[0].uid,
+                  "messageUid"
+                )
+              }
+              disabled={checkedMessageObjectRows.length !== 1}
+            >
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <Divider key={"divider"} />,
         <MenuItem key={"properties"} onClick={onClickModify} disabled={checkedMessageObjectRows.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/NestedMenuItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/NestedMenuItem.tsx
@@ -5,7 +5,7 @@ import MenuItem, { MenuItemProps } from "@material-ui/core/MenuItem";
 import ArrowRight from "@material-ui/icons/ArrowRight";
 import React, { useImperativeHandle, useRef, useState } from "react";
 import { colors } from "../../styles/Colors";
-import Icon from "../../styles/Icons";
+import { StyledIcon } from "./ContextMenuUtils";
 
 export interface NestedMenuItemProps extends Omit<MenuItemProps, "button"> {
   label: string;
@@ -90,9 +90,7 @@ const NestedMenuItem = React.forwardRef<HTMLLIElement | null, NestedMenuItemProp
   return (
     <div {...ContainerProps} ref={containerRef} onFocus={handleFocus} tabIndex={tabIndex} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} onKeyDown={handleKeyDown}>
       <MenuItem {...MenuItemProps} ref={menuItemRef}>
-        <ListItemIcon>
-          <Icon name={icon ?? "launch"} color={colors.interactive.primaryResting} />
-        </ListItemIcon>
+        <StyledIcon name={icon ?? "launch"} color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>{label}</Typography>
         <ListItemIcon>
           <ArrowRight />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
@@ -94,11 +94,7 @@ const RigContextMenu = (props: RigContextMenuProps): React.ReactElement => {
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedRigRows.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem
-              key={server.name}
-              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedRigRows[0].wellUid, checkedRigRows[0].wellboreUid, checkedRigRows[0].uid, "rigUid")}
-              disabled={checkedRigRows.length !== 1}
-            >
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, checkedRigRows[0], "rigUid")} disabled={checkedRigRows.length !== 1}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
@@ -14,8 +14,9 @@ import ConfirmModal from "../Modals/ConfirmModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import RigPropertiesModal, { RigPropertiesModalProps } from "../Modals/RigPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste, orderCopyJob } from "./CopyUtils";
+import NestedMenuItem from "./NestedMenuItem";
 import { onClickCopy } from "./RigContextMenuUtils";
 import { useClipboardReferencesOfType } from "./UseClipboardReferences";
 
@@ -91,6 +92,17 @@ const RigContextMenu = (props: RigContextMenuProps): React.ReactElement => {
           </ListItemIcon>
           <Typography color="primary">{menuItemText("delete", "rig", rigs)}</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedRigRows.length !== 1}>
+          {servers.map((server: Server) => (
+            <MenuItem
+              key={server.name}
+              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedRigRows[0].wellUid, checkedRigRows[0].wellboreUid, checkedRigRows[0].uid, "rigUid")}
+              disabled={checkedRigRows.length !== 1}
+            >
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <Divider key={"divider"} />,
         <MenuItem key={"properties"} onClick={onClickModify} disabled={checkedRigRows.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RiskContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RiskContextMenu.tsx
@@ -12,8 +12,9 @@ import { RiskObjectRow } from "../ContentViews/RisksListView";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import RiskPropertiesModal, { RiskPropertiesModalProps } from "../Modals/RiskPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste, orderCopyJob } from "./CopyUtils";
+import NestedMenuItem from "./NestedMenuItem";
 import { onClickCopy, onClickDelete } from "./RiskContextMenuUtils";
 import { useClipboardReferencesOfType } from "./UseClipboardReferences";
 
@@ -56,6 +57,17 @@ const RiskObjectContextMenu = (props: RiskObjectContextMenuProps): React.ReactEl
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>{menuItemText("delete", "risk", risks)}</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={risks.length !== 1}>
+          {servers.map((server: Server) => (
+            <MenuItem
+              key={server.name}
+              onClick={() => onClickShowOnServer(dispatchOperation, server, risks[0].wellUid, risks[0].wellboreUid, risks[0].uid, "riskUid")}
+              disabled={risks.length !== 1}
+            >
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <Divider key={"divider"} />,
         <MenuItem key={"properties"} onClick={onClickModify} disabled={checkedRiskObjectRows.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RiskContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RiskContextMenu.tsx
@@ -59,11 +59,7 @@ const RiskObjectContextMenu = (props: RiskObjectContextMenuProps): React.ReactEl
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={risks.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem
-              key={server.name}
-              onClick={() => onClickShowOnServer(dispatchOperation, server, risks[0].wellUid, risks[0].wellboreUid, risks[0].uid, "riskUid")}
-              disabled={risks.length !== 1}
-            >
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, risks[0], "riskUid")} disabled={risks.length !== 1}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
@@ -50,11 +50,7 @@ const TrajectoryContextMenu = (props: TrajectoryContextMenuProps): React.ReactEl
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={trajectories.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem
-              key={server.name}
-              onClick={() => onClickShowOnServer(dispatchOperation, server, trajectories[0].wellUid, trajectories[0].wellboreUid, trajectories[0].uid, "trajectoryUid")}
-              disabled={trajectories.length !== 1}
-            >
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectories[0], "trajectoryUid")} disabled={trajectories.length !== 1}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
@@ -9,8 +9,9 @@ import Wellbore from "../../models/wellbore";
 import { JobType } from "../../services/jobService";
 import { colors } from "../../styles/Colors";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste, orderCopyJob } from "./CopyUtils";
+import NestedMenuItem from "./NestedMenuItem";
 import { onClickCopy, onClickDelete } from "./TrajectoryContextMenuUtils";
 import { useClipboardReferencesOfType } from "./UseClipboardReferences";
 
@@ -46,7 +47,18 @@ const TrajectoryContextMenu = (props: TrajectoryContextMenuProps): React.ReactEl
         <MenuItem key={"delete"} onClick={() => onClickDelete(trajectories, dispatchOperation)} disabled={trajectories.length === 0}>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>{menuItemText("delete", "trajectory", trajectories)}</Typography>
-        </MenuItem>
+        </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={trajectories.length !== 1}>
+          {servers.map((server: Server) => (
+            <MenuItem
+              key={server.name}
+              onClick={() => onClickShowOnServer(dispatchOperation, server, trajectories[0].wellUid, trajectories[0].wellboreUid, trajectories[0].uid, "trajectoryUid")}
+              disabled={trajectories.length !== 1}
+            >
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>
       ]}
     />
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectorySidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectorySidebarContextMenu.tsx
@@ -6,8 +6,9 @@ import { Server } from "../../models/server";
 import Trajectory from "../../models/trajectory";
 import { colors } from "../../styles/Colors";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste } from "./CopyUtils";
+import NestedMenuItem from "./NestedMenuItem";
 import { onClickCopy, onClickDelete } from "./TrajectoryContextMenuUtils";
 import { orderCopyTrajectoryStationsJob, useClipboardTrajectoryStationReferences } from "./TrajectoryStationContextMenuUtils";
 
@@ -38,7 +39,14 @@ const TrajectorySidebarContextMenu = (props: TrajectorySidebarContextMenuProps):
         <MenuItem key={"delete"} onClick={() => onClickDelete([trajectory], dispatchOperation)}>
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Delete trajectory</Typography>
-        </MenuItem>
+        </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
+          {servers.map((server: Server) => (
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectory.wellUid, trajectory.wellboreUid, trajectory.uid, "trajectoryUid")}>
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>
       ]}
     />
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectorySidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectorySidebarContextMenu.tsx
@@ -42,7 +42,7 @@ const TrajectorySidebarContextMenu = (props: TrajectorySidebarContextMenuProps):
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectory.wellUid, trajectory.wellboreUid, trajectory.uid, "trajectoryUid")}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectory, "trajectoryUid")}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenu.tsx
@@ -14,8 +14,9 @@ import { TrajectoryStationRow } from "../ContentViews/TrajectoryView";
 import ConfirmModal from "../Modals/ConfirmModal";
 import TrajectoryStationPropertiesModal from "../Modals/TrajectoryStationPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste } from "./CopyUtils";
+import NestedMenuItem from "./NestedMenuItem";
 import { orderCopyTrajectoryStationsJob, useClipboardTrajectoryStationReferences } from "./TrajectoryStationContextMenuUtils";
 
 export interface TrajectoryStationContextMenuProps {
@@ -97,6 +98,13 @@ const TrajectoryStationContextMenu = (props: TrajectoryStationContextMenuProps):
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>{menuItemText("delete", "trajectory station", checkedTrajectoryStations)}</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
+          {servers.map((server: Server) => (
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectory.wellUid, trajectory.wellboreUid, trajectory.uid, "trajectoryUid")}>
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <Divider key={"divider"} />,
         <MenuItem key={"properties"} onClick={onClickProperties} disabled={checkedTrajectoryStations.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenu.tsx
@@ -100,7 +100,7 @@ const TrajectoryStationContextMenu = (props: TrajectoryStationContextMenuProps):
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectory.wellUid, trajectory.wellboreUid, trajectory.uid, "trajectoryUid")}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, trajectory, "trajectoryUid")}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
@@ -14,11 +14,11 @@ import { TubularComponentRow } from "../ContentViews/TubularView";
 import ConfirmModal from "../Modals/ConfirmModal";
 import TubularComponentPropertiesModal from "../Modals/TubularComponentPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste } from "./CopyUtils";
 import NestedMenuItem from "./NestedMenuItem";
 import { orderCopyTubularComponentsJob, useClipboardTubularComponentReferences } from "./TubularComponentContextMenuUtils";
-import { onClickRefresh, onClickShowOnServer } from "./TubularContextMenuUtils";
+import { onClickRefresh } from "./TubularContextMenuUtils";
 
 export interface TubularComponentContextMenuProps {
   checkedTubularComponents: TubularComponentRow[];
@@ -102,7 +102,7 @@ const TubularComponentContextMenu = (props: TubularComponentContextMenuProps): R
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular.wellUid, tubular.wellboreUid, tubular.uid)}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular.wellUid, tubular.wellboreUid, tubular.uid, "tubularUid")}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
@@ -102,7 +102,7 @@ const TubularComponentContextMenu = (props: TubularComponentContextMenuProps): R
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular.wellUid, tubular.wellboreUid, tubular.uid, "tubularUid")}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular, "tubularUid")}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularContextMenuUtils.tsx
@@ -54,13 +54,6 @@ export const onClickDelete = async (tubulars: Tubular[], dispatchOperation: Disp
   dispatchOperation({ type: OperationType.DisplayModal, payload: confirmation });
 };
 
-export const onClickShowOnServer = async (dispatchOperation: DispatchOperation, server: Server, wellUid: string, wellboreUid: string, tubularUid: string) => {
-  const host = `${window.location.protocol}//${window.location.host}`;
-  const logUrl = `${host}/?serverUrl=${server.url}&wellUid=${wellUid}&wellboreUid=${wellboreUid}&tubularUid=${tubularUid}`;
-  window.open(logUrl);
-  dispatchOperation({ type: OperationType.HideContextMenu });
-};
-
 export const onClickRefresh = async (tubular: Tubular, dispatchOperation: DispatchOperation, dispatchNavigation: (action: UpdateWellboreTubularAction) => void) => {
   let freshTubular = await TubularService.getTubular(tubular.wellUid, tubular.wellboreUid, tubular.uid);
   const exists = !!freshTubular;

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
@@ -65,11 +65,7 @@ const TubularObjectContextMenu = (props: TubularObjectContextMenuProps): React.R
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={tubulars.length !== 1}>
           {servers.map((server: Server) => (
-            <MenuItem
-              key={server.name}
-              onClick={() => onClickShowOnServer(dispatchOperation, server, tubulars[0].wellUid, tubulars[0].wellboreUid, tubulars[0].uid, "tubularUid")}
-              disabled={tubulars.length !== 1}
-            >
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubulars[0], "tubularUid")} disabled={tubulars.length !== 1}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularObjectContextMenu.tsx
@@ -13,10 +13,10 @@ import { colors } from "../../styles/Colors";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import TubularPropertiesModal from "../Modals/TubularPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste, orderCopyJob } from "./CopyUtils";
 import NestedMenuItem from "./NestedMenuItem";
-import { onClickCopy, onClickDelete, onClickRefresh, onClickShowOnServer } from "./TubularContextMenuUtils";
+import { onClickCopy, onClickDelete, onClickRefresh } from "./TubularContextMenuUtils";
 import { useClipboardReferencesOfType } from "./UseClipboardReferences";
 
 export interface TubularObjectContextMenuProps {
@@ -67,7 +67,7 @@ const TubularObjectContextMenu = (props: TubularObjectContextMenuProps): React.R
           {servers.map((server: Server) => (
             <MenuItem
               key={server.name}
-              onClick={() => onClickShowOnServer(dispatchOperation, server, tubulars[0].wellUid, tubulars[0].wellboreUid, tubulars[0].uid)}
+              onClick={() => onClickShowOnServer(dispatchOperation, server, tubulars[0].wellUid, tubulars[0].wellboreUid, tubulars[0].uid, "tubularUid")}
               disabled={tubulars.length !== 1}
             >
               <Typography color={"primary"}>{server.name}</Typography>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
@@ -57,7 +57,7 @@ const TubularSidebarContextMenu = (props: TubularSidebarContextMenuProps): React
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular.wellUid, tubular.wellboreUid, tubular.uid, "tubularUid")}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular, "tubularUid")}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularSidebarContextMenu.tsx
@@ -10,11 +10,11 @@ import { colors } from "../../styles/Colors";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import TubularPropertiesModal from "../Modals/TubularPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, StyledIcon } from "./ContextMenuUtils";
+import { menuItemText, onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
 import { onClickPaste } from "./CopyUtils";
 import NestedMenuItem from "./NestedMenuItem";
 import { orderCopyTubularComponentsJob, useClipboardTubularComponentReferences } from "./TubularComponentContextMenuUtils";
-import { onClickCopy, onClickDelete, onClickRefresh, onClickShowOnServer } from "./TubularContextMenuUtils";
+import { onClickCopy, onClickDelete, onClickRefresh } from "./TubularContextMenuUtils";
 
 export interface TubularSidebarContextMenuProps {
   dispatchNavigation: (action: UpdateWellboreTubularsAction | UpdateWellboreTubularAction) => void;
@@ -57,7 +57,7 @@ const TubularSidebarContextMenu = (props: TubularSidebarContextMenuProps): React
         </MenuItem>,
         <NestedMenuItem key={"showOnServer"} label={"Show on server"}>
           {servers.map((server: Server) => (
-            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular.wellUid, tubular.wellboreUid, tubular.uid)}>
+            <MenuItem key={server.name} onClick={() => onClickShowOnServer(dispatchOperation, server, tubular.wellUid, tubular.wellboreUid, tubular.uid, "tubularUid")}>
               <Typography color={"primary"}>{server.name}</Typography>
             </MenuItem>
           ))}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometryContextMenu.tsx
@@ -16,7 +16,8 @@ import ConfirmModal from "../Modals/ConfirmModal";
 import { PropertiesModalMode } from "../Modals/ModalParts";
 import WbGeometryPropertiesModal, { WbGeometryPropertiesModalProps } from "../Modals/WbGeometryPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { StyledIcon } from "./ContextMenuUtils";
+import { onClickShowOnServer, StyledIcon } from "./ContextMenuUtils";
+import NestedMenuItem from "./NestedMenuItem";
 
 export interface WbGeometryObjectContextMenuProps {
   checkedWbGeometryObjectRows: WbGeometryObjectRow[];
@@ -27,7 +28,7 @@ export interface WbGeometryObjectContextMenuProps {
 }
 
 const WbGeometryObjectContextMenu = (props: WbGeometryObjectContextMenuProps): React.ReactElement => {
-  const { checkedWbGeometryObjectRows, dispatchOperation, dispatchNavigation } = props;
+  const { checkedWbGeometryObjectRows, dispatchOperation, dispatchNavigation, servers } = props;
 
   const onClickModify = async () => {
     const mode = PropertiesModalMode.Edit;
@@ -83,6 +84,26 @@ const WbGeometryObjectContextMenu = (props: WbGeometryObjectContextMenuProps): R
           <StyledIcon name="deleteToTrash" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Delete</Typography>
         </MenuItem>,
+        <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedWbGeometryObjectRows.length !== 1}>
+          {servers.map((server: Server) => (
+            <MenuItem
+              key={server.name}
+              onClick={() =>
+                onClickShowOnServer(
+                  dispatchOperation,
+                  server,
+                  checkedWbGeometryObjectRows[0].wellUid,
+                  checkedWbGeometryObjectRows[0].wellboreUid,
+                  checkedWbGeometryObjectRows[0].uid,
+                  "wbGeometryUid"
+                )
+              }
+              disabled={checkedWbGeometryObjectRows.length !== 1}
+            >
+              <Typography color={"primary"}>{server.name}</Typography>
+            </MenuItem>
+          ))}
+        </NestedMenuItem>,
         <Divider key={"divider"} />,
         <MenuItem key={"properties"} onClick={onClickModify} disabled={checkedWbGeometryObjectRows.length !== 1}>
           <StyledIcon name="settings" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometryContextMenu.tsx
@@ -88,16 +88,7 @@ const WbGeometryObjectContextMenu = (props: WbGeometryObjectContextMenuProps): R
           {servers.map((server: Server) => (
             <MenuItem
               key={server.name}
-              onClick={() =>
-                onClickShowOnServer(
-                  dispatchOperation,
-                  server,
-                  checkedWbGeometryObjectRows[0].wellUid,
-                  checkedWbGeometryObjectRows[0].wellboreUid,
-                  checkedWbGeometryObjectRows[0].uid,
-                  "wbGeometryUid"
-                )
-              }
+              onClick={() => onClickShowOnServer(dispatchOperation, server, checkedWbGeometryObjectRows[0], "wbGeometryUid")}
               disabled={checkedWbGeometryObjectRows.length !== 1}
             >
               <Typography color={"primary"}>{server.name}</Typography>

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -897,6 +897,7 @@ const selectTrajectoriesGroup = (state: NavigationState, { payload }: SelectTraj
 
 const selectTrajectory = (state: NavigationState, { payload }: SelectTrajectoryAction) => {
   const { well, wellbore, trajectory, trajectoryGroup } = payload;
+  const shouldExpandNode = shouldExpand(state.expandedTreeNodes, calculateTrajectoryGroupId(wellbore), calculateWellboreNodeId(wellbore));
   return {
     ...state,
     ...allDeselected,
@@ -906,7 +907,8 @@ const selectTrajectory = (state: NavigationState, { payload }: SelectTrajectoryA
     selectedTrajectoryGroup: trajectoryGroup,
     selectedTrajectory: trajectory,
     currentSelected: trajectory,
-    currentProperties: getObjectOnWellboreProperties(trajectory, ObjectType.Trajectory)
+    currentProperties: getObjectOnWellboreProperties(trajectory, ObjectType.Trajectory),
+    expandedTreeNodes: shouldExpandNode ? toggleTreeNode(state.expandedTreeNodes, calculateTrajectoryGroupId(wellbore)) : state.expandedTreeNodes
   };
 };
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-568

## Description
Implement show on server for every object.
Update the url when navigating for every object, and navigate on copied url.

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
