### PR TITLE
WE-570 dual securityscheme

### DIFF
--- a/Src/WitsmlExplorer.Api/Configuration/BasicCredentials.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/BasicCredentials.cs
@@ -5,9 +5,9 @@ namespace WitsmlExplorer.Api.Configuration
 {
     public class BasicCredentials : ICredentials
     {
-        public string UserId { get; }
-        public string Password { get; }
-
+        public string UserId { get; init; }
+        public string Password { get; init; }
+        internal BasicCredentials() { }
         public BasicCredentials(string base64EncodedString)
         {
             string credentialString = Encoding.UTF8.GetString(Convert.FromBase64String(base64EncodedString));
@@ -20,6 +20,10 @@ namespace WitsmlExplorer.Api.Configuration
         {
             UserId = username;
             Password = password;
+        }
+        public bool IsNullOrEmpty()
+        {
+            return string.IsNullOrEmpty(UserId) || string.IsNullOrEmpty(Password);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Configuration/ServerCredentials.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/ServerCredentials.cs
@@ -19,6 +19,10 @@ namespace WitsmlExplorer.Api.Configuration
         public string Host { get; init; }
         public string UserId { get; init; }
         public string Password { get; init; }
+        public bool IsNullOrEmpty()
+        {
+            return string.IsNullOrEmpty(Host) || string.IsNullOrEmpty(UserId) || string.IsNullOrEmpty(Password);
+        }
 
     }
 }

--- a/Src/WitsmlExplorer.Api/Configuration/ServerCredentials.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/ServerCredentials.cs
@@ -2,7 +2,7 @@ namespace WitsmlExplorer.Api.Configuration
 {
     public class ServerCredentials : ICredentials
     {
-        internal ServerCredentials() { }
+        public ServerCredentials() { }
 
         public ServerCredentials(string host, string userid, string password)
         {

--- a/Src/WitsmlExplorer.Api/Extensions/BuilderExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/BuilderExtensions.cs
@@ -2,7 +2,6 @@ using System;
 
 using Azure.Identity;
 
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 
 using WitsmlExplorer.Api.Configuration;
@@ -12,23 +11,6 @@ namespace WitsmlExplorer.Api.Extensions
 {
     public static class BuilderExtensions
     {
-        public static TBuilder SetupAuthorization<TBuilder>(this TBuilder builder, bool oAuth2Enabled) where TBuilder : IEndpointConventionBuilder
-        {
-            if (oAuth2Enabled)
-            {
-                builder.RequireAuthorization();
-            }
-            return builder;
-        }
-
-        public static TBuilder SetupAuthorization<TBuilder>(this TBuilder builder, bool oAuth2Enabled, params string[] policyNames) where TBuilder : IEndpointConventionBuilder
-        {
-            if (oAuth2Enabled)
-            {
-                builder.RequireAuthorization(policyNames);
-            }
-            return builder;
-        }
 
         public static IConfigurationBuilder AddAzureWitsmlServerCreds(this ConfigurationManager configuration)
         {

--- a/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
@@ -6,57 +6,60 @@ using Microsoft.AspNetCore.Routing;
 
 namespace WitsmlExplorer.Api.Extensions
 {
+
     public static class WebApplicationExtensions
     {
+        private static readonly string OAuth2Path = "/secure";
+        private static readonly string BasicPath = "/basic";
         public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
         {
             if (useOAuth2)
             {
-                endpoints.MapGet("/api2" + pattern, handler).RequireAuthorization();
+                endpoints.MapGet(OAuth2Path + pattern, handler).RequireAuthorization();
             }
-            endpoints.MapGet("api" + pattern, handler);
+            endpoints.MapGet(BasicPath + pattern, handler);
         }
 
         public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapGet("/api2" + pattern, handler).RequireAuthorization(policyNames);
+                endpoints.MapGet(OAuth2Path + pattern, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapGet("api" + pattern, handler);
+            endpoints.MapGet(BasicPath + pattern, handler);
         }
         public static void MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
         {
             if (useOAuth2)
             {
-                endpoints.MapPost("/api2" + pattern, handler).RequireAuthorization();
+                endpoints.MapPost(OAuth2Path + pattern, handler).RequireAuthorization();
             }
-            endpoints.MapPost("api" + pattern, handler);
+            endpoints.MapPost(BasicPath + pattern, handler);
         }
         public static void MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapPost("/api2" + pattern, handler).RequireAuthorization(policyNames);
+                endpoints.MapPost(OAuth2Path + pattern, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapPost("api" + pattern, handler);
+            endpoints.MapPost(BasicPath + pattern, handler);
         }
         public static void MapDelete(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapDelete("/api2" + pattern, handler).RequireAuthorization(policyNames);
+                endpoints.MapDelete(OAuth2Path + pattern, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapDelete("api" + pattern, handler);
+            endpoints.MapDelete(BasicPath + pattern, handler);
         }
 
         public static void MapMethods(this IEndpointRouteBuilder endpoints, string pattern, IEnumerable<string> httpMethods, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapMethods("/api2" + pattern, httpMethods, handler).RequireAuthorization(policyNames);
+                endpoints.MapMethods(OAuth2Path + pattern, httpMethods, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapMethods("api" + pattern, httpMethods, handler);
+            endpoints.MapMethods(BasicPath + pattern, httpMethods, handler);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+
+namespace WitsmlExplorer.Api.Extensions
+{
+    public static class WebApplicationExtensions
+    {
+        public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
+        {
+            if (useOAuth2)
+            {
+                endpoints.MapGet("/api2" + pattern, handler).RequireAuthorization();
+            }
+            endpoints.MapGet("api" + pattern, handler);
+        }
+
+        public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
+        {
+            if (useOAuth2)
+            {
+                endpoints.MapGet("/api2" + pattern, handler).RequireAuthorization(policyNames);
+            }
+            endpoints.MapGet("api" + pattern, handler);
+        }
+        public static void MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
+        {
+            if (useOAuth2)
+            {
+                endpoints.MapPost("/api2" + pattern, handler).RequireAuthorization();
+            }
+            endpoints.MapPost("api" + pattern, handler);
+        }
+        public static void MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
+        {
+            if (useOAuth2)
+            {
+                endpoints.MapPost("/api2" + pattern, handler).RequireAuthorization(policyNames);
+            }
+            endpoints.MapPost("api" + pattern, handler);
+        }
+        public static void MapDelete(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
+        {
+            if (useOAuth2)
+            {
+                endpoints.MapDelete("/api2" + pattern, handler).RequireAuthorization(policyNames);
+            }
+            endpoints.MapDelete("api" + pattern, handler);
+        }
+
+        public static void MapMethods(this IEndpointRouteBuilder endpoints, string pattern, IEnumerable<string> httpMethods, Delegate handler, bool useOAuth2, params string[] policyNames)
+        {
+            if (useOAuth2)
+            {
+                endpoints.MapMethods("/api2" + pattern, httpMethods, handler).RequireAuthorization(policyNames);
+            }
+            endpoints.MapMethods("api" + pattern, httpMethods, handler);
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
@@ -9,57 +9,74 @@ namespace WitsmlExplorer.Api.Extensions
 
     public static class WebApplicationExtensions
     {
-        private static readonly string OAuth2Path = "/secure";
-        private static readonly string BasicPath = "/api";
+        private static readonly string ApiPath = "/api";
         public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
         {
             if (useOAuth2)
             {
-                endpoints.MapGet(OAuth2Path + pattern, handler).RequireAuthorization();
+                endpoints.MapGet(ApiPath + pattern, handler).RequireAuthorization();
             }
-            endpoints.MapGet(BasicPath + pattern, handler);
+            else
+            {
+                endpoints.MapGet(ApiPath + pattern, handler);
+            }
         }
 
         public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapGet(OAuth2Path + pattern, handler).RequireAuthorization(policyNames);
+                endpoints.MapGet(ApiPath + pattern, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapGet(BasicPath + pattern, handler);
+            else
+            {
+                endpoints.MapGet(ApiPath + pattern, handler);
+            }
         }
         public static void MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
         {
             if (useOAuth2)
             {
-                endpoints.MapPost(OAuth2Path + pattern, handler).RequireAuthorization();
+                endpoints.MapPost(ApiPath + pattern, handler).RequireAuthorization();
             }
-            endpoints.MapPost(BasicPath + pattern, handler);
+            else
+            {
+                endpoints.MapPost(ApiPath + pattern, handler);
+            }
         }
         public static void MapPost(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapPost(OAuth2Path + pattern, handler).RequireAuthorization(policyNames);
+                endpoints.MapPost(ApiPath + pattern, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapPost(BasicPath + pattern, handler);
+            else
+            {
+                endpoints.MapPost(ApiPath + pattern, handler);
+            }
         }
         public static void MapDelete(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapDelete(OAuth2Path + pattern, handler).RequireAuthorization(policyNames);
+                endpoints.MapDelete(ApiPath + pattern, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapDelete(BasicPath + pattern, handler);
+            else
+            {
+                endpoints.MapDelete(ApiPath + pattern, handler);
+            }
         }
 
         public static void MapMethods(this IEndpointRouteBuilder endpoints, string pattern, IEnumerable<string> httpMethods, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapMethods(OAuth2Path + pattern, httpMethods, handler).RequireAuthorization(policyNames);
+                endpoints.MapMethods(ApiPath + pattern, httpMethods, handler).RequireAuthorization(policyNames);
             }
-            endpoints.MapMethods(BasicPath + pattern, httpMethods, handler);
+            else
+            {
+                endpoints.MapMethods(ApiPath + pattern, httpMethods, handler);
+            }
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
@@ -10,7 +10,7 @@ namespace WitsmlExplorer.Api.Extensions
     public static class WebApplicationExtensions
     {
         private static readonly string OAuth2Path = "/secure";
-        private static readonly string BasicPath = "/basic";
+        private static readonly string BasicPath = "/api";
         public static void MapGet(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2)
         {
             if (useOAuth2)

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -11,7 +11,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
     {
         public static async Task<IResult> Authorize(Server witsmlServer, ICredentialsService credentialsService)
         {
-            return Results.Ok(await credentialsService.BasicAuthorization(witsmlServer.Url));
+            return Results.Ok(await credentialsService.ProtectBasicAuthorization(witsmlServer.Url));
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,17 +1,17 @@
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
-using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandlers
 {
     public static class AuthorizeHandler
     {
-        public static async Task<IResult> Authorize(Server witsmlServer, ICredentialsService credentialsService)
+        public static async Task<IResult> Authorize([FromServices] ICredentialsService credentialsService)
         {
-            return Results.Ok(await credentialsService.ProtectBasicAuthorization(witsmlServer.Url));
+            return Results.Ok(await credentialsService.ProtectBasicAuthorization());
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -15,55 +15,50 @@ namespace WitsmlExplorer.Api
         {
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
 
-            app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers).SetupAuthorization(useOAuth2);
-            app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer).SetupAuthorization(useOAuth2, AuthorizationPolicyRoles.ADMIN);
-            app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer).SetupAuthorization(useOAuth2, AuthorizationPolicyRoles.ADMIN);
-            app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer).SetupAuthorization(useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers, useOAuth2);
+            app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
 
-            app.MapGet("/api/wells", WellHandler.GetAllWells).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells", WellHandler.GetAllWells, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore).SetupAuthorization(useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo).SetupAuthorization(useOAuth2);
-            app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo, useOAuth2);
+            app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations).SetupAuthorization(useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory, useOAuth2);
+            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations, useOAuth2);
 
-            app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob).SetupAuthorization(useOAuth2);
-            app.MapPost("/api/jobs/jobinfos", JobHandler.GetJobInfosById).SetupAuthorization(useOAuth2);
-            app.MapGet("/api/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser).SetupAuthorization(useOAuth2);
+            app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
+            app.MapPost("/api/jobs/jobinfos", JobHandler.GetJobInfosById, useOAuth2);
+            app.MapGet("/api/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
 
-            app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize).SetupAuthorization(useOAuth2);
-
-            if (app.Environment.EnvironmentName == "Development")
-            {
-                app.MapFallback(() => Results.Redirect("/swagger"));
-            }
+            app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
 
         }
     }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -15,50 +15,50 @@ namespace WitsmlExplorer.Api
         {
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
 
-            app.MapGet("/api/witsml-servers", WitsmlServerHandler.GetWitsmlServers, useOAuth2);
-            app.MapPost("/api/witsml-servers", WitsmlServerHandler.CreateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
-            app.MapMethods("/api/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
-            app.MapDelete("/api/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapGet("/witsml-servers", WitsmlServerHandler.GetWitsmlServers, useOAuth2);
+            app.MapPost("/witsml-servers", WitsmlServerHandler.CreateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapMethods("/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapDelete("/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
 
-            app.MapGet("/api/wells", WellHandler.GetAllWells, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}", WellHandler.GetWell, useOAuth2);
+            app.MapGet("/wells", WellHandler.GetAllWells, useOAuth2);
+            app.MapGet("/wells/{wellUid}", WellHandler.GetWell, useOAuth2);
 
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/wbGeometrys", WbGeometryHandler.GetWbGeometries, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/risks", RiskHandler.GetRisks, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/tubulars", TubularHandler.GetTubulars, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}", TubularHandler.GetTubular, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/tubulars/{tubularUid}/tubularcomponents", TubularHandler.GetTubularComponents, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/messages", MessageHandler.GetMessages, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/messages/{messageUid}", MessageHandler.GetMessage, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/bharuns", BhaRunHandler.GetBhaRuns, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/bharuns/{bhaRunUid}", BhaRunHandler.GetBhaRun, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/rigs", RigHandler.GetRigs, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/rigs/{rigUid}", RigHandler.GetRig, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo, useOAuth2);
-            app.MapPost("/api/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/logs", LogHandler.GetLogs, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}", LogHandler.GetLog, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logcurveinfo", LogHandler.GetLogCurveInfo, useOAuth2);
+            app.MapPost("/wells/{wellUid}/wellbores/{wellboreUid}/logs/{logUid}/logdata", LogHandler.GetLogData, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs", MudLogHandler.GetMudLogs, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/mudlogs/{mudlogUid}", MudLogHandler.GetMudLog, useOAuth2);
 
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory, useOAuth2);
-            app.MapGet("/api/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/trajectories", TrajectoryHandler.GetTrajectories, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}", TrajectoryHandler.GetTrajectory, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations, useOAuth2);
 
-            app.MapPost("/api/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
-            app.MapPost("/api/jobs/jobinfos", JobHandler.GetJobInfosById, useOAuth2);
-            app.MapGet("/api/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
+            app.MapPost("/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
+            app.MapPost("/jobs/jobinfos", JobHandler.GetJobInfosById, useOAuth2);
+            app.MapGet("/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
 
-            app.MapPost("/api/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
+            app.MapPost("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
 
         }
     }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -58,7 +58,7 @@ namespace WitsmlExplorer.Api
             app.MapPost("/jobs/jobinfos", JobHandler.GetJobInfosById, useOAuth2);
             app.MapGet("/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
 
-            app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
+            app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, false);
 
         }
     }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -58,7 +58,7 @@ namespace WitsmlExplorer.Api
             app.MapPost("/jobs/jobinfos", JobHandler.GetJobInfosById, useOAuth2);
             app.MapGet("/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
 
-            app.MapPost("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
+            app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
 
         }
     }

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -49,7 +49,7 @@ namespace WitsmlExplorer.Api.Services
             _allServers = _witsmlServerRepository.GetDocumentsAsync();
         }
 
-        public async Task<string> ProtectBasicAuthorization(Uri serverUrl)
+        public async Task<string> ProtectBasicAuthorization()
         {
             if (_httpContextAccessor.HttpContext == null) { return ""; }
 

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -30,6 +30,7 @@ namespace WitsmlExplorer.Api.Services
         private readonly WitsmlClientCapabilities _clientCapabilities;
         private readonly IWitsmlSystemCredentials _witsmlServerCredentials;
         private readonly IDocumentRepository<Server, Guid> _witsmlServerRepository;
+        private readonly Task<IEnumerable<Server>> _allServers;
         private const string AuthorizationHeader = "Authorization";
 
         public CredentialsService(
@@ -46,6 +47,7 @@ namespace WitsmlExplorer.Api.Services
             _clientCapabilities = clientCapabilities.Value ?? throw new ArgumentException("Missing WitsmlClientCapabilities");
             _witsmlServerCredentials = witsmlServerCredentials ?? throw new ArgumentException("Missing WitsmlServerCredentials");
             _witsmlServerRepository = witsmlServerRepository ?? throw new ArgumentException("Missing WitsmlServerRepository");
+            _allServers = _witsmlServerRepository.GetDocumentsAsync();
         }
 
         public async Task<string> BasicAuthorization(Uri serverUrl)
@@ -63,21 +65,22 @@ namespace WitsmlExplorer.Api.Services
             return protectedPayload;
         }
 
-        public string Decrypt(ICredentials credentials)
+        public string Decrypt(ServerCredentials credentials)
         {
             return _dataProtector.Unprotect(credentials.Password);
         }
 
-        public bool VerifyIsEncrypted(ICredentials credentials)
+
+        public string Decrypt(string inputString)
         {
+
             try
             {
-                Decrypt(credentials);
-                return true;
+                return _dataProtector.Unprotect(inputString);
             }
             catch
             {
-                return false;
+                return null;
             }
         }
 
@@ -86,7 +89,7 @@ namespace WitsmlExplorer.Api.Services
             try
             {
                 IHeaderDictionary headers = httpRequest.Headers;
-                List<ICredentials> credentialsList = await GetCredentials(headers);
+                List<ServerCredentials> credentialsList = await GetCredentialsFromHeaders(headers);
                 StringValues server = headers["Witsml-ServerUrl"];
                 ServerCredentials serverCreds = new(server, credentialsList[0].UserId, Decrypt(credentialsList[0]));
                 await VerifyCredentials(serverCreds);
@@ -99,9 +102,9 @@ namespace WitsmlExplorer.Api.Services
             return true;
         }
 
-        public Task<List<ICredentials>> GetCredentials(IHeaderDictionary headers)
+        public Task<List<ServerCredentials>> GetCredentialsFromHeaders(IHeaderDictionary headers)
         {
-            Task<List<ICredentials>> credentials = Task.FromResult(new List<ICredentials>());
+            Task<List<ServerCredentials>> credentials = Task.FromResult(new List<ServerCredentials>());
             string scheme = headers["Authorization"].ToString().Split()[0];
             if (string.IsNullOrEmpty(scheme)) { return credentials; }
 
@@ -134,10 +137,21 @@ namespace WitsmlExplorer.Api.Services
             }
             return result;
         }
-
-        private static List<ICredentials> ParseBasicAuthorization(string base64Data, string sourceServer, string server)
+        private async Task<bool> UserHasRoleForHost(string[] roles, string host)
         {
-            List<ICredentials> credentials = new();
+            bool result = true;
+            IEnumerable<Server> allServers = await _allServers;
+
+            bool systemCredsExists = _witsmlServerCredentials.WitsmlCreds.Any(n => n.Host == host);
+            IEnumerable<Server> hostServer = allServers.Where(n => n.Url.ToString() == host);
+            bool validRole = hostServer.Any(n => roles.Contains(n.Role));
+            result &= systemCredsExists & validRole;
+
+            return result;
+        }
+        private static List<ServerCredentials> ParseBasicAuthorization(string base64Data, string sourceServer, string server)
+        {
+            List<ServerCredentials> credentials = new();
             string credentialString = Encoding.UTF8.GetString(Convert.FromBase64String(base64Data));
             string[] usernamesAndPasswords = credentialString.Split(':');
             credentials.Add(new ServerCredentials(server, usernamesAndPasswords[0], usernamesAndPasswords[1]));
@@ -148,22 +162,64 @@ namespace WitsmlExplorer.Api.Services
             return credentials;
         }
 
-        private async Task<List<ICredentials>> ParseBearerAuthorization(string base64Data, string sourceServer, string server)
+        public async Task<List<ServerCredentials>> ParseBearerAuthorization(string token, string sourceServer, string targetServer)
         {
-            List<ICredentials> credentials = new();
+            List<ServerCredentials> credentials = new();
             JwtSecurityTokenHandler handler = new();
-            JwtSecurityToken jwt = handler.ReadJwtToken(base64Data);
+            JwtSecurityToken jwt = handler.ReadJwtToken(token);
             string[] roles = jwt.Claims.Where(n => n.Type == "roles").Select(n => n.Value).ToArray();
             _logger.LogDebug("{roles}", string.Join(",", roles));
-            if (await HasUserRoleForHosts(roles, new string[] { server, sourceServer }))
+            if (await HasUserRoleForHosts(roles, new string[] { targetServer, sourceServer }))
             {
-                ServerCredentials creds = _witsmlServerCredentials.WitsmlCreds.Single(n => n.Host == server);
-                credentials.Add(new ServerCredentials(server, creds.UserId, creds.Password));
+                ServerCredentials creds = _witsmlServerCredentials.WitsmlCreds.Single(n => n.Host == targetServer);
+                credentials.Add(new ServerCredentials(targetServer, creds.UserId, creds.Password));
             }
 
             return credentials;
         }
 
+        /// <summary>
+        /// 1. Server input has been parsed from HTTP Headers "Witsml-ServerUrl" or "Witsml-Source-ServerUrl" and might contain b64 encoded Basic auth
+        /// 2. Token will always be JWT token and should have <code>roles</code>
+        /// 3. Prefer attached basic credentials over system credentials fetched from keyvault.
+        /// </summary>
+        public async Task<ServerCredentials> GetCredsWithToken(string token, string serverHeader)
+        {
+            ServerCredentials result = GetBasicCreds(serverHeader);
+            if (result == null)
+            {
+                JwtSecurityTokenHandler handler = new();
+                JwtSecurityToken jwt = handler.ReadJwtToken(token);
+                string[] userRoles = jwt.Claims.Where(n => n.Type == "roles").Select(n => n.Value).ToArray();
+                _logger.LogDebug("User roles in JWT: {roles}", string.Join(",", userRoles));
+                if (await UserHasRoleForHost(userRoles, serverHeader))
+                {
+                    return _witsmlServerCredentials.WitsmlCreds.Single(n => n.Host == serverHeader);
+                }
+
+            }
+            return result;
+        }
+
+        public ServerCredentials GetBasicCreds(string serverHeader)
+        {
+            BasicCredentials basic = new(serverHeader.Split("@")[1]);
+            if (serverHeader.Split().Length > 1 && Decrypt(basic?.Password) != null)
+            {
+                return new ServerCredentials()
+                {
+                    Host = serverHeader.Split("@")[1],
+                    UserId = basic.UserId,
+                    Password = Decrypt(basic.Password)
+                };
+            }
+            return null;
+        }
+
+        public bool VerifyIsEncrypted(ServerCredentials credentials)
+        {
+            throw new NotImplementedException();
+        }
     }
 
 }

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -31,7 +31,6 @@ namespace WitsmlExplorer.Api.Services
         private readonly IWitsmlSystemCredentials _witsmlServerCredentials;
         private readonly IDocumentRepository<Server, Guid> _witsmlServerRepository;
         private readonly Task<IEnumerable<Server>> _allServers;
-        private const string AuthorizationHeader = "Authorization";
 
         public CredentialsService(
             IDataProtectionProvider dataProtectionProvider,
@@ -55,8 +54,8 @@ namespace WitsmlExplorer.Api.Services
             if (_httpContextAccessor.HttpContext == null) { return ""; }
 
             IHeaderDictionary headers = _httpContextAccessor.HttpContext.Request.Headers;
-            string base64EncodedCredentials = headers[AuthorizationHeader].ToString()["Basic ".Length..].Trim();
-            ServerCredentials credentials = new(serverUrl.AbsoluteUri, new BasicCredentials(base64EncodedCredentials));
+            string witsmlServerWithCreds = headers[WitsmlClientProvider.WitsmlServerUrlHeader];
+            ServerCredentials credentials = this.GetBasicCredsFromHeader(witsmlServerWithCreds);
 
             await VerifyCredentials(credentials);
 

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -10,12 +10,11 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface ICredentialsService
     {
-        public Task<string> BasicAuthorization(Uri serverUrl);
-        public string Decrypt(ServerCredentials credentials);
-        public bool VerifyIsEncrypted(ServerCredentials credentials);
+        public Task<string> ProtectBasicAuthorization(Uri serverUrl);
+
         public Task<bool> AuthorizeWithEncryptedPassword(HttpRequest httpRequest);
         public Task<List<ServerCredentials>> GetCredentialsFromHeaders(IHeaderDictionary headers);
         public Task<ServerCredentials> GetCredsWithToken(string token, string serverHeader);
-        public ServerCredentials GetBasicCreds(string serverHeader);
+        public ServerCredentials GetBasicCredsFromHeader(string serverHeader);
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -10,7 +10,7 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface ICredentialsService
     {
-        public Task<string> ProtectBasicAuthorization(Uri serverUrl);
+        public Task<string> ProtectBasicAuthorization();
 
         public Task<bool> AuthorizeWithEncryptedPassword(HttpRequest httpRequest);
         public Task<List<ServerCredentials>> GetCredentialsFromHeaders(IHeaderDictionary headers);

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -11,9 +11,11 @@ namespace WitsmlExplorer.Api.Services
     public interface ICredentialsService
     {
         public Task<string> BasicAuthorization(Uri serverUrl);
-        public string Decrypt(ICredentials credentials);
-        public bool VerifyIsEncrypted(ICredentials credentials);
+        public string Decrypt(ServerCredentials credentials);
+        public bool VerifyIsEncrypted(ServerCredentials credentials);
         public Task<bool> AuthorizeWithEncryptedPassword(HttpRequest httpRequest);
-        public Task<List<ICredentials>> GetCredentials(IHeaderDictionary headers);
+        public Task<List<ServerCredentials>> GetCredentialsFromHeaders(IHeaderDictionary headers);
+        public Task<ServerCredentials> GetCredsWithToken(string token, string serverHeader);
+        public ServerCredentials GetBasicCreds(string serverHeader);
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -57,8 +57,8 @@ namespace WitsmlExplorer.Api.Services
             // Use b64 encoded Basic creds
             else if (authorizationHeader?.Count == 0 && targetServerHeader?.Count > 0)
             {
-                _targetCreds = credentialsService.GetBasicCreds(targetServerHeader.ToString());
-                _sourceCreds = credentialsService.GetBasicCreds(sourceServerHeader.ToString());
+                _targetCreds = credentialsService.GetBasicCredsFromHeader(targetServerHeader.ToString());
+                _sourceCreds = credentialsService.GetBasicCredsFromHeader(sourceServerHeader.ToString());
             }
 
             _witsmlClient = !_targetCreds.IsNullOrEmpty() ? new WitsmlClient(_targetCreds.Host, _targetCreds.UserId, _targetCreds.Password, _clientCapabilities, null, logQueries) : null;

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -13,7 +13,7 @@ namespace WitsmlExplorer.Api.Swagger
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            List<string> emptyHeader = new() { typeof(HttpHandlers.AuthorizeHandler).ToString(), typeof(HttpHandlers.WitsmlServerHandler).ToString() };
+            List<string> emptyHeader = new() { typeof(HttpHandlers.WitsmlServerHandler).ToString() };
             List<string> witsmlSourceHeader = new() { typeof(HttpHandlers.JobHandler).ToString() };
             if (operation.Parameters == null)
             {

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text;
+
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using Witsml.Data;
+
+using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Repositories;
+using WitsmlExplorer.Api.Services;
+
+using Xunit;
+namespace WitsmlExplorer.Api.Tests.Services
+{
+    public class CredentialsTest
+    {
+        private readonly CredentialsService _credentialsService;
+        public CredentialsTest()
+        {
+            Mock<IOptions<WitsmlClientCapabilities>> clientCapabilitiesMock = new();
+            clientCapabilitiesMock.Setup(ap => ap.Value).Returns(new WitsmlClientCapabilities());
+            _credentialsService = new CredentialsService(
+                DataProtectionProvider.Create("Mock"),
+                new Mock<IHttpContextAccessor>().Object,
+                clientCapabilitiesMock.Object,
+                new Mock<IWitsmlSystemCredentials>().Object,
+                new Mock<IDocumentRepository<Server, Guid>>().Object,
+                new Mock<ILogger<CredentialsService>>().Object);
+        }
+
+        [Fact]
+        public void GetBasicCredsFromHeader_ValidInput_CorrectlyParsed()
+        {
+            ServerCredentials scInput = new()
+            {
+                Host = "http://validstring.com",
+                UserId = "username",
+                Password = "password"
+            };
+
+            string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(scInput.UserId + ":" + scInput.Password));
+            string input = b64Creds + "@" + scInput.Host;
+            ServerCredentials serverCreds = _credentialsService.GetBasicCredsFromHeader(input);
+            Assert.Equal(scInput, serverCreds);
+        }
+
+        [Fact]
+        public void GetBasicCredsFromHeader_NoPassword_IsNullOrEmpty()
+        {
+            ServerCredentials scInput = new()
+            {
+                Host = "http://validstring.com",
+                UserId = "username",
+                Password = null
+            };
+
+            string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(scInput.UserId + ":" + scInput.Password));
+            string input = b64Creds + "@" + scInput.Host;
+            ServerCredentials serverCreds = _credentialsService.GetBasicCredsFromHeader(input);
+            Assert.True(serverCreds.IsNullOrEmpty());
+        }
+    }
+}

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsTests.cs
@@ -47,7 +47,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(scInput.UserId + ":" + scInput.Password));
             string input = b64Creds + "@" + scInput.Host;
             ServerCredentials serverCreds = _credentialsService.GetBasicCredsFromHeader(input);
-            Assert.Equal(scInput, serverCreds);
+            Assert.Equivalent(scInput, serverCreds);
         }
 
         [Fact]


### PR DESCRIPTION
## Fixes
This pull request fixes WE-570

## Description
Prepare dual use of both Basic and OAuth2 authentication flows


## Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update

## Impacted Areas in Application
Api

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests

## Further comments
This PR is needed for WE-546 and will break current authentication functionality until WE-546 has been merged and should be done at the same time preferably