### PR TITLE
WE-610 authorize with and set cookie

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -27,9 +28,9 @@ namespace WitsmlExplorer.Api.HttpHandlers
 
             CookieOptions cookieOptions = new()
             {
-                SameSite = SameSiteMode.None,
+                SameSite = SameSiteMode.Strict,
                 MaxAge = TimeSpan.FromDays(1),
-                Secure = false,
+                Secure = true,
                 HttpOnly = true
             };
             string cookieValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{creds.UserId}:{encryptedPassword}"));
@@ -50,6 +51,15 @@ namespace WitsmlExplorer.Api.HttpHandlers
                 return Results.Unauthorized();
             }
             return Results.Ok(cookie);
+        }
+
+        public static IResult Deauthorize(IHttpContextAccessor httpContextAccessor)
+        {
+            foreach (KeyValuePair<string, string> cookie in httpContextAccessor.HttpContext.Request.Cookies)
+            {
+                httpContextAccessor.HttpContext.Response.Cookies.Delete(cookie.Key);
+            }
+            return Results.Ok();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,8 +1,12 @@
+using System;
+using System.Text;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
+using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandlers
@@ -13,6 +17,39 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
             string basicAuth = httpRequest.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
             return Results.Ok(await credentialsService.ProtectBasicAuthorization(basicAuth));
+        }
+
+        public static async Task<IResult> AuthorizeAndSetCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
+        {
+            string basicAuth = httpContextAccessor?.HttpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
+            ServerCredentials creds = await credentialsService.GetCredentialsFromHeaderValue(basicAuth);
+            string encryptedPassword = await credentialsService.ProtectBasicAuthorization(basicAuth);
+
+            CookieOptions cookieOptions = new()
+            {
+                SameSite = SameSiteMode.None,
+                MaxAge = TimeSpan.FromDays(1),
+                Secure = false,
+                HttpOnly = true
+            };
+            string cookieValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{creds.UserId}:{encryptedPassword}"));
+            httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), cookieValue, cookieOptions);
+            return Results.Ok(encryptedPassword);
+        }
+
+        public static IResult AuthorizeWithCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
+        {
+            ServerCredentials targetServer = httpContextAccessor?.HttpContext?.Request.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
+            IRequestCookieCollection cookies = httpContextAccessor.HttpContext.Request.Cookies;
+            if (targetServer.Host == null || !cookies.TryGetValue(Uri.EscapeDataString(targetServer.Host.ToString()), out string cookie))
+            {
+                return Results.Unauthorized();
+            }
+            if (!credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
+            {
+                return Results.Unauthorized();
+            }
+            return Results.Ok(cookie);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -58,7 +58,8 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, false);
-
+            app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, false);
+            app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, false);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -57,9 +57,10 @@ namespace WitsmlExplorer.Api
             app.MapPost("/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
             app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
 
-            app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, false);
-            app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, false);
-            app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, false);
+            app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
+            app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, useOAuth2);
+            app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, useOAuth2);
+            app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);
         }
     }
 }

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -33,14 +33,8 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
   const authorizeWithCookie = async () => {
     try {
       setIsLoading(true);
-      const cookie = await CredentialsService.verifyCredentialsWithCookie({ server });
-      const decoded = Buffer.from(cookie, "base64").toString();
-      const creds = decoded.split(":");
-      CredentialsService.saveCredentials({
-        server,
-        username: creds[0],
-        password: creds[1]
-      });
+      const creds = await CredentialsService.verifyCredentialsWithCookie({ server });
+      CredentialsService.saveCredentials(creds);
     } catch (error) {
       setIsLoading(false);
     }

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -1,5 +1,6 @@
+import { Checkbox } from "@equinor/eds-core-react";
 import { TextField } from "@material-ui/core";
-import React, { useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import { Server } from "../../models/server";
 import CredentialsService, { BasicServerCredentials } from "../../services/credentialsService";
 import ModalDialog, { ModalWidth } from "./ModalDialog";
@@ -26,7 +27,29 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
   const [password, setPassword] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const [keepLoggedIn, setKeepLoggedIn] = useState(false);
   const shouldFocusPasswordInput = !!username;
+
+  const onOpenModal = async () => {
+    setIsLoading(true);
+    try {
+      const cookie = await CredentialsService.verifyCredentialsWithCookie({ server });
+      const decoded = Buffer.from(cookie, "base64").toString();
+      const creds = decoded.split(":");
+      CredentialsService.saveCredentials({
+        server,
+        username: creds[0],
+        password: creds[1]
+      });
+    } catch (error) {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    //TODO do this conditionally if user has previously set keep logged in to true for current server
+    onOpenModal();
+  }, []);
 
   useEffect(() => {
     if (serverCredentials) {
@@ -51,7 +74,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       password
     };
     try {
-      const encryptedPassword = await CredentialsService.verifyCredentials(credentials);
+      const encryptedPassword = keepLoggedIn ? await CredentialsService.verifyCredentialsAndSetCookie(credentials) : await CredentialsService.verifyCredentials(credentials);
       CredentialsService.saveCredentials({ ...credentials, password: encryptedPassword });
     } catch (error) {
       setErrorMessage(error.message);
@@ -105,6 +128,12 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
             autoComplete="current-password"
             inputProps={{ minLength: 1, maxLength: 7936 }}
             onChange={(e) => setPassword(e.target.value)}
+          />
+          <Checkbox
+            label={`Keep me logged in to ${server.name} for 24 hours`}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setKeepLoggedIn(e.target.checked);
+            }}
           />
         </>
       }

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -6,6 +6,7 @@ import OperationContext from "../contexts/operationContext";
 import { UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
 import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
+import CredentialsService from "../services/credentialsService";
 import Icon from "../styles/Icons";
 import ContextMenu from "./ContextMenus/ContextMenu";
 import JobsButton from "./JobsButton";
@@ -52,7 +53,11 @@ const TopRightCornerMenu = (): React.ReactElement => {
         <StyledMenuItem
           key={"signout"}
           onClick={() => {
-            signOut();
+            const logout = async () => {
+              await CredentialsService.deauthorize();
+              signOut();
+            };
+            logout();
             dispatchOperation({ type: OperationType.HideContextMenu });
           }}
         >

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -34,11 +34,16 @@ export class ApiClient {
     return null;
   }
 
-  public static async get(pathName: string, abortSignal: AbortSignal | null = null, currentCredentials = CredentialsService.getCredentials()): Promise<Response> {
+  public static async get(
+    pathName: string,
+    abortSignal: AbortSignal | null = null,
+    currentCredentials = CredentialsService.getCredentials(),
+    includeCredentials = false
+  ): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
       headers: await ApiClient.getCommonHeaders(currentCredentials),
-      credentials: "include"
+      ...(includeCredentials ? { credentials: "include" } : {})
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -37,7 +37,8 @@ export class ApiClient {
   public static async get(pathName: string, abortSignal: AbortSignal | null = null, currentCredentials = CredentialsService.getCredentials()): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
-      headers: await ApiClient.getCommonHeaders(currentCredentials)
+      headers: await ApiClient.getCommonHeaders(currentCredentials),
+      credentials: "include"
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -106,6 +106,26 @@ class CredentialsService {
     }
   }
 
+  public async verifyCredentialsWithCookie(credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<string> {
+    const response = await ApiClient.get(`/api/credentials/authorizewithcookie`, abortSignal);
+    if (response.ok) {
+      return response.json();
+    } else {
+      const { message }: ErrorDetails = await response.json();
+      CredentialsService.throwError(response.status, message);
+    }
+  }
+
+  public async verifyCredentialsAndSetCookie(credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<any> {
+    const response = await ApiClient.get(`/api/credentials/authorizeandsetcookie`, abortSignal, [credentials]);
+    if (response.ok) {
+      return response.json();
+    } else {
+      const { message }: ErrorDetails = await response.json();
+      CredentialsService.throwError(response.status, message);
+    }
+  }
+
   private static throwError(statusCode: number, message: string) {
     switch (statusCode) {
       case 401:


### PR DESCRIPTION
## Fixes
This pull request fixes WE-610

## Description
Use httpOnly cookies to save credentials for 24 hours when keep logged in is checked for a server on login. 
* Add AuthorizeAndSetCookie, AuthorizeWithCookie, and Deauthorize routes.
* Authorize to a WITSML server automatically with cookie if present.
* Use local storage to save cookie expiration time and keepLoggedIn preference per server.
* Remove cookies on account signOut.

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [X] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [X] Code follows the style guidelines
* [X] I have self-reviewed my code
* [X] No new warnings are generated

*Test coverage*
* [X] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
TODO in future PRs
* logout button per server
* find out whether to use a single auth route instead of the current three
