### PR TITLE
WE-613 use cookies over in-memory handling

### DIFF
--- a/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
@@ -22,7 +22,6 @@ namespace WitsmlExplorer.Api.Configuration
         public static void ConfigureDependencies(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddSingleton<ICredentialsService, CredentialsService>();
-            services.AddScoped<IWitsmlClientProvider, WitsmlClientProvider>();
             AddRepository<Server, Guid>(services, configuration);
             services.RegisterAssemblyPublicNonGenericClasses(Assembly.GetAssembly(typeof(Program)))
                 .IgnoreThisInterface<ICopyLogDataWorker>()
@@ -31,6 +30,8 @@ namespace WitsmlExplorer.Api.Configuration
             services.AddSingleton<IJobCache, JobCache>();
             services.AddSingleton<IJobQueue, JobQueue>();
             services.AddSingleton<IWitsmlSystemCredentials, WitsmlSystemCredentials>();
+            services.AddScoped<IWitsmlClientProvider, WitsmlClientProvider>();
+
         }
 
         private static void AddRepository<TDocument, T>(IServiceCollection services, IConfiguration configuration) where TDocument : DbDocument<T>

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -35,40 +35,6 @@ namespace WitsmlExplorer.Api.HttpHandlers
                 return Results.Ok();
             }
         }
-
-        // public static async Task<IResult> AuthorizeAndSetCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
-        // {
-        //     string basicAuth = httpContextAccessor?.HttpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
-        //     ServerCredentials creds = await credentialsService.GetCredentialsFromHeaderValue(basicAuth);
-        //     string encryptedPassword = await credentialsService.ProtectBasicAuthorization(basicAuth);
-
-        //     CookieOptions cookieOptions = new()
-        //     {
-        //         SameSite = SameSiteMode.Strict,
-        //         MaxAge = TimeSpan.FromDays(1),
-        //         Secure = true,
-        //         HttpOnly = true
-        //     };
-        //     string cookieValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{creds.UserId}:{encryptedPassword}"));
-        //     httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), cookieValue, cookieOptions);
-        //     return Results.Ok(encryptedPassword);
-        // }
-
-        // public static IResult AuthorizeWithCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
-        // {
-        //     ServerCredentials targetServer = httpContextAccessor?.HttpContext?.Request.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
-        //     IRequestCookieCollection cookies = httpContextAccessor.HttpContext.Request.Cookies;
-        //     if (targetServer.Host == null || !cookies.TryGetValue(Uri.EscapeDataString(targetServer.Host.ToString()), out string cookie))
-        //     {
-        //         return Results.Unauthorized();
-        //     }
-        //     if (!credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
-        //     {
-        //         return Results.Unauthorized();
-        //     }
-        //     return Results.Ok(cookie);
-        // }
-
         public static IResult Deauthorize(IHttpContextAccessor httpContextAccessor)
         {
             foreach (KeyValuePair<string, string> cookie in httpContextAccessor.HttpContext.Request.Cookies)

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,57 +1,73 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 using WitsmlExplorer.Api.Configuration;
-using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandlers
 {
     public static class AuthorizeHandler
     {
-        public static async Task<IResult> Authorize([FromServices] ICredentialsService credentialsService, HttpRequest httpRequest)
+        public static async Task<IResult> Authorize([FromQuery(Name = "keep")] bool keep, [FromServices] ICredentialsService credentialsService, HttpContext httpContext)
         {
-            string basicAuth = httpRequest.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
-            return Results.Ok(await credentialsService.ProtectBasicAuthorization(basicAuth));
-        }
-
-        public static async Task<IResult> AuthorizeAndSetCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
-        {
-            string basicAuth = httpContextAccessor?.HttpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
+            string basicAuth = httpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader].ToString();
             ServerCredentials creds = await credentialsService.GetCredentialsFromHeaderValue(basicAuth);
-            string encryptedPassword = await credentialsService.ProtectBasicAuthorization(basicAuth);
 
-            CookieOptions cookieOptions = new()
-            {
-                SameSite = SameSiteMode.Strict,
-                MaxAge = TimeSpan.FromDays(1),
-                Secure = true,
-                HttpOnly = true
-            };
-            string cookieValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{creds.UserId}:{encryptedPassword}"));
-            httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), cookieValue, cookieOptions);
-            return Results.Ok(encryptedPassword);
-        }
-
-        public static IResult AuthorizeWithCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
-        {
-            ServerCredentials targetServer = httpContextAccessor?.HttpContext?.Request.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
-            IRequestCookieCollection cookies = httpContextAccessor.HttpContext.Request.Cookies;
-            if (targetServer.Host == null || !cookies.TryGetValue(Uri.EscapeDataString(targetServer.Host.ToString()), out string cookie))
+            if (creds.IsCredsNullOrEmpty())
             {
                 return Results.Unauthorized();
             }
-            if (!credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
+            else
             {
-                return Results.Unauthorized();
+                string encryptedCredentials = await credentialsService.ProtectBasicAuthorization(basicAuth);
+                CookieOptions cookieOptions = new()
+                {
+                    SameSite = SameSiteMode.Strict,
+                    MaxAge = keep ? TimeSpan.FromDays(1) : null,
+                    Secure = true,
+                    HttpOnly = true
+                };
+                httpContext?.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), encryptedCredentials, cookieOptions);
+                return Results.Ok();
             }
-            return Results.Ok(cookie);
         }
+
+        // public static async Task<IResult> AuthorizeAndSetCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
+        // {
+        //     string basicAuth = httpContextAccessor?.HttpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
+        //     ServerCredentials creds = await credentialsService.GetCredentialsFromHeaderValue(basicAuth);
+        //     string encryptedPassword = await credentialsService.ProtectBasicAuthorization(basicAuth);
+
+        //     CookieOptions cookieOptions = new()
+        //     {
+        //         SameSite = SameSiteMode.Strict,
+        //         MaxAge = TimeSpan.FromDays(1),
+        //         Secure = true,
+        //         HttpOnly = true
+        //     };
+        //     string cookieValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{creds.UserId}:{encryptedPassword}"));
+        //     httpContextAccessor.HttpContext.Response.Cookies.Append(Uri.EscapeDataString(creds.Host.ToString()), cookieValue, cookieOptions);
+        //     return Results.Ok(encryptedPassword);
+        // }
+
+        // public static IResult AuthorizeWithCookie([FromServices] ICredentialsService credentialsService, IHttpContextAccessor httpContextAccessor)
+        // {
+        //     ServerCredentials targetServer = httpContextAccessor?.HttpContext?.Request.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
+        //     IRequestCookieCollection cookies = httpContextAccessor.HttpContext.Request.Cookies;
+        //     if (targetServer.Host == null || !cookies.TryGetValue(Uri.EscapeDataString(targetServer.Host.ToString()), out string cookie))
+        //     {
+        //         return Results.Unauthorized();
+        //     }
+        //     if (!credentialsService.ValidEncryptedBasicCredentials($"{cookie}@{targetServer.Host}"))
+        //     {
+        //         return Results.Unauthorized();
+        //     }
+        //     return Results.Ok(cookie);
+        // }
 
         public static IResult Deauthorize(IHttpContextAccessor httpContextAccessor)
         {

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -14,7 +14,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
     {
         public static async Task<IResult> Authorize([FromQuery(Name = "keep")] bool keep, [FromServices] ICredentialsService credentialsService, HttpContext httpContext)
         {
-            string basicAuth = httpContext?.Request.Headers[WitsmlClientProvider.WitsmlTargetServerHeader].ToString();
+            string basicAuth = httpContext?.Request.Headers[EssentialHeaders.WitsmlTargetServer].ToString();
             ServerCredentials creds = await credentialsService.GetCredentialsFromHeaderValue(basicAuth);
 
             if (creds.IsCredsNullOrEmpty())

--- a/Src/WitsmlExplorer.Api/HttpHandlers/EssentialHeaders.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/EssentialHeaders.cs
@@ -1,0 +1,55 @@
+
+using System;
+
+using Microsoft.AspNetCore.Http;
+
+namespace WitsmlExplorer.Api.HttpHandlers
+{
+    public interface IEssentialHeaders
+    {
+        public string Authorization { get; }
+        public bool HasCookieCredentials(string server);
+        public string GetCookie(string server);
+        public string GetHost(string server);
+        public string GetBearerToken();
+    }
+
+    public class EssentialHeaders : IEssentialHeaders
+    {
+        public static readonly string WitsmlTargetServer = "WitsmlTargetServer";
+        public static readonly string WitsmlSourceServer = "WitsmlSourceServer";
+        public EssentialHeaders() { }
+        public EssentialHeaders(HttpRequest httpRequest)
+        {
+
+            Authorization = httpRequest?.Headers["Authorization"];
+            TargetServer = httpRequest?.Headers[WitsmlTargetServer];
+            SourceServer = httpRequest?.Headers[WitsmlSourceServer];
+            TargetServerCookie = httpRequest?.Cookies[Uri.EscapeDataString(TargetServer)];
+            SourceServerCookie = httpRequest?.Cookies[Uri.EscapeDataString(SourceServer)];
+        }
+        public string Authorization { get; init; }
+        private string TargetServer { get; init; }
+        private string SourceServer { get; init; }
+        private string TargetServerCookie { get; init; }
+        private string SourceServerCookie { get; init; }
+
+        public bool HasCookieCredentials(string server)
+        {
+            return (server == WitsmlTargetServer) ? !string.IsNullOrEmpty(TargetServerCookie) : !string.IsNullOrEmpty(SourceServerCookie);
+        }
+        public string GetCookie(string server)
+        {
+            return (server == WitsmlTargetServer) ? TargetServerCookie : SourceServerCookie;
+        }
+        public string GetHost(string server)
+        {
+            return (server == WitsmlTargetServer) ? TargetServer : SourceServer;
+        }
+        public string GetBearerToken()
+        {
+            return Authorization?.Split()[1];
+        }
+    }
+}
+

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -20,9 +20,9 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
 
             string bearerAuth = httpRequest.Headers["Authorization"];
-            string basicAuth = httpRequest.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
-            ServerCredentials witsmlTarget = httpRequest.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
-            ServerCredentials witsmlSource = httpRequest.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlSourceServerHeader, n => "");
+            string basicAuth = httpRequest.Headers[EssentialHeaders.WitsmlTargetServer];
+            ServerCredentials witsmlTarget = httpRequest.GetWitsmlServerHttpHeader(EssentialHeaders.WitsmlTargetServer, n => "");
+            ServerCredentials witsmlSource = httpRequest.GetWitsmlServerHttpHeader(EssentialHeaders.WitsmlSourceServer, n => "");
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
 
             (string userPrincipalName, string witsmlUsername) = credentialsService.GetUsernamesFromHeaderValues(bearerAuth, basicAuth);
@@ -41,7 +41,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
             string bearerAuth = httpRequest.Headers["Authorization"];
-            string basicAuth = httpRequest.Headers[WitsmlClientProvider.WitsmlTargetServerHeader];
+            string basicAuth = httpRequest.Headers[EssentialHeaders.WitsmlTargetServer];
             (string userPrincipalName, string witsmlUserName) = credentialsService.GetUsernamesFromHeaderValues(bearerAuth, basicAuth);
 
             if ((useOAuth2 && string.IsNullOrEmpty(userPrincipalName)) ||

--- a/Src/WitsmlExplorer.Api/Middleware/ExceptionMiddleware.cs
+++ b/Src/WitsmlExplorer.Api/Middleware/ExceptionMiddleware.cs
@@ -10,8 +10,10 @@ using Serilog;
 
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Extensions;
+using WitsmlExplorer.Api.HttpHandlers;
 using WitsmlExplorer.Api.Repositories;
 using WitsmlExplorer.Api.Services;
+
 namespace WitsmlExplorer.Api.Middleware
 {
     // Source: https://code-maze.com/global-error-handling-aspnetcore/
@@ -44,7 +46,7 @@ namespace WitsmlExplorer.Api.Middleware
             catch (EndpointNotFoundException ex)
             {
                 Log.Debug($"Not able to connect server endpoint. : {ex}");
-                ServerCredentials witsmlTarget = httpContext.Request.GetWitsmlServerHttpHeader(WitsmlClientProvider.WitsmlTargetServerHeader, n => "");
+                ServerCredentials witsmlTarget = httpContext.Request.GetWitsmlServerHttpHeader(EssentialHeaders.WitsmlTargetServer, n => "");
                 ErrorDetails errorDetails = new()
                 {
                     StatusCode = (int)HttpStatusCode.NotFound,

--- a/Src/WitsmlExplorer.Api/Program.cs
+++ b/Src/WitsmlExplorer.Api/Program.cs
@@ -42,4 +42,12 @@ app.ConfigureApi(builder.Configuration);
 
 startup.Configure(app, app.Environment);
 
+foreach (var serv in builder.Services)
+{
+    if (serv.ServiceType.FullName.Contains("WitsmlClientProvider") && !serv.ServiceType.FullName.Contains("Microsoft"))
+    {
+        System.Console.WriteLine($"{serv.Lifetime} - {serv.ServiceType}");
+    }
+}
+
 app.Run();

--- a/Src/WitsmlExplorer.Api/Program.cs
+++ b/Src/WitsmlExplorer.Api/Program.cs
@@ -42,12 +42,4 @@ app.ConfigureApi(builder.Configuration);
 
 startup.Configure(app, app.Environment);
 
-foreach (var serv in builder.Services)
-{
-    if (serv.ServiceType.FullName.Contains("WitsmlClientProvider") && !serv.ServiceType.FullName.Contains("Microsoft"))
-    {
-        System.Console.WriteLine($"{serv.Lifetime} - {serv.ServiceType}");
-    }
-}
-
 app.Run();

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -58,8 +58,6 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
-            //app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, useOAuth2);
-            //app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);
         }
     }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -58,8 +58,8 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
-            app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, useOAuth2);
-            app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, useOAuth2);
+            //app.MapGet("/credentials/authorizeandsetcookie", AuthorizeHandler.AuthorizeAndSetCookie, useOAuth2);
+            //app.MapGet("/credentials/authorizewithcookie", AuthorizeHandler.AuthorizeWithCookie, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);
         }
     }

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -137,15 +137,11 @@ namespace WitsmlExplorer.Api.Services
             return HttpRequestExtensions.ParseServerHttpHeader(headerValue, Decrypt);
         }
 
-        public bool ValidEncryptedBasicCredentials(string headerValue)
+        public (string userPrincipalName, string witsmlUserName) GetUsernamesFromCookieAndToken(EssentialHeaders headers)
         {
-            return GetBasicCredentialsFromHeaderValue(headerValue) != null;
+            ServerCredentials witsmlCredentials = GetCredentialsCookieFirst(headers, EssentialHeaders.WitsmlTargetServer).Result;
+            return (GetTokenUserPrincipalName(headers.Authorization), witsmlCredentials.UserId);
         }
 
-        public (string userPrincipalName, string witsmlUserName) GetUsernamesFromHeaderValues(string authorization, string witsmlServerHeaderValue)
-        {
-            ServerCredentials witsmlCredentials = GetBasicCredentialsFromHeaderValue(witsmlServerHeaderValue);
-            return (GetTokenUserPrincipalName(authorization), witsmlCredentials.UserId);
-        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -13,6 +13,7 @@ using Witsml.Data;
 
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Extensions;
+using WitsmlExplorer.Api.HttpHandlers;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Repositories;
 
@@ -51,7 +52,7 @@ namespace WitsmlExplorer.Api.Services
             return Encrypt($"{credentials.UserId}:{credentials.Password}");
         }
 
-        public async Task<ServerCredentials> GetCredentialsCookieFirst(EssentialHeaders headers, string server)
+        public async Task<ServerCredentials> GetCredentialsCookieFirst(IEssentialHeaders headers, string server)
         {
             ServerCredentials result;
             if (headers.HasCookieCredentials(server))

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -2,12 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
-using System.Security.Principal;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -78,6 +75,7 @@ namespace WitsmlExplorer.Api.Services
             }
             return result;
         }
+
         private async Task VerifyCredentials(ServerCredentials serverCreds)
         {
             WitsmlClient witsmlClient = new(serverCreds.Host.ToString(), serverCreds.UserId, serverCreds.Password, _clientCapabilities);

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -57,7 +57,7 @@ namespace WitsmlExplorer.Api.Services
             ServerCredentials result;
             if (headers.HasCookieCredentials(server))
             {
-                var cred = Decrypt(headers.GetCookie(server)).Split(":");
+                string[] cred = Decrypt(headers.GetCookie(server)).Split(":");
                 result = new ServerCredentials(headers.GetHost(server), cred[0], cred[1]);
             }
             else

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -10,7 +10,7 @@ namespace WitsmlExplorer.Api.Services
         public Task<string> ProtectBasicAuthorization(string headerValue);
         public Task<ServerCredentials> GetCredentialsCookieFirst(IEssentialHeaders headers, string server);
         public Task<ServerCredentials> GetCredentialsFromHeaderValue(string headerValue, string token = null);
-        public bool ValidEncryptedBasicCredentials(string headerValue);
-        public (string userPrincipalName, string witsmlUserName) GetUsernamesFromHeaderValues(string authorization, string witsmltargetserver);
+        public (string userPrincipalName, string witsmlUserName) GetUsernamesFromCookieAndToken(EssentialHeaders headers);
+
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -7,6 +7,7 @@ namespace WitsmlExplorer.Api.Services
     public interface ICredentialsService
     {
         public Task<string> ProtectBasicAuthorization(string headerValue);
+        public Task<ServerCredentials> GetCredentialsCookieFirst(EssentialHeaders headers, string server);
         public Task<ServerCredentials> GetCredentialsFromHeaderValue(string headerValue, string token = null);
         public bool ValidEncryptedBasicCredentials(string headerValue);
         public (string userPrincipalName, string witsmlUserName) GetUsernamesFromHeaderValues(string authorization, string witsmltargetserver);

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -10,7 +10,6 @@ namespace WitsmlExplorer.Api.Services
         public Task<string> ProtectBasicAuthorization(string headerValue);
         public Task<ServerCredentials> GetCredentialsCookieFirst(IEssentialHeaders headers, string server);
         public Task<ServerCredentials> GetCredentialsFromHeaderValue(string headerValue, string token = null);
-        public bool ValidEncryptedBasicCredentials(string headerValue);
-        public (string userPrincipalName, string witsmlUserName) GetUsernamesFromHeaderValues(string authorization, string witsmltargetserver);
+        public (string userPrincipalName, string witsmlUserName) GetUsernamesFromCookieAndToken(EssentialHeaders headers);
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -1,13 +1,14 @@
 using System.Threading.Tasks;
 
 using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.HttpHandlers;
 
 namespace WitsmlExplorer.Api.Services
 {
     public interface ICredentialsService
     {
         public Task<string> ProtectBasicAuthorization(string headerValue);
-        public Task<ServerCredentials> GetCredentialsCookieFirst(EssentialHeaders headers, string server);
+        public Task<ServerCredentials> GetCredentialsCookieFirst(IEssentialHeaders headers, string server);
         public Task<ServerCredentials> GetCredentialsFromHeaderValue(string headerValue, string token = null);
         public bool ValidEncryptedBasicCredentials(string headerValue);
         public (string userPrincipalName, string witsmlUserName) GetUsernamesFromHeaderValues(string authorization, string witsmltargetserver);

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -4,7 +4,7 @@ using Microsoft.OpenApi.Models;
 
 using Swashbuckle.AspNetCore.SwaggerGen;
 
-using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.HttpHandlers;
 
 namespace WitsmlExplorer.Api.Swagger
 {
@@ -15,8 +15,8 @@ namespace WitsmlExplorer.Api.Swagger
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            List<string> emptyHeader = new() { typeof(HttpHandlers.WitsmlServerHandler).ToString() };
-            List<string> witsmlSourceHeader = new() { typeof(HttpHandlers.JobHandler).ToString() };
+            List<string> emptyHeader = new() { typeof(WitsmlServerHandler).ToString() };
+            List<string> witsmlSourceHeader = new() { typeof(JobHandler).ToString() };
             if (operation.Parameters == null)
             {
                 operation.Parameters = new List<OpenApiParameter>();
@@ -27,7 +27,7 @@ namespace WitsmlExplorer.Api.Swagger
             {
                 operation.Parameters.Add(new OpenApiParameter
                 {
-                    Name = WitsmlClientProvider.WitsmlTargetServerHeader,
+                    Name = EssentialHeaders.WitsmlTargetServer,
                     In = ParameterLocation.Header,
                     Schema = new OpenApiSchema { Type = "string" },
                     Required = true
@@ -36,7 +36,7 @@ namespace WitsmlExplorer.Api.Swagger
                 {
                     operation.Parameters.Add(new OpenApiParameter
                     {
-                        Name = WitsmlClientProvider.WitsmlSourceServerHeader,
+                        Name = EssentialHeaders.WitsmlSourceServer,
                         In = ParameterLocation.Header,
                         Schema = new OpenApiSchema { Type = "string" },
                         Required = false

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -37,7 +37,7 @@ export const JobsView = (): React.ReactElement => {
 
   useEffect(() => {
     const eventHandler = (notification: Notification) => {
-      const shouldFetch = CredentialsService.hasPasswordForUrl(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
+      const shouldFetch = CredentialsService.isLoggedInTo(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
       if (shouldFetch) {
         setShouldRefresh(true);
       }

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -37,7 +37,8 @@ export const JobsView = (): React.ReactElement => {
 
   useEffect(() => {
     const eventHandler = (notification: Notification) => {
-      const shouldFetch = CredentialsService.isLoggedInTo(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
+      const shouldFetch =
+        CredentialsService.hasValidCookieForServer(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
       if (shouldFetch) {
         setShouldRefresh(true);
       }

--- a/Src/WitsmlExplorer.Frontend/components/JobsButton.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/JobsButton.tsx
@@ -15,8 +15,8 @@ const JobsButton = (): React.ReactElement => {
     dispatchNavigation({ type: NavigationType.SelectJobs, payload: {} });
   };
 
-  const currentPassword = CredentialsService.getCredentials().find((cred) => cred.server.id == selectedServer?.id)?.password;
-  const disabled = !selectedServer || (!msalEnabled && !currentPassword);
+  const access = CredentialsService.hasValidCookieForServer(selectedServer?.url);
+  const disabled = !selectedServer || (!msalEnabled && !access);
 
   return (
     <Button variant="ghost" onClick={onClick} disabled={disabled}>

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -44,6 +44,24 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     }
   }, [props]);
 
+  const onSave = async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+    const credentials = {
+      server,
+      username,
+      password
+    };
+    try {
+      const blank = "blank";
+      await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
+      CredentialsService.saveCredentials({ ...credentials, password: blank });
+    } catch (error) {
+      setErrorMessage(error.message);
+      setIsLoading(false);
+    }
+  };
+
   const onVerifyConnection = async () => {
     setIsLoading(true);
     setErrorMessage("");
@@ -55,13 +73,11 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     try {
       const blank = "";
       await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
-      CredentialsService.saveCredentials({ ...credentials, password: blank });
+      props.onConnectionVerified({ ...credentials, password: blank });
     } catch (error) {
       setErrorMessage(error.message);
     }
-    if (mode !== CredentialsMode.SAVE) {
-      setIsLoading(false);
-    }
+    setIsLoading(false);
   };
 
   return (
@@ -105,7 +121,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       }
       confirmDisabled={!validText(username) || !validText(password)}
       confirmText={confirmText ?? mode === CredentialsMode.SAVE ? "Login" : "Test"}
-      onSubmit={onVerifyConnection}
+      onSubmit={mode === CredentialsMode.SAVE ? onSave : onVerifyConnection}
       onCancel={props.onCancel}
       isLoading={isLoading}
       errorMessage={errorMessage}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -44,23 +44,6 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     }
   }, [props]);
 
-  const onSave = async () => {
-    setIsLoading(true);
-    setErrorMessage("");
-    const credentials = {
-      server,
-      username,
-      password
-    };
-    try {
-      await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
-      await CredentialsService.saveCredentials({ ...credentials, password: "cookie-handled" });
-    } catch (error) {
-      setErrorMessage(error.message);
-      setIsLoading(false);
-    }
-  };
-
   const onVerifyConnection = async () => {
     setIsLoading(true);
     setErrorMessage("");
@@ -70,12 +53,15 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       password
     };
     try {
+      const blank = "";
       await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
-      await CredentialsService.saveCredentials({ ...credentials, password: "cookie-handled" });
+      CredentialsService.saveCredentials({ ...credentials, password: blank });
     } catch (error) {
       setErrorMessage(error.message);
     }
-    setIsLoading(false);
+    if (mode === CredentialsMode.SAVE) {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -119,7 +105,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       }
       confirmDisabled={!validText(username) || !validText(password)}
       confirmText={confirmText ?? mode === CredentialsMode.SAVE ? "Login" : "Test"}
-      onSubmit={mode === CredentialsMode.SAVE ? onSave : onVerifyConnection}
+      onSubmit={onVerifyConnection}
       onCancel={props.onCancel}
       isLoading={isLoading}
       errorMessage={errorMessage}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -27,8 +27,8 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
   const [password, setPassword] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [keepLoggedIn, setKeepLoggedIn] = useState<boolean>(false);
   const shouldFocusPasswordInput = !!username;
+  const [keepLoggedIn, setKeepLoggedIn] = useState<boolean>(CredentialsService.keepLoggedInToServer(server.url));
 
   useEffect(() => {
     if (serverCredentials) {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -59,7 +59,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     } catch (error) {
       setErrorMessage(error.message);
     }
-    if (mode === CredentialsMode.SAVE) {
+    if (mode !== CredentialsMode.SAVE) {
       setIsLoading(false);
     }
   };

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -30,22 +30,6 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
   const [keepLoggedIn, setKeepLoggedIn] = useState<boolean>(false);
   const shouldFocusPasswordInput = !!username;
 
-  // const authorizeWithCookie = async () => {
-  //   try {
-  //     setIsLoading(true);
-  //     const creds = await CredentialsService.verifyCredentialsWithCookie({ server });
-  //     CredentialsService.saveCredentials(creds);
-  //   } catch (error) {
-  //     setIsLoading(false);
-  //   }
-  // };
-
-  // useEffect(() => {
-  //   if (CredentialsService.hasValidCookieForServer(server.url)) {
-  //     authorizeWithCookie();
-  //   }
-  // }, []);
-
   useEffect(() => {
     if (serverCredentials) {
       setUsername(serverCredentials.username);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -60,6 +60,23 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     }
   }, [props]);
 
+  const onSave = async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+    const credentials = {
+      server,
+      username,
+      password
+    };
+    try {
+      await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
+      await CredentialsService.saveCredentials({ ...credentials, password: "cookie-handled" });
+    } catch (error) {
+      setErrorMessage(error.message);
+      setIsLoading(false);
+    }
+  };
+
   const onVerifyConnection = async () => {
     setIsLoading(true);
     setErrorMessage("");
@@ -118,7 +135,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       }
       confirmDisabled={!validText(username) || !validText(password)}
       confirmText={confirmText ?? mode === CredentialsMode.SAVE ? "Login" : "Test"}
-      onSubmit={onVerifyConnection}
+      onSubmit={mode === CredentialsMode.SAVE ? onSave : onVerifyConnection}
       onCancel={props.onCancel}
       isLoading={isLoading}
       errorMessage={errorMessage}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -27,24 +27,24 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
   const [password, setPassword] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [keepLoggedIn, setKeepLoggedIn] = useState(CredentialsService.keepLoggedInToServer(server.url));
+  const [keepLoggedIn, setKeepLoggedIn] = useState<boolean>(false);
   const shouldFocusPasswordInput = !!username;
 
-  const authorizeWithCookie = async () => {
-    try {
-      setIsLoading(true);
-      const creds = await CredentialsService.verifyCredentialsWithCookie({ server });
-      CredentialsService.saveCredentials(creds);
-    } catch (error) {
-      setIsLoading(false);
-    }
-  };
+  // const authorizeWithCookie = async () => {
+  //   try {
+  //     setIsLoading(true);
+  //     const creds = await CredentialsService.verifyCredentialsWithCookie({ server });
+  //     CredentialsService.saveCredentials(creds);
+  //   } catch (error) {
+  //     setIsLoading(false);
+  //   }
+  // };
 
-  useEffect(() => {
-    if (CredentialsService.hasValidCookieForServer(server.url)) {
-      authorizeWithCookie();
-    }
-  }, []);
+  // useEffect(() => {
+  //   if (CredentialsService.hasValidCookieForServer(server.url)) {
+  //     authorizeWithCookie();
+  //   }
+  // }, []);
 
   useEffect(() => {
     if (serverCredentials) {
@@ -60,26 +60,6 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     }
   }, [props]);
 
-  const onSave = async () => {
-    setIsLoading(true);
-    setErrorMessage("");
-    const credentials = {
-      server,
-      username,
-      password
-    };
-    try {
-      const encryptedPassword = keepLoggedIn ? await CredentialsService.verifyCredentialsAndSetCookie(credentials) : await CredentialsService.verifyCredentials(credentials);
-      CredentialsService.saveCredentials({ ...credentials, password: encryptedPassword });
-      if (!keepLoggedIn) {
-        localStorage.removeItem(credentials.server.url);
-      }
-    } catch (error) {
-      setErrorMessage(error.message);
-      setIsLoading(false);
-    }
-  };
-
   const onVerifyConnection = async () => {
     setIsLoading(true);
     setErrorMessage("");
@@ -89,8 +69,8 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       password
     };
     try {
-      const encryptedPassword = await CredentialsService.verifyCredentials(credentials);
-      props.onConnectionVerified({ ...credentials, password: encryptedPassword });
+      await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
+      await CredentialsService.saveCredentials({ ...credentials, password: "cookie-handled" });
     } catch (error) {
       setErrorMessage(error.message);
     }
@@ -138,7 +118,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       }
       confirmDisabled={!validText(username) || !validText(password)}
       confirmText={confirmText ?? mode === CredentialsMode.SAVE ? "Login" : "Test"}
-      onSubmit={mode === CredentialsMode.SAVE ? onSave : onVerifyConnection}
+      onSubmit={onVerifyConnection}
       onCancel={props.onCancel}
       isLoading={isLoading}
       errorMessage={errorMessage}

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
@@ -2,7 +2,7 @@ import { useIsAuthenticated } from "@azure/msal-react";
 import { Typography } from "@equinor/eds-core-react";
 import { Divider, FormControl as MuiFormControl, FormHelperText, InputLabel, Link, ListItemIcon, ListItemSecondaryAction, MenuItem, Select } from "@material-ui/core";
 import React, { useContext, useEffect, useState } from "react";
-import { useIdleTimer } from "react-idle-timer";
+// import { useIdleTimer } from "react-idle-timer";
 import styled from "styled-components";
 import ModificationType from "../../contexts/modificationType";
 import NavigationContext from "../../contexts/navigationContext";
@@ -22,7 +22,7 @@ import ServerModal, { ServerModalProps } from "../Modals/ServerModal";
 import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
 
 const NEW_SERVER_ID = "1";
-const IDLE_TIMEOUT = 1000 * 60 * 10;
+// const IDLE_TIMEOUT = 1000 * 60 * 10;
 
 const ServerManager = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
@@ -142,14 +142,14 @@ const ServerManager = (): React.ReactElement => {
     }
   };
 
-  const onIdle = () => {
-    if (!msalEnabled && selectedServer?.id) {
-      CredentialsService.clearPasswords();
-      showCredentialsModal(selectedServer);
-    }
-  };
+  // const onIdle = () => {
+  //   if (!msalEnabled && selectedServer?.id) {
+  //     CredentialsService.clearPasswords();
+  //     showCredentialsModal(selectedServer);
+  //   }
+  // };
 
-  useIdleTimer({ onIdle: onIdle, timeout: IDLE_TIMEOUT });
+  // useIdleTimer({ onIdle: onIdle, timeout: IDLE_TIMEOUT });
 
   return (
     <>

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ServerManager.tsx
@@ -2,7 +2,6 @@ import { useIsAuthenticated } from "@azure/msal-react";
 import { Typography } from "@equinor/eds-core-react";
 import { Divider, FormControl as MuiFormControl, FormHelperText, InputLabel, Link, ListItemIcon, ListItemSecondaryAction, MenuItem, Select } from "@material-ui/core";
 import React, { useContext, useEffect, useState } from "react";
-// import { useIdleTimer } from "react-idle-timer";
 import styled from "styled-components";
 import ModificationType from "../../contexts/modificationType";
 import NavigationContext from "../../contexts/navigationContext";
@@ -22,7 +21,6 @@ import ServerModal, { ServerModalProps } from "../Modals/ServerModal";
 import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
 
 const NEW_SERVER_ID = "1";
-// const IDLE_TIMEOUT = 1000 * 60 * 10;
 
 const ServerManager = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
@@ -141,15 +139,6 @@ const ServerManager = (): React.ReactElement => {
       }
     }
   };
-
-  // const onIdle = () => {
-  //   if (!msalEnabled && selectedServer?.id) {
-  //     CredentialsService.clearPasswords();
-  //     showCredentialsModal(selectedServer);
-  //   }
-  // };
-
-  // useIdleTimer({ onIdle: onIdle, timeout: IDLE_TIMEOUT });
 
   return (
     <>

--- a/Src/WitsmlExplorer.Frontend/components/Snackbar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Snackbar.tsx
@@ -10,7 +10,7 @@ const Snackbar = (): React.ReactElement => {
 
   useEffect(() => {
     const unsubscribe = NotificationService.Instance.snackbarDispatcherAsEvent.subscribe((notification) => {
-      const shouldNotify = CredentialsService.hasPasswordForUrl(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
+      const shouldNotify = CredentialsService.isLoggedInTo(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
       if (shouldNotify) {
         enqueueSnackbar(notification.message, {
           variant: notification.isSuccess ? "success" : "error"

--- a/Src/WitsmlExplorer.Frontend/components/Snackbar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Snackbar.tsx
@@ -10,7 +10,8 @@ const Snackbar = (): React.ReactElement => {
 
   useEffect(() => {
     const unsubscribe = NotificationService.Instance.snackbarDispatcherAsEvent.subscribe((notification) => {
-      const shouldNotify = CredentialsService.isLoggedInTo(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
+      const shouldNotify =
+        CredentialsService.hasValidCookieForServer(notification.serverUrl.toString()) || notification.serverUrl.toString() === navigationState.selectedServer?.url;
       if (shouldNotify) {
         enqueueSnackbar(notification.message, {
           variant: notification.isSuccess ? "success" : "error"

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -54,22 +54,24 @@ export class ApiClient {
     abortSignal: AbortSignal | null = null,
     currentCredentials: BasicServerCredentials[] = CredentialsService.getCredentials()
   ): Promise<Response> {
-    const requestInit = {
+    const requestInit: RequestInit = {
       signal: abortSignal,
       method: "POST",
       body: body,
-      headers: await ApiClient.getCommonHeaders(currentCredentials, true)
+      headers: await ApiClient.getCommonHeaders(currentCredentials, true),
+      ...{ credentials: "include" }
     };
     return ApiClient.runHttpRequest(pathName, requestInit);
   }
 
   public static async patch(pathName: string, body: string, abortSignal: AbortSignal | null = null): Promise<Response> {
     const currentCredentials = CredentialsService.getCredentials();
-    const requestInit = {
+    const requestInit: RequestInit = {
       signal: abortSignal,
       method: "PATCH",
       body: body,
-      headers: await ApiClient.getCommonHeaders(currentCredentials, true)
+      headers: await ApiClient.getCommonHeaders(currentCredentials, true),
+      ...{ credentials: "include" }
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);
@@ -77,10 +79,11 @@ export class ApiClient {
 
   public static async delete(pathName: string, abortSignal: AbortSignal | null = null): Promise<Response> {
     const currentCredentials = CredentialsService.getCredentials();
-    const requestInit = {
+    const requestInit: RequestInit = {
       signal: abortSignal,
       method: "DELETE",
-      headers: await ApiClient.getCommonHeaders(currentCredentials, true)
+      headers: await ApiClient.getCommonHeaders(currentCredentials, true),
+      ...{ credentials: "include" }
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -88,6 +88,7 @@ export class ApiClient {
   }
 
   private static runHttpRequest(pathName: string, requestInit: RequestInit) {
+    CredentialsService.refreshLocalstorageSessions();
     return new Promise<Response>((resolve, reject) => {
       if (!("Authorization" in requestInit.headers)) {
         if (msalEnabled) {

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -37,13 +37,12 @@ export class ApiClient {
     pathName: string,
     abortSignal: AbortSignal | null = null,
     currentCredentials = CredentialsService.getCredentials(),
-    includeCredentials = true,
     serverHeaderOnly = true
   ): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
       headers: await ApiClient.getCommonHeaders(currentCredentials, serverHeaderOnly),
-      ...(includeCredentials ? { credentials: "include" } : {})
+      ...{ credentials: "include" }
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -82,29 +82,12 @@ class CredentialsService {
     return this.credentials.find((c) => c.server.id === this.sourceServer?.id);
   }
 
-  // public clearPasswords() {
-  //   this.credentials = this.credentials.map((creds) => {
-  //     if (this.hasValidCookieForServer(creds.server.url)) {
-  //       return creds;
-  //     }
-  //     return { server: creds.server };
-  //   });
-  //   if (!this.hasValidCookieForServer(this.server.url)) {
-  //     this._onCredentialStateChanged.dispatch({ server: this.server, hasPassword: this.isAuthorizedForServer(this.server) });
-  //   }
-  // }
-
   public isAuthorizedForServer(server: Server): boolean {
     if (msalEnabled && server?.securityscheme == SecurityScheme.OAuth2 && getUserAppRoles().some((x) => server.roles.includes(x))) {
       return true;
     }
     return this.hasValidCookieForServer(server?.url);
-    //return this.credentials.find((c) => c.server.id === server?.id)?.password !== undefined;
   }
-
-  // public hasPasswordForUrl(serverUrl: string) {
-  //   return this.credentials.find((c) => c.server.url === serverUrl)?.password !== undefined;
-  // }
 
   public hasValidCookieForServer(serverUrl: string): boolean {
     //use local storage to check whether the cookie is valid, because the cookie is httpOnly
@@ -116,10 +99,6 @@ class CredentialsService {
       return new Date().getTime() < new Date(cInfo.expiry).getTime();
     }
   }
-
-  // public keepLoggedInToServer(serverUrl: string): boolean {
-  //   return !!localStorage.getItem(serverUrl) && localStorage.getItem(serverUrl);
-  // }
 
   // Verify basic credentials for the first time
   // Basic credentials for this call will be set in header: WitsmlTargetServer
@@ -136,36 +115,6 @@ class CredentialsService {
       CredentialsService.throwError(response.status, message);
     }
   }
-
-  // public async verifyCredentialsWithCookie(credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<BasicServerCredentials> {
-  //   const response = await ApiClient.get(`/api/credentials/authorizewithcookie`, abortSignal, [credentials], true);
-  //   if (response.ok) {
-  //     const cookie = await response.json();
-  //     const decoded = Buffer.from(cookie, "base64").toString();
-  //     const creds = decoded.split(":");
-  //     return {
-  //       server: credentials.server,
-  //       username: creds[0],
-  //       password: creds[1]
-  //     };
-  //   } else {
-  //     const { message }: ErrorDetails = await response.json();
-  //     CredentialsService.throwError(response.status, message);
-  //   }
-  // }
-
-  // public async verifyCredentialsAndSetCookie(credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<any> {
-  //   const response = await ApiClient.get(`/api/credentials/authorizeandsetcookie`, abortSignal, [credentials], true);
-  //   if (response.ok) {
-  //     const expirationTime = new Date();
-  //     expirationTime.setDate(expirationTime.getDate() + 1);
-  //     localStorage.setItem(credentials.server.url, expirationTime.toJSON());
-  //     return response.json();
-  //   } else {
-  //     const { message }: ErrorDetails = await response.json();
-  //     CredentialsService.throwError(response.status, message);
-  //   }
-  // }
 
   public async deauthorize(abortSignal?: AbortSignal): Promise<any> {
     const response = await ApiClient.get(`/api/credentials/deauthorize`, abortSignal, undefined, true);

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -130,7 +130,6 @@ class CredentialsService {
       .map((n) => JSON.parse(n))
       .filter((n) => n.type == "WExSession");
     cookies.forEach((element) => {
-      localStorage.removeItem(element.url);
       const refreshedCookie = { type: "WExSession", url: element.url, expiry: expirationTime };
       localStorage.setItem(element.url, JSON.stringify(refreshedCookie));
     });
@@ -139,7 +138,7 @@ class CredentialsService {
   // Verify basic credentials for the first time
   // Basic credentials for this call will be set in header: WitsmlTargetServer
   public async verifyCredentials(credentials: BasicServerCredentials, keep: boolean, abortSignal?: AbortSignal): Promise<any> {
-    const response = await ApiClient.get(`/api/credentials/authorize?keep=` + keep, abortSignal, [credentials], true, false);
+    const response = await ApiClient.get(`/api/credentials/authorize?keep=` + keep, abortSignal, [credentials], false);
     if (response.ok) {
       const offset = keep ? 24 : 1;
       const expirationTime = new Date();

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -93,15 +93,24 @@ class CredentialsService {
   public hasValidCookieForServer(serverUrl: string): boolean {
     //use local storage to check whether the cookie is valid, because the cookie is httpOnly
     const cookieInfo = localStorage.getItem(serverUrl);
-    if (!cookieInfo) {
-      return false;
-    } else {
+    if (this.isJsonString(cookieInfo)) {
       const cInfo: CookieInfo = JSON.parse(cookieInfo);
       return new Date().getTime() < new Date(cInfo.expiry).getTime();
     }
+    return false;
+  }
+
+  public keepLoggedInToServer(serverUrl: string): boolean {
+    const item = localStorage.getItem(serverUrl);
+    if (this.isJsonString(item)) {
+      const cookie: CookieInfo = JSON.parse(item);
+      return cookie.type === "WExPersistent";
+    }
+    return false;
   }
 
   private isJsonString(str: string) {
+    if (str === null) return false;
     try {
       JSON.parse(str);
     } catch (e) {

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -148,28 +148,6 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetUsernamesFromHeaderValues_ValidTokenValidRole_ReturnUPNFromToken()
-        {
-            string upn = "tokenuser@arpa.net";
-            string basicHeader = "http://some.url.com";
-            string token = $"Bearer {CreateJwtToken(new string[] { "validrole" }, false, upn)}";
-
-            (string tokenUser, _) = _credentialsService.GetUsernamesFromHeaderValues(token, basicHeader);
-            Assert.Equal(upn, tokenUser);
-        }
-
-        [Fact]
-        public void GetUsernamesFromHeaderValues_ValidTokenUserValidBasicUserValidRole_ReturnUsernames()
-        {
-            string upn = "tokenuser@arpa.net";
-            string witsmlServerHeaderValue = CreateBasicHeaderValue("basicuser", "basicpassword", "http://some.url.com");
-            string authorizationHeader = $"Bearer {CreateJwtToken(new string[] { "validrole" }, false, upn)}";
-
-            (string tokenUser, string basicUser) = _credentialsService.GetUsernamesFromHeaderValues(authorizationHeader, witsmlServerHeaderValue);
-            Assert.Equal((upn, "basicuser"), (tokenUser, basicUser));
-        }
-
-        [Fact]
         public void GetCredentialsCookieFirst_ValidCookie_ReturnCookieCreds()
         {
             string host = "http://some.targeturl.com/";

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -14,6 +14,7 @@ using Moq;
 using Witsml.Data;
 
 using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.HttpHandlers;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Repositories;
 using WitsmlExplorer.Api.Services;
@@ -69,7 +70,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCreds_BasicCreds_ReturnBasicCreds()
+        public void GetCredentialsFromHeaderValue_BasicCreds_ReturnBasicCreds()
         {
             string token = null;
             string basicHeader = CreateBasicHeaderValue("basicuser", "basicpassword", "http://some.url.com");
@@ -79,7 +80,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCreds_BasicNoCreds_ReturnEmpty()
+        public void GetCredentialsFromHeaderValue_BasicNoCreds_ReturnEmpty()
         {
             string token = null;
             string basicHeader = "http://some.url.com";
@@ -89,7 +90,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCreds_BasicNoHeader_ReturnEmpty()
+        public void GetCredentialsFromHeaderValue_BasicNoHeader_ReturnEmpty()
         {
             string token = null;
             string basicHeader = null;
@@ -98,7 +99,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             Assert.True(creds.IsCredsNullOrEmpty());
         }
         [Fact]
-        public void GetCreds_BasicAndTokenValidRolesHeaderValidURL_ReturnBasicCreds()
+        public void GetCredentialsFromHeaderValue_BasicAndTokenValidRolesHeaderValidURL_ReturnBasicCreds()
         {
             // WHEN
             //  Valid Basic credentials and Valid Bearer token are present along with Valid URL
@@ -112,7 +113,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCreds_ValidTokenValidRolesValidURLBasicHeader_ReturnSystemCreds()
+        public void GetCredentialsFromHeaderValue_ValidTokenValidRolesValidURLBasicHeader_ReturnSystemCreds()
         {
             // 1. CONFIG:   There is a server config in DB with URL: "http://some.url.com" and role: ["user"]
             // 2. CONFIG:   There exist system credentials in keyvault for server with URL: "http://some.url.com"
@@ -127,7 +128,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCreds_ValidTokenValidRolesInvalidURLBasicHeader_ReturnEmpty()
+        public void GetCredentialsFromHeaderValue_ValidTokenValidRolesInvalidURLBasicHeader_ReturnEmpty()
         {
             string basicHeader = "http://some.invalidurl.com";
             string token = CreateJwtToken(new string[] { "validrole" }, false, "tokenuser@arpa.net");
@@ -137,7 +138,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCreds_InvalidTokenRolesURLOnlyBasicHeader_ReturnEmpty()
+        public void GetCredentialsFromHeaderValue_InvalidTokenRolesURLOnlyBasicHeader_ReturnEmpty()
         {
             string basicHeader = "http://some.url.com";
             string token = CreateJwtToken(new string[] { "invalidrole" }, false, "tokenuser@arpa.net");
@@ -147,7 +148,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetUsernames_ValidTokenValidRole_ReturnUPNFromToken()
+        public void GetUsernamesFromHeaderValues_ValidTokenValidRole_ReturnUPNFromToken()
         {
             string upn = "tokenuser@arpa.net";
             string basicHeader = "http://some.url.com";
@@ -158,7 +159,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetUsernames_ValidTokenUserValidBasicUserValidRole_ReturnUsernames()
+        public void GetUsernamesFromHeaderValues_ValidTokenUserValidBasicUserValidRole_ReturnUsernames()
         {
             string upn = "tokenuser@arpa.net";
             string witsmlServerHeaderValue = CreateBasicHeaderValue("basicuser", "basicpassword", "http://some.url.com");
@@ -166,6 +167,41 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             (string tokenUser, string basicUser) = _credentialsService.GetUsernamesFromHeaderValues(authorizationHeader, witsmlServerHeaderValue);
             Assert.Equal((upn, "basicuser"), (tokenUser, basicUser));
+        }
+
+        [Fact]
+        public void GetCredentialsCookieFirst_ValidCookie_ReturnCookieCreds()
+        {
+            string host = "http://some.targeturl.com/";
+            ServerCredentials scTarget = new() { UserId = "cookieuser", Password = "cookiepass", Host = new Uri(host) };
+            IEssentialHeaders essentialHeaders = CreateEssentialHeaders(scTarget, null);
+            ServerCredentials serverCreds = _credentialsService.GetCredentialsCookieFirst(essentialHeaders, EssentialHeaders.WitsmlTargetServer).Result;
+
+            Assert.True(serverCreds.UserId == "cookieuser" && serverCreds.Password == "cookiepass" && serverCreds.Host.ToString() == host);
+        }
+
+        private static IEssentialHeaders CreateEssentialHeaders(ServerCredentials targetCreds, ServerCredentials sourceCreds)
+        {
+            Mock<IEssentialHeaders> essentialHeaders = new();
+            string targetCookie = CreateCookie(targetCreds, n => n);
+            string sourceCookie = CreateCookie(sourceCreds, n => n);
+            essentialHeaders.Setup(eh => eh.HasCookieCredentials(EssentialHeaders.WitsmlTargetServer)).Returns(!string.IsNullOrEmpty(targetCookie));
+            essentialHeaders.Setup(eh => eh.HasCookieCredentials(EssentialHeaders.WitsmlSourceServer)).Returns(!string.IsNullOrEmpty(sourceCookie));
+            essentialHeaders.Setup(eh => eh.GetHost(EssentialHeaders.WitsmlTargetServer)).Returns(targetCreds?.Host?.ToString());
+            essentialHeaders.Setup(eh => eh.GetHost(EssentialHeaders.WitsmlSourceServer)).Returns(sourceCreds?.Host?.ToString());
+            essentialHeaders.Setup(eh => eh.GetCookie(EssentialHeaders.WitsmlTargetServer)).Returns(targetCookie);
+            essentialHeaders.Setup(eh => eh.GetCookie(EssentialHeaders.WitsmlSourceServer)).Returns(sourceCookie);
+            return essentialHeaders.Object;
+        }
+
+        private static string CreateCookie(ServerCredentials creds, Func<string, string> encrypt)
+        {
+            if (creds == null)
+            {
+                return null;
+            }
+
+            return Convert.ToBase64String(Encoding.ASCII.GetBytes(encrypt(creds.UserId + ":" + creds.Password)));
         }
 
         private static string CreateBasicHeaderValue(string username, string dummypassword, string host)

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -177,7 +177,9 @@ namespace WitsmlExplorer.Api.Tests.Services
             IEssentialHeaders essentialHeaders = CreateEssentialHeaders(scTarget, null);
             ServerCredentials serverCreds = _credentialsService.GetCredentialsCookieFirst(essentialHeaders, EssentialHeaders.WitsmlTargetServer).Result;
 
-            Assert.True(serverCreds.UserId == "cookieuser" && serverCreds.Password == "cookiepass" && serverCreds.Host.ToString() == host);
+            Assert.True(serverCreds.UserId == "cookieuser");
+            Assert.True(serverCreds.Password == "cookiepass");
+            Assert.True(serverCreds.Host.ToString() == host);
         }
 
         private static IEssentialHeaders CreateEssentialHeaders(ServerCredentials targetCreds, ServerCredentials sourceCreds)


### PR DESCRIPTION
## Fixes
This pull request fixes `WE-613` and `WE-612`

## Description
Remove handling of passwords from frontend and use cookies exclusively as a replacement for Basic auth against WITSML servers.

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application
API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
Is part of story WE-586 and will be followed up by `WE-614` and `WE-615` to reduce header sizes for Basic auth, and support OAUTH along with no cookies and no frontend credentials handling.