### PR TITLE
WIP WE-610 authorize with and set cookie

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandlers
@@ -13,6 +16,39 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
             string basicAuth = httpRequest.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
             return Results.Ok(await credentialsService.ProtectBasicAuthorization(basicAuth));
+        }
+
+        public static async Task<IResult> AuthorizeAndSetCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
+        {
+            string basicAuth = httpContextAccessor?.HttpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
+            ServerCredentials creds = await credentialsService.GetCredentialsFromHeaderValue(basicAuth);
+            string encryptedPassword = await credentialsService.ProtectBasicAuthorization(basicAuth);
+
+            CookieOptions cookieOptions = new()
+            {
+                SameSite = SameSiteMode.Lax,
+                MaxAge = TimeSpan.FromDays(1),
+                Secure = false,
+                HttpOnly = true
+            };
+            //TODO maybe encrypt user id as well
+            httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), $"{creds.UserId}:{encryptedPassword}", cookieOptions);
+            return Results.Ok(encryptedPassword);
+        }
+
+        public static IResult AuthorizeWithCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
+        {
+            ServerCredentials targetServer = httpContextAccessor?.HttpContext?.Request.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
+            IRequestCookieCollection cookies = httpContextAccessor.HttpContext.Request.Cookies;
+            if (targetServer.Host == null || !cookies.TryGetValue(Uri.EscapeDataString(targetServer.Host.ToString()), out string cookie))
+            {
+                return Results.Unauthorized();
+            }
+            if (credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
+            {
+                return Results.Unauthorized();
+            }
+            return Results.Ok(cookie);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
@@ -26,13 +27,13 @@ namespace WitsmlExplorer.Api.HttpHandlers
 
             CookieOptions cookieOptions = new()
             {
-                SameSite = SameSiteMode.Lax,
+                SameSite = SameSiteMode.None,
                 MaxAge = TimeSpan.FromDays(1),
                 Secure = false,
                 HttpOnly = true
             };
-            //TODO maybe encrypt user id as well
-            httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), $"{creds.UserId}:{encryptedPassword}", cookieOptions);
+            string cookieValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{creds.UserId}:{encryptedPassword}"));
+            httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), cookieValue, cookieOptions);
             return Results.Ok(encryptedPassword);
         }
 
@@ -44,7 +45,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
             {
                 return Results.Unauthorized();
             }
-            if (credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
+            if (!credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
             {
                 return Results.Unauthorized();
             }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -58,7 +58,8 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, false);
-
+            app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, false);
+            app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, false);
         }
     }
 }

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -34,8 +34,9 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     setIsLoading(true);
     try {
       const cookie = await CredentialsService.verifyCredentialsWithCookie({ server });
-      const creds = cookie.split(":");
-      props.onConnectionVerified({
+      const decoded = Buffer.from(cookie, "base64").toString();
+      const creds = decoded.split(":");
+      CredentialsService.saveCredentials({
         server,
         username: creds[0],
         password: creds[1]

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -37,7 +37,8 @@ export class ApiClient {
   public static async get(pathName: string, abortSignal: AbortSignal | null = null, currentCredentials = CredentialsService.getCredentials()): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
-      headers: await ApiClient.getCommonHeaders(currentCredentials)
+      headers: await ApiClient.getCommonHeaders(currentCredentials),
+      credentials: "include"
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -106,6 +106,26 @@ class CredentialsService {
     }
   }
 
+  public async verifyCredentialsWithCookie(credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<string> {
+    const response = await ApiClient.get(`/api/credentials/authorizewithcookie`, abortSignal);
+    if (response.ok) {
+      return response.json();
+    } else {
+      const { message }: ErrorDetails = await response.json();
+      CredentialsService.throwError(response.status, message);
+    }
+  }
+
+  public async verifyCredentialsAndSetCookie(credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<any> {
+    const response = await ApiClient.get(`/api/credentials/authorizeandsetcookie`, abortSignal, [credentials]);
+    if (response.ok) {
+      return response.json();
+    } else {
+      const { message }: ErrorDetails = await response.json();
+      CredentialsService.throwError(response.status, message);
+    }
+  }
+
   private static throwError(statusCode: number, message: string) {
     switch (statusCode) {
       case 401:


### PR DESCRIPTION
TODO:
* try authorizing with cookie only if keepLoggedIn was previously set to true for given server (also save the expiration time of the cookie so that we do not attempt to log in with it once it has expired)
* do not log out on idle if keepLoggedIn is set to true
* do not send credentials on every get request
* include cookie invalidate on logout
 
## Fixes
This pull request fixes WE-610

## Description
_Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change._

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [ ] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [ ] Code follows the style guidelines
* [ ] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
* logout button per server
* find out whether to use a single auth route instead of the current three
