### PR TITLE
WE-591 Indicator for fetching wells

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -13,7 +13,7 @@ export interface WellRow extends ContentTableRow, Well {}
 
 export const WellsListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { servers, filteredWells, wells, selectedServer } = navigationState;
+  const { servers, filteredWells } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
@@ -42,10 +42,10 @@ export const WellsListView = (): React.ReactElement => {
     });
   };
 
-  return wells?.length == 0 && selectedServer != null ? (
-    <WellProgress />
-  ) : (
-    <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />
+  return (
+    <WellProgress>
+      <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />
+    </WellProgress>
   );
 };
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -6,13 +6,14 @@ import OperationType from "../../contexts/operationType";
 import Well from "../../models/well";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import WellContextMenu, { WellContextMenuProps } from "../ContextMenus/WellContextMenu";
+import WellProgress from "../WellProgress";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 
 export interface WellRow extends ContentTableRow, Well {}
 
 export const WellsListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { servers, filteredWells } = navigationState;
+  const { servers, filteredWells, wells } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
@@ -41,7 +42,7 @@ export const WellsListView = (): React.ReactElement => {
     });
   };
 
-  return <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />;
+  return wells?.length == 0 ? <WellProgress /> : <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />;
 };
 
 export default WellsListView;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -13,7 +13,7 @@ export interface WellRow extends ContentTableRow, Well {}
 
 export const WellsListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { servers, filteredWells, wells } = navigationState;
+  const { servers, filteredWells, wells, selectedServer } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
@@ -42,7 +42,11 @@ export const WellsListView = (): React.ReactElement => {
     });
   };
 
-  return wells?.length == 0 ? <WellProgress /> : <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />;
+  return wells?.length == 0 && selectedServer != null ? (
+    <WellProgress />
+  ) : (
+    <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />
+  );
 };
 
 export default WellsListView;

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -12,26 +12,27 @@ import WellItem from "./WellItem";
 
 const Sidebar = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
-  const { filteredWells, expandedTreeNodes, currentProperties, wells, selectedServer } = navigationState;
+  const { filteredWells, expandedTreeNodes, currentProperties } = navigationState;
 
   return (
     <>
       <ServerManager />
       <FilterPanel />
       <SidebarTreeView>
-        {filteredWells && filteredWells.length > 0 && (
-          <TreeView
-            defaultCollapseIcon={<Icon name="chevronDown" color={"disabled"} />}
-            defaultExpandIcon={<Icon name="chevronRight" color={"disabled"} />}
-            defaultEndIcon={<div style={{ width: 24 }} />}
-            expanded={expandedTreeNodes}
-          >
-            {filteredWells.map((well: Well) => (
-              <WellItem key={well.uid} well={well} />
-            ))}
-          </TreeView>
-        )}
-        {wells?.length == 0 && selectedServer != null && <WellProgress />}
+        <WellProgress>
+          {filteredWells && filteredWells.length > 0 && (
+            <TreeView
+              defaultCollapseIcon={<Icon name="chevronDown" color={"disabled"} />}
+              defaultExpandIcon={<Icon name="chevronRight" color={"disabled"} />}
+              defaultEndIcon={<div style={{ width: 24 }} />}
+              expanded={expandedTreeNodes}
+            >
+              {filteredWells.map((well: Well) => (
+                <WellItem key={well.uid} well={well} />
+              ))}
+            </TreeView>
+          )}
+        </WellProgress>
       </SidebarTreeView>
       <PropertiesPanel properties={currentProperties} />
     </>

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -12,7 +12,7 @@ import WellItem from "./WellItem";
 
 const Sidebar = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
-  const { filteredWells, expandedTreeNodes, currentProperties, wells } = navigationState;
+  const { filteredWells, expandedTreeNodes, currentProperties, wells, selectedServer } = navigationState;
 
   return (
     <>
@@ -31,7 +31,7 @@ const Sidebar = (): React.ReactElement => {
             ))}
           </TreeView>
         )}
-        {wells?.length == 0 && <WellProgress />}
+        {wells?.length == 0 && selectedServer != null && <WellProgress />}
       </SidebarTreeView>
       <PropertiesPanel properties={currentProperties} />
     </>

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import NavigationContext from "../../contexts/navigationContext";
 import Well from "../../models/well";
 import Icon from "../../styles/Icons";
+import WellProgress from "../WellProgress";
 import FilterPanel from "./FilterPanel";
 import PropertiesPanel from "./PropertiesPanel";
 import ServerManager from "./ServerManager";
@@ -11,7 +12,7 @@ import WellItem from "./WellItem";
 
 const Sidebar = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
-  const { filteredWells, expandedTreeNodes, currentProperties } = navigationState;
+  const { filteredWells, expandedTreeNodes, currentProperties, wells } = navigationState;
 
   return (
     <>
@@ -30,6 +31,7 @@ const Sidebar = (): React.ReactElement => {
             ))}
           </TreeView>
         )}
+        {wells?.length == 0 && <WellProgress />}
       </SidebarTreeView>
       <PropertiesPanel properties={currentProperties} />
     </>

--- a/Src/WitsmlExplorer.Frontend/components/WellProgress.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/WellProgress.tsx
@@ -1,0 +1,27 @@
+import { CircularProgress, Typography } from "@equinor/eds-core-react";
+import styled from "styled-components";
+
+const WellProgress = (): React.ReactElement => {
+  return (
+    <ProgressLayout>
+      <InnerProgressLayout>
+        <CircularProgress style={{ margin: "auto" }} />
+        <Typography style={{ margin: "auto", paddingTop: "10px" }}>Fetching wells. This may take some time.</Typography>
+      </InnerProgressLayout>
+    </ProgressLayout>
+  );
+};
+
+const ProgressLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+const InnerProgressLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+`;
+
+export default WellProgress;

--- a/Src/WitsmlExplorer.Frontend/components/WellProgress.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/WellProgress.tsx
@@ -1,14 +1,25 @@
 import { CircularProgress, Typography } from "@equinor/eds-core-react";
+import React, { useContext } from "react";
 import styled from "styled-components";
+import NavigationContext from "../contexts/navigationContext";
+import CredentialsService from "../services/credentialsService";
 
-const WellProgress = (): React.ReactElement => {
-  return (
+type Props = {
+  children: JSX.Element;
+};
+const WellProgress = ({ children }: Props): React.ReactElement => {
+  const { navigationState } = useContext(NavigationContext);
+  const { wells, selectedServer } = navigationState;
+  const showIndicator = wells?.length == 0 && selectedServer != null && CredentialsService.isAuthorizedForServer(selectedServer);
+  return showIndicator ? (
     <ProgressLayout>
       <InnerProgressLayout>
         <CircularProgress style={{ margin: "auto" }} />
         <Typography style={{ margin: "auto", paddingTop: "10px" }}>Fetching wells. This may take some time.</Typography>
       </InnerProgressLayout>
     </ProgressLayout>
+  ) : (
+    children
   );
 };
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-591

## Description
Show a spinner in Sidebar and WellsView when there are no wells in the navigation state. It will spin forever on a server with no wells or on error (but on error an error message will still be shown).

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
