### PR TITLE
WE-576 Allow for the use of Basic auth when Msal is enabled

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
@@ -40,8 +40,8 @@ export const onClickCopyCurveToServer = async (targetServer: Server, sourceServe
     }
   };
 
-  const hasPassword = CredentialsService.hasPasswordForServer(targetServer);
-  if (!hasPassword) {
+  const isAuthorized = CredentialsService.isAuthorizedForServer(targetServer);
+  if (!isAuthorized) {
     const message = `You are trying to copy an object to a server that you are not logged in to. Please provide username and password for ${targetServer.name}.`;
     showCredentialsModal(targetServer, dispatchOperation, () => onCredentials(), message);
   } else {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyLogToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyLogToServer.tsx
@@ -47,8 +47,8 @@ export const onClickCopyLogToServer = async (targetServer: Server, sourceServer:
     }
   };
 
-  const hasPassword = CredentialsService.hasPasswordForServer(targetServer);
-  if (!hasPassword) {
+  const isAuthorized = CredentialsService.isAuthorizedForServer(targetServer);
+  if (!isAuthorized) {
     const message = `You are trying to copy an object to a server that you are not logged in to. Please provide username and password for ${targetServer.name}.`;
     showCredentialsModal(targetServer, dispatchOperation, () => onCredentials(), message);
   } else {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
@@ -12,8 +12,8 @@ export const onClickPaste = async (servers: Server[], serverUrl: string, dispatc
   const sourceServer = servers.find((server) => server.url === serverUrl);
   if (sourceServer !== null) {
     CredentialsService.setSourceServer(sourceServer);
-    const hasPassword = CredentialsService.hasPasswordForServer(sourceServer);
-    if (!hasPassword) {
+    const isAuthorized = CredentialsService.isAuthorizedForServer(sourceServer);
+    if (!isAuthorized) {
       const message = `You are trying to paste an object from a server that you are not logged in to. Please provide username and password for ${sourceServer.name}.`;
       showCredentialsModal(sourceServer, dispatchOperation, () => orderCopyJob(), message);
     } else {

--- a/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
@@ -21,7 +21,7 @@ const RefreshHandler = (): React.ReactElement => {
 
   useEffect(() => {
     const unsubscribe = NotificationService.Instance.refreshDispatcher.subscribe(async (refreshAction) => {
-      const loggedIn = CredentialsService.hasPasswordForServer(navigationState.selectedServer);
+      const loggedIn = CredentialsService.isAuthorizedForServer(navigationState.selectedServer);
       const shouldTryRefresh = refreshAction?.serverUrl.toString() === navigationState.selectedServer?.url && loggedIn;
       if (!shouldTryRefresh) {
         return;

--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -70,7 +70,7 @@ const Routing = (): React.ReactElement => {
   const [queryParamsFromUrl, setQueryParamsFromUrl] = useState<QueryParams>(null);
   const [currentQueryParams, setCurrentQueryParams] = useState<QueryParams>(null);
   useEffect(() => {
-    if (isSyncingUrlAndState && (router.asPath === "/" || router.query?.serverUrl)) {
+    if (isSyncingUrlAndState) {
       setQueryParamsFromUrl(getQueryParamsFromUrl(router));
       setCurrentQueryParams(getQueryParamsFromState(navigationState));
     }
@@ -276,13 +276,13 @@ const Routing = (): React.ReactElement => {
 };
 
 const isQueryParamsEqual = (urlQp: QueryParams, stateQp: QueryParams): boolean => {
-  let property: keyof QueryParams;
-  for (property in urlQp) {
-    if (urlQp[property] !== stateQp[property]) {
-      return false;
-    }
+  if (Object.keys(urlQp).length !== Object.keys(urlQp).length) {
+    return false;
   }
-  return true;
+
+  return (Object.keys(urlQp) as (keyof typeof urlQp)[]).every((key) => {
+    return Object.prototype.hasOwnProperty.call(stateQp, key) && urlQp[key] === stateQp[key];
+  });
 };
 
 const getQueryParamsFromState = (state: NavigationState): QueryParams => {

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -65,6 +65,8 @@ export const getAccountInfo = (): AccountInfo | null => {
   return activeAccount;
 };
 
+export const getUserAppRoles = (): string[] => getAccountInfo()?.idTokenClaims?.roles ?? [];
+
 export async function signOut(): Promise<void> {
   type TokenClaims = {
     login_hint: string;


### PR DESCRIPTION
## Description
Use Basic auth when Msal is enabled, but the server is Basic or the user does not have the specified OAuth role.
Change CredentialsService.hasPasswordForServer to isAuthorizedForServer to incorporate that.
Fix (hopefully) snyk warning in Routing.isQueryParamsEqual.
Adjust onCurrentLoginStateChange in ServerManager to allow Basic servers.
Adjust Routing to properly check syncing state.
Make ServerManager check for authentication state to get the server list when authentication is finally done.

## Type of change

* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [ ] Code follows the style guidelines
* [ ] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
onCurrentLoginStateChange() has become somewhat spaghettified and should probably be cleaned up, together with related logic of _onCredentialStateChanged dispatches.
