### PR TITLE
WE-559 Alert on failing to connect to WITSML Server with OAuth

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
@@ -19,7 +19,7 @@ const Alerts = (): React.ReactElement => {
         setAlert("Lost connection to notifications service. Please wait for reconnection or refresh browser");
       }
     });
-    const unsubscribeOnJobFinished = NotificationService.Instance.alertDispatcher.subscribe((notification) => {
+    const unsubscribeOnJobFinished = NotificationService.Instance.alertDispatcherAsEvent.subscribe((notification) => {
       const shouldNotify = notification.serverUrl.toString() === navigationState.selectedServer?.url;
       if (!shouldNotify) {
         return;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -44,7 +44,7 @@ export const JobsView = (): React.ReactElement => {
       }
     };
     const unsubscribeOnSnackbar = NotificationService.Instance.snackbarDispatcherAsEvent.subscribe(eventHandler);
-    const unsubscribeOnAlert = NotificationService.Instance.alertDispatcher.subscribe(eventHandler);
+    const unsubscribeOnAlert = NotificationService.Instance.alertDispatcherAsEvent.subscribe(eventHandler);
 
     return function cleanup() {
       unsubscribeOnSnackbar();

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
@@ -13,6 +13,7 @@ import OperationType from "../../contexts/operationType";
 import { emptyServer, Server } from "../../models/server";
 import { getUserAppRoles, msalEnabled, SecurityScheme } from "../../msal/MsalAuthProvider";
 import CredentialsService from "../../services/credentialsService";
+import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
 import WellService from "../../services/wellService";
 import { colors } from "../../styles/Colors";
@@ -48,7 +49,11 @@ const ServerManager = (): React.ReactElement => {
             dispatchNavigation({ type: ModificationType.UpdateWells, payload: { wells: wells } });
           }
         } catch (error) {
-          // Show error in Alert.tsx
+          NotificationService.Instance.alertDispatcher.dispatch({
+            serverUrl: new URL(selectedServer.url),
+            message: error.message,
+            isSuccess: false
+          });
         }
       } else if (currentWitsmlLoginState.server) {
         const isLoggedInToSelectedServer = CredentialsService.isAuthorizedForServer(selectedServer);

--- a/Src/WitsmlExplorer.Frontend/services/notificationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/notificationService.ts
@@ -82,11 +82,15 @@ export default class NotificationService {
     return this._snackbarDispatcher;
   }
 
+  public get alertDispatcher(): SimpleEventDispatcher<Notification> {
+    return this._alertDispatcher;
+  }
+
   public get snackbarDispatcherAsEvent(): ISimpleEvent<Notification> {
     return this._snackbarDispatcher.asEvent();
   }
 
-  public get alertDispatcher(): ISimpleEvent<Notification> {
+  public get alertDispatcherAsEvent(): ISimpleEvent<Notification> {
     return this._alertDispatcher.asEvent();
   }
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-559

## Description
Show an alert in frontend when failing to retrieve wells from a server with OAuth scheme.

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
