### PR TITLE
WE-598 Keep CredentialsService in sync with the server list

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
@@ -29,6 +29,7 @@ const ServerManager = (): React.ReactElement => {
   const { selectedServer, servers, wells } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [isOpen, setIsOpen] = useState<boolean>();
+  const [hasFetchedServers, setHasFetchedServers] = useState(false);
   const [currentWitsmlLoginState, setLoginState] = useState<{ isLoggedIn: boolean; username?: string; server?: Server }>({ isLoggedIn: false });
 
   useEffect(() => {
@@ -78,10 +79,12 @@ const ServerManager = (): React.ReactElement => {
 
   const isAuthenticated = !msalEnabled || useIsAuthenticated();
   useEffect(() => {
-    if (isAuthenticated) {
+    if (isAuthenticated && !hasFetchedServers) {
       const abortController = new AbortController();
       const getServers = async () => {
         const freshServers = await ServerService.getServers(abortController.signal);
+        setHasFetchedServers(true);
+        CredentialsService.saveServers(freshServers);
         const action: UpdateServerListAction = { type: ModificationType.UpdateServerList, payload: { servers: freshServers } };
         dispatchNavigation(action);
       };

--- a/Src/WitsmlExplorer.Frontend/services/serverService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/serverService.tsx
@@ -1,6 +1,7 @@
 import { ErrorDetails } from "../models/errorDetails";
 import { emptyServer, Server } from "../models/server";
 import { ApiClient } from "./apiClient";
+import CredentialsService from "./credentialsService";
 
 export default class ServerService {
   public static async getServers(abortSignal?: AbortSignal): Promise<Server[]> {
@@ -15,7 +16,9 @@ export default class ServerService {
   public static async addServer(server: Server, abortSignal?: AbortSignal): Promise<Server> {
     const response = await ApiClient.post(`/api/witsml-servers`, JSON.stringify(server), abortSignal, undefined);
     if (response.ok) {
-      return response.json();
+      const result = await response.json();
+      CredentialsService.addServer(result);
+      return result;
     } else {
       return emptyServer();
     }
@@ -24,7 +27,9 @@ export default class ServerService {
   public static async updateServer(server: Server, abortSignal?: AbortSignal): Promise<Server> {
     const response = await ApiClient.patch(`/api/witsml-servers/${server.id}`, JSON.stringify(server), abortSignal);
     if (response.ok) {
-      return response.json();
+      const result = await response.json();
+      CredentialsService.updateServer(result);
+      return result;
     } else {
       return emptyServer();
     }
@@ -33,6 +38,7 @@ export default class ServerService {
   public static async removeServer(serverUid: string, abortSignal?: AbortSignal): Promise<boolean> {
     const response = await ApiClient.delete(`/api/witsml-servers/${serverUid}`, abortSignal);
     if (response.ok) {
+      CredentialsService.removeServer(serverUid);
       return true;
     } else {
       const { message }: ErrorDetails = await response.json();


### PR DESCRIPTION
## Fixes
This pull request fixes WE-598

## Description
Keep CredentialsService in sync with the server list so that the ApiClient can set server headers when using OAuth.
Stop saving credentials in local storage.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests