### PR TITLE
WE-603 Use HeaderOnly for source logs in CopyLogWorker

### DIFF
--- a/Src/WitsmlExplorer.Api/Workers/WorkerTools.cs
+++ b/Src/WitsmlExplorer.Api/Workers/WorkerTools.cs
@@ -26,12 +26,5 @@ namespace WitsmlExplorer.Api.Workers
             return !result.Logs.Any() ? null : result.Logs.First();
         }
 
-        public static async Task<WitsmlLog> GetLog(IWitsmlClient client, string logUid, string wellboreUid, string wellUid, ReturnElements optionsInReturnElements)
-        {
-            WitsmlLogs logQuery = LogQueries.GetWitsmlLogById(wellUid, wellboreUid, logUid);
-            WitsmlLogs result = await client.GetFromStoreAsync(logQuery, new OptionsIn(optionsInReturnElements));
-            return !result.Logs.Any() ? null : result.Logs.First();
-        }
-
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -70,7 +70,6 @@ namespace WitsmlExplorer.Api.Tests.Workers
             (WorkerResult, RefreshAction) result = await _copyLogWorker.Execute(copyLogJob);
             WitsmlLog logInQuery = copyLogQuery.First().Logs.First();
             Assert.True(result.Item1.IsSuccess);
-            Assert.Empty(logInQuery.LogData.Data);
             Assert.Null(logInQuery.EndIndex);
             Assert.Null(logInQuery.StartIndex);
             Assert.Equal(TimeStart, logInQuery.StartDateTimeIndex);
@@ -91,7 +90,6 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             WitsmlLog logInQuery = copyLogQuery.First().Logs.First();
             Assert.True(result.Item1.IsSuccess);
-            Assert.Empty(logInQuery.LogData.Data);
             Assert.Equal(DepthEnd, double.Parse(logInQuery.EndIndex.Value));
             Assert.Equal(DepthStart, double.Parse(logInQuery.StartIndex.Value));
             Assert.Null(logInQuery.StartDateTimeIndex);
@@ -104,12 +102,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.All, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, DepthStart, DepthEnd));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.All, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, TimeStart, TimeEnd));
                     break;
                 default:


### PR DESCRIPTION
## Fixes
This pull request fixes WE-603

## Description
Use ReturnElements.HeaderOnly instead of All when fetching source logs in CopyLogWorker. This reduces the amount of data transferred, and eliminates some unexpected errors when copying logs. The errors were probably from trying to fetch malformed or empty log data, which could crash the whole worker.

## Type of change

* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [X] PR is related to an issue

*Code quality*
* [X] Code follows the style guidelines
* [X] I have self-reviewed my code
* [X] No new warnings are generated

*Test coverage*
* [X] Existing tests pass
* [ ] New code is covered by passing tests
