### PR TITLE
WE-602 fix disappearing content view on trajectories refresh

### DIFF
--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -309,7 +309,6 @@ it("Should update trajectories for selected wellbore", () => {
     selectedWellbore: updatedWellbore,
     selectedTrajectoryGroup: TRAJECTORY_GROUP_1,
     selectedTrajectory,
-    currentSelected: TRAJECTORY_GROUP_1,
     wells: [updatedWell, WELL_2, WELL_3],
     filteredWells: [updatedWell, WELL_2, WELL_3]
   });

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -517,7 +517,6 @@ const updateWellboreTrajectories = (state: NavigationState, { payload }: UpdateW
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
     selectedTrajectory,
-    currentSelected: state.selectedTrajectoryGroup,
     wells: freshWells
   };
 };


### PR DESCRIPTION
## Fixes
This pull request fixes WE-602

## Description
Do not set currentSelected on updateWellboreTrajectories to fix disappearing content view on refreshing trajectories.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [X] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [X] Code follows the style guidelines
* [X] I have self-reviewed my code
* [X] No new warnings are generated

*Test coverage*
* [X] Existing tests pass
* [ ] New code is covered by passing tests
