### PR TITLE
WE-600 fix fetching wells from wrong server

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
@@ -53,7 +53,7 @@ const ServerManager = (): React.ReactElement => {
       const useOauth = msalEnabled && selectedServer?.securityscheme == SecurityScheme.OAuth2 && getUserAppRoles().some((x) => selectedServer.roles.includes(x));
       if (useOauth) {
         try {
-          fetchWells();
+          await fetchWells();
         } catch (error) {
           NotificationService.Instance.alertDispatcher.dispatch({
             serverUrl: new URL(selectedServer.url),
@@ -64,7 +64,7 @@ const ServerManager = (): React.ReactElement => {
       } else if (currentWitsmlLoginState.server) {
         if (CredentialsService.isAuthorizedForServer(selectedServer)) {
           try {
-            fetchWells();
+            await fetchWells();
             dispatchOperation({ type: OperationType.HideModal });
           } catch (error) {
             showCredentialsModal(currentWitsmlLoginState.server, error.message);


### PR DESCRIPTION
## Fixes
This pull request fixes WE-600

## Description
Include an abortController in the wells fetching logic to abort on login state changed. This fixes the former behavior of fetching wells for a previously selected server.
Reproduction of fixed bug:
1. Pick Equinor Sitecom Prod
2. Whilst the servers are being fetched, pick Equinor Sitecom Test
3. Wait until the Equinor Sitecom Prod wells are fetched
4. Enter credentials for Equinor Sitecom Test
5. Observe that the Equinor Sitecom Prod wells persist and Test wells are not being fetched.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
