### PR TITLE
WE-573 Rework job routes to work with both auth methods

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -3,9 +3,10 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Configuration;
 
 using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
@@ -15,25 +16,27 @@ namespace WitsmlExplorer.Api.HttpHandlers
     public static class JobHandler
     {
         [Produces(typeof(string))]
-        public static async Task<IResult> CreateJob(JobType jobType, HttpRequest httpRequest, IJobService jobService)
+        public static async Task<IResult> CreateJob(JobType jobType, HttpRequest httpRequest, IJobService jobService, ICredentialsService credentialsService)
         {
-            IHeaderDictionary headers = httpRequest.Headers;
-            StringValues sourceServer = headers[WitsmlClientProvider.WitsmlTargetServerHeader];
-            StringValues targetServer = headers[WitsmlClientProvider.WitsmlTargetServerHeader];
-            string targetServerString = targetServer.ToString();
-            BasicCredentials basic = targetServerString.Split("@").Length == 2 ? new(targetServerString.Split("@")[0]) : new BasicCredentials();
-            return Results.Ok(await jobService.CreateJob(jobType, basic.UserId ?? "unknown", sourceServer, targetServer, httpRequest.Body));
+            ServerCredentials witsmlTarget = httpRequest.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
+            ServerCredentials witsmlSource = httpRequest.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlSourceServerHeader, n => "");
+
+            (string username, string witsmlUsername) = await credentialsService.GetUsernames();
+
+            return Results.Ok(await jobService.CreateJob(jobType, username, witsmlUsername, witsmlSource.Host?.ToString(), witsmlTarget.Host?.ToString(), httpRequest.Body));
         }
 
         [Produces(typeof(IEnumerable<JobInfo>))]
-        public static IResult GetJobInfosById([FromBody] IEnumerable<string> ids, IJobCache jobCache)
+        public static IResult GetJobInfosByUser(string username, IJobCache jobCache, IConfiguration configuration, ICredentialsService credentialsService)
         {
-            return Results.Ok(jobCache.GetJobInfosById(ids));
-        }
-
-        [Produces(typeof(IEnumerable<JobInfo>))]
-        public static IResult GetJobInfosByUser(string username, IJobCache jobCache)
-        {
+            bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
+            if (!useOAuth2)
+            {
+                if (!credentialsService.ValidEncryptedBasicCredentials(WitsmlClientProvider.WitsmlTargetServerHeader))
+                {
+                    return Results.Unauthorized();
+                }
+            }
             return Results.Ok(jobCache.GetJobInfosByUser(username));
         }
 

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -20,10 +20,15 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
             ServerCredentials witsmlTarget = httpRequest.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
             ServerCredentials witsmlSource = httpRequest.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlSourceServerHeader, n => "");
-
             (string username, string witsmlUsername) = await credentialsService.GetUsernames();
-
-            return Results.Ok(await jobService.CreateJob(jobType, username, witsmlUsername, witsmlSource.Host?.ToString(), witsmlTarget.Host?.ToString(), httpRequest.Body));
+            JobInfo jobInfo = new()
+            {
+                Username = username,
+                WitsmlUsername = witsmlUsername,
+                SourceServer = witsmlSource.Host?.ToString(),
+                TargetServer = witsmlTarget.Host?.ToString()
+            };
+            return Results.Ok(await jobService.CreateJob(jobType, jobInfo, httpRequest.Body));
         }
 
         [Produces(typeof(IEnumerable<JobInfo>))]

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
         }
 
         [Produces(typeof(IEnumerable<JobInfo>))]
-        public static IResult GetJobInfosByUser(string username, IJobCache jobCache, IConfiguration configuration, ICredentialsService credentialsService)
+        public static async Task<IResult> GetJobInfosByUser(string polledUser, IJobCache jobCache, IConfiguration configuration, ICredentialsService credentialsService)
         {
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
             if (!useOAuth2)
@@ -42,7 +42,13 @@ namespace WitsmlExplorer.Api.HttpHandlers
                     return Results.Unauthorized();
                 }
             }
-            return Results.Ok(jobCache.GetJobInfosByUser(username));
+
+            (string username, _) = await credentialsService.GetUsernames();
+            if (polledUser != username)
+            {
+                return Results.Unauthorized();
+            }
+            return Results.Ok(jobCache.GetJobInfosByUser(polledUser));
         }
 
     }

--- a/Src/WitsmlExplorer.Api/Jobs/Job.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/Job.cs
@@ -1,24 +1,21 @@
-using System.Text.Json.Serialization;
-
 namespace WitsmlExplorer.Api.Jobs
 {
-    public abstract record Job : IJsonOnDeserialized
+    public abstract record Job
     {
-
-        public Job()
-        {
-            JobInfo = new JobInfo();
-        }
+        private JobInfo _jobInfo;
 
         public abstract string Description();
 
-        public void OnDeserialized()
+        public JobInfo JobInfo
         {
-            JobInfo.Description = Description();
-            JobInfo.JobType = GetType().Name;
+            get => _jobInfo;
+            set
+            {
+                _jobInfo = value;
+                _jobInfo.Description = Description();
+                _jobInfo.JobType = GetType().Name;
+            }
         }
-
-        public JobInfo JobInfo { get; init; }
 
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
@@ -10,7 +10,7 @@ namespace WitsmlExplorer.Api.Jobs
         {
             Id = Guid.NewGuid().ToString();
             StartTime = DateTime.Now;
-            Status = JobStatus.Ordered;
+            Status = JobStatus.Started;
         }
 
         public string JobType { get; internal set; }
@@ -55,7 +55,6 @@ namespace WitsmlExplorer.Api.Jobs
 
     public enum JobStatus
     {
-        Ordered,
         Started,
         Finished,
         Failed

--- a/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
@@ -21,6 +21,8 @@ namespace WitsmlExplorer.Api.Jobs
 
         public string Username { get; set; }
 
+        public string WitsmlUsername { get; set; }
+
         public string SourceServer { get; set; }
 
         public string TargetServer { get; set; }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -55,7 +55,6 @@ namespace WitsmlExplorer.Api
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations, useOAuth2);
 
             app.MapPost("/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
-            app.MapPost("/jobs/jobinfos", JobHandler.GetJobInfosById, useOAuth2);
             app.MapGet("/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, false);

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -55,7 +55,7 @@ namespace WitsmlExplorer.Api
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/trajectories/{trajectoryUid}/trajectorystations", TrajectoryHandler.GetTrajectoryStations, useOAuth2);
 
             app.MapPost("/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
-            app.MapGet("/jobs/jobinfos/{username}", JobHandler.GetJobInfosByUser, useOAuth2);
+            app.MapGet("/jobs/jobinfos/{polledUser}", JobHandler.GetJobInfosByUser, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, false);
 

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -131,7 +131,7 @@ namespace WitsmlExplorer.Api.Services
             return Decrypt(creds.Password) != null;
         }
 
-        public async Task<(string Username, string WitsmlUsername)> GetUsernames()
+        public async Task<(string username, string witsmlUsername)> GetUsernames()
         {
             StringValues authorizationHeader = _httpContextAccessor.HttpContext.Request.Headers["Authorization"];
             string bearerToken = authorizationHeader.Count > 0 ? authorizationHeader.ToString().Split()[1] : null;

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -59,7 +59,7 @@ namespace WitsmlExplorer.Api.Services
         }
 
         /// <summary>
-        /// 1. Server input has been parsed from HTTP Headers "Witsml-ServerUrl" or "Witsml-Source-ServerUrl" and might contain b64 encoded Basic auth
+        /// 1. Server input has been parsed from HTTP Headers "WitsmlTargetServer" or "WitsmlSourceServer" and might contain b64 encoded Basic auth
         /// 2. Token will always be JWT token and should have <code>roles</code>
         /// 3. Prefer attached basic credentials over system credentials fetched from keyvault.
         /// </summary>

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -9,6 +9,6 @@ namespace WitsmlExplorer.Api.Services
         public Task<string> ProtectBasicAuthorization();
         public Task<ServerCredentials> GetCreds(string headerName, string token = null);
         public bool ValidEncryptedBasicCredentials(string headerName);
-        public Task<(string Username, string WitsmlUsername)> GetUsernames();
+        public Task<(string username, string witsmlUsername)> GetUsernames();
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -8,5 +8,7 @@ namespace WitsmlExplorer.Api.Services
     {
         public Task<string> ProtectBasicAuthorization();
         public Task<ServerCredentials> GetCreds(string headerName, string token = null);
+        public bool ValidEncryptedBasicCredentials(string headerName);
+        public Task<(string Username, string WitsmlUsername)> GetUsernames();
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -12,8 +12,7 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface IJobCache
     {
-        void CacheJob(JobInfo job);
-        IEnumerable<JobInfo> GetJobInfosById(IEnumerable<string> ids);
+        void CacheJob(JobInfo jobInfo);
         IEnumerable<JobInfo> GetJobInfosByUser(string username);
     }
 
@@ -46,11 +45,6 @@ namespace WitsmlExplorer.Api.Services
             }
         }
 
-        public IEnumerable<JobInfo> GetJobInfosById(IEnumerable<string> ids)
-        {
-            return ids.Select(id => _jobs.GetValueOrDefault(id)).Where(jobInfo => jobInfo != default);
-        }
-
         public IEnumerable<JobInfo> GetJobInfosByUser(string username)
         {
             return _jobs.Values.Where(job => job.Username == username);
@@ -61,7 +55,7 @@ namespace WitsmlExplorer.Api.Services
             _logger.LogInformation("JobCache start cleanup, jobs: {count}", _jobs.Count);
             int deleted = 0;
             int failed = 0;
-            foreach (var job in _jobs)
+            foreach (KeyValuePair<string, JobInfo> job in _jobs)
             {
                 if (DateTime.Now > job.Value.KillTime)
                 {

--- a/Src/WitsmlExplorer.Api/Services/JobService.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
+using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Workers;
 
@@ -11,7 +12,7 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface IJobService
     {
-        Task<string> CreateJob(JobType jobType, string username, string witsmlUsername, string sourceServer, string targetServer, Stream jobStream);
+        Task<string> CreateJob(JobType jobType, JobInfo jobInfo, Stream jobStream);
     }
 
     public class JobService : IJobService
@@ -27,7 +28,7 @@ namespace WitsmlExplorer.Api.Services
             _jobCache = jobCache;
         }
 
-        public async Task<string> CreateJob(JobType jobType, string username, string witsmlUsername, string sourceServer, string targetServer, Stream jobStream)
+        public async Task<string> CreateJob(JobType jobType, JobInfo jobInfo, Stream jobStream)
         {
             IWorker worker = _workers.FirstOrDefault(worker => worker.JobType == jobType);
             if (worker == null)
@@ -35,12 +36,9 @@ namespace WitsmlExplorer.Api.Services
                 throw new ArgumentOutOfRangeException(nameof(jobType), jobType, $"No worker setup to execute {jobType}");
             }
 
-            (Task<(WorkerResult, RefreshAction)> task, Jobs.Job job) = await worker.SetupWorker(jobStream);
+            (Task<(WorkerResult, RefreshAction)> task, Job job) = await worker.SetupWorker(jobStream);
+            job.JobInfo = jobInfo;
             _jobQueue.Enqueue(task);
-            job.JobInfo.Username = username;
-            job.JobInfo.WitsmlUsername = witsmlUsername;
-            job.JobInfo.SourceServer = sourceServer;
-            job.JobInfo.TargetServer = targetServer;
             _jobCache.CacheJob(job.JobInfo);
 
             return job.JobInfo.Id;

--- a/Src/WitsmlExplorer.Api/Services/JobService.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobService.cs
@@ -11,7 +11,7 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface IJobService
     {
-        Task<string> CreateJob(JobType jobType, string username, string sourceServer, string targetServer, Stream jobStream);
+        Task<string> CreateJob(JobType jobType, string username, string witsmlUsername, string sourceServer, string targetServer, Stream jobStream);
     }
 
     public class JobService : IJobService
@@ -27,7 +27,7 @@ namespace WitsmlExplorer.Api.Services
             _jobCache = jobCache;
         }
 
-        public async Task<string> CreateJob(JobType jobType, string username, string sourceServer, string targetServer, Stream jobStream)
+        public async Task<string> CreateJob(JobType jobType, string username, string witsmlUsername, string sourceServer, string targetServer, Stream jobStream)
         {
             IWorker worker = _workers.FirstOrDefault(worker => worker.JobType == jobType);
             if (worker == null)
@@ -38,8 +38,9 @@ namespace WitsmlExplorer.Api.Services
             (Task<(WorkerResult, RefreshAction)> task, Jobs.Job job) = await worker.SetupWorker(jobStream);
             _jobQueue.Enqueue(task);
             job.JobInfo.Username = username;
-            job.JobInfo.SourceServer = sourceServer?.Split("@").Length == 2 ? sourceServer.Split("@")[1] : sourceServer;
-            job.JobInfo.TargetServer = targetServer?.Split("@").Length == 2 ? targetServer.Split("@")[1] : targetServer;
+            job.JobInfo.WitsmlUsername = witsmlUsername;
+            job.JobInfo.SourceServer = sourceServer;
+            job.JobInfo.TargetServer = targetServer;
             _jobCache.CacheJob(job.JobInfo);
 
             return job.JobInfo.Id;

--- a/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers
         {
             try
             {
-                job.JobInfo.Status = JobStatus.Started;
+                await Task.Delay(1);
                 (WorkerResult WorkerResult, RefreshAction RefreshAction) task = await Execute(job);
                 job.JobInfo.Status = task.WorkerResult.IsSuccess ? JobStatus.Finished : JobStatus.Failed;
                 if (!task.WorkerResult.IsSuccess)

--- a/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/BaseWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers
         {
             try
             {
-                await Task.Delay(1);
+                await Task.Delay(1); // Delay to return the task to JobService ASAP
                 (WorkerResult WorkerResult, RefreshAction RefreshAction) task = await Execute(job);
                 job.JobInfo.Status = task.WorkerResult.IsSuccess ? JobStatus.Finished : JobStatus.Failed;
                 if (!task.WorkerResult.IsSuccess)

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -4,6 +4,7 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import JobInfo from "../../models/jobs/jobInfo";
 import { Server } from "../../models/server";
+import { getUsername, msalEnabled } from "../../msal/MsalAuthProvider";
 import CredentialsService from "../../services/credentialsService";
 import JobService from "../../services/jobService";
 import NotificationService, { Notification } from "../../services/notificationService";
@@ -19,7 +20,7 @@ export const JobsView = (): React.ReactElement => {
   const [shouldRefresh, setShouldRefresh] = useState<boolean>(true);
 
   const credentials = CredentialsService.getCredentials();
-  const username = credentials.find((creds) => creds.server.id == selectedServer.id)?.username;
+  const username = msalEnabled ? getUsername() : credentials.find((creds) => creds.server.id == selectedServer.id)?.username;
 
   const fetchJobs = () => {
     if (username) {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/JobInfoPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/JobInfoPropertiesModal.tsx
@@ -52,6 +52,8 @@ const JobInfoPropertiesModal = (props: JobInfoPropertiesModalInterface): React.R
               defaultValue={jobInfo.killTime ? new Date(jobInfo.killTime).toLocaleString() : "-"}
               fullWidth
             />
+            <TextField InputProps={{ readOnly: true }} id="username" label="Username" defaultValue={jobInfo.username} fullWidth />
+            <TextField InputProps={{ readOnly: true }} id="witsmlUsername" label="WITSML Username" defaultValue={jobInfo.witsmlUsername} fullWidth />
           </>
         }
         onSubmit={() => {

--- a/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
@@ -3,6 +3,7 @@ export default interface JobInfo {
   description: string;
   id: string;
   username: string;
+  witsmlUsername: string;
   sourceServer: string;
   targetServer: string;
   startTime: string;

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -67,6 +67,8 @@ export const getAccountInfo = (): AccountInfo | null => {
 
 export const getUserAppRoles = (): string[] => getAccountInfo()?.idTokenClaims?.roles ?? [];
 
+export const getUsername = (): string | null => getAccountInfo()?.username;
+
 export async function signOut(): Promise<void> {
   type TokenClaims = {
     login_hint: string;

--- a/Tests/WitsmlExplorer.Api.Tests/Services/JobCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/JobCacheTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.Extensions.Logging;
@@ -19,10 +20,10 @@ namespace WitsmlExplorer.Api.Tests.Services
 
         public JobCacheTests()
         {
-            var logger = new Mock<ILogger<JobCache>>();
+            Mock<ILogger<JobCache>> logger = new();
             _jobCache = new(logger.Object);
             _jobInfos = new JobInfo[] { new(), new(), new(), new() };
-            foreach (var jobInfo in _jobInfos)
+            foreach (JobInfo jobInfo in _jobInfos)
             {
                 _jobCache.CacheJob(jobInfo);
             }
@@ -36,40 +37,16 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetJobInfosById_CorrectReturn()
-        {
-            var indicesToGet = new int[] { 1, 2 };
-            var ids = indicesToGet.Select(index => _jobInfos[index].Id);
-            var result = _jobCache.GetJobInfosById(ids);
-            Assert.Equal(indicesToGet.Length, result.Count());
-            foreach (JobInfo jobInfo in result)
-            {
-                Assert.Contains(jobInfo.Id, ids);
-            }
-            Assert.Distinct(result.Select(jobInfo => jobInfo.Id));
-        }
-
-        [Fact]
-        public void GetJobInfosId_IdNotPresent_ResultOmitted()
-        {
-            var validId = _jobInfos[3].Id;
-            var ids = new string[] { validId, "invalid_id" };
-            var result = _jobCache.GetJobInfosById(ids);
-            Assert.Single(result);
-            Assert.Equal(validId, result.First().Id);
-        }
-
-        [Fact]
         public void GetJobInfosByUser_ReturnCorrectUser()
         {
-            var user1 = "Alice";
-            var user2 = "Bob";
+            string user1 = "Alice";
+            string user2 = "Bob";
             _jobInfos[0].Username = user1;
             _jobInfos[1].Username = user2;
             _jobInfos[2].Username = user1;
             _jobInfos[3].Username = user2;
 
-            var result = _jobCache.GetJobInfosByUser(user2);
+            IEnumerable<JobInfo> result = _jobCache.GetJobInfosByUser(user2);
             Assert.Equal(2, result.Count());
             foreach (JobInfo jobInfo in result)
             {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-573

## Description
Remove unused GetJobInfosById route.
Add witsmlUsername to JobInfo.
Check both the server headers and bearer token for user id when creating a job.
Authorize job fetching when Msal is disabled.
Use username from Msal when fetching jobs in frontend.

After review:
Check whether creds username matches polled user in GetJobInfosByUser.
Move instantiation of JobInfo from Job constructor to CreateJob.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
