### PR TITLE
WE-577 ensure source server is set on copyjobs

### DIFF
--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyBhaRunWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyBhaRunWorker.cs
@@ -27,7 +27,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyBhaRunWorker(ILogger<CopyBhaRunJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyUtils copyUtils) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
             _copyUtils = copyUtils;
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyLogDataWorker(IWitsmlClientProvider witsmlClientProvider, ILogger<CopyLogDataJob> logger = null) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
         }
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(CopyLogDataJob job)

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
@@ -31,7 +31,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyLogWorker(ILogger<CopyLogJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyLogDataWorker copyLogDataWorker = null) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
             _copyLogDataWorker = copyLogDataWorker ?? new CopyLogDataWorker(witsmlClientProvider);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyRigWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyRigWorker.cs
@@ -27,7 +27,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyRigWorker(ILogger<CopyRigJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyUtils copyUtils) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
             _copyUtils = copyUtils;
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyRiskWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyRiskWorker(ILogger<CopyRiskJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyUtils copyUtils) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
             _copyUtils = copyUtils;
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyTrajectoryStationsWorker(ILogger<CopyTrajectoryStationsJob> logger, IWitsmlClientProvider witsmlClientProvider) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
         }
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(CopyTrajectoryStationsJob job)

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyTrajectoryWorker(ILogger<CopyTrajectoryJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyUtils copyUtils) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
             _copyUtils = copyUtils;
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularComponentsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularComponentsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyTubularComponentsWorker(ILogger<CopyTubularComponentsJob> logger, IWitsmlClientProvider witsmlClientProvider) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
         }
 
         public override async Task<(WorkerResult, RefreshAction)> Execute(CopyTubularComponentsJob job)

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularWorker.cs
@@ -27,7 +27,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         public CopyTubularWorker(ILogger<CopyTubularJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyUtils copyUtils) : base(logger)
         {
             _witsmlClient = witsmlClientProvider.GetClient();
-            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? _witsmlClient;
+            _witsmlSourceClient = witsmlClientProvider.GetSourceClient() ?? throw new WitsmlClientProviderException("Missing WitsmlSource in CopyJob", 500);
             _copyUtils = copyUtils;
         }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -52,6 +52,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Mock<IWitsmlClientProvider> witsmlClientProvider = new();
             _witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlClient.Object);
             Mock<ILogger<CopyLogDataJob>> logger = new();
             _worker = new CopyLogDataWorker(witsmlClientProvider.Object, logger.Object);
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -52,6 +52,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             _copyLogDataWorker = new Mock<ICopyLogDataWorker>();
             _witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlClient.Object);
             Mock<ILogger<CopyLogJob>> logger = new();
             _copyLogWorker = new CopyLogWorker(logger.Object, witsmlClientProvider.Object, _copyLogDataWorker.Object);
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTrajectoryWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTrajectoryWorkerTests.cs
@@ -38,6 +38,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Mock<IWitsmlClientProvider> witsmlClientProvider = new();
             _witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlClient.Object);
             Mock<ILogger<CopyTrajectoryJob>> logger = new();
             CopyUtils copyUtils = new(new Mock<ILogger<CopyUtils>>().Object, witsmlClientProvider.Object);
             _copyTrajectoryWorker = new CopyTrajectoryWorker(logger.Object, witsmlClientProvider.Object, copyUtils);

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularComponentTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularComponentTests.cs
@@ -39,6 +39,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Mock<IWitsmlClientProvider> witsmlClientProvider = new();
             _witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlClient.Object);
             Mock<ILogger<CopyTubularComponentsJob>> logger = new();
             _copyTubularComponentWorker = new CopyTubularComponentsWorker(logger.Object, witsmlClientProvider.Object);
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
@@ -36,6 +36,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Mock<IWitsmlClientProvider> witsmlClientProvider = new();
             _witsmlClient = new Mock<IWitsmlClient>();
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlClient.Object);
             Mock<ILogger<CopyTubularJob>> logger = new();
             CopyUtils copyUtils = new(new Mock<ILogger<CopyUtils>>().Object, witsmlClientProvider.Object);
             _copyTubularWorker = new CopyTubularWorker(logger.Object, witsmlClientProvider.Object, copyUtils);


### PR DESCRIPTION

## Fixes
This pull request fixes WE-577

## Description
Workers initiating copy jobs would fallback on the same server as destination if source server request `Header` named `WitsmlSourceServer` had not been set.

## Type of change

:bug: Bugfix

## Impacted Areas in Application
`API` Workers

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
