### PR TITLE
WE-619 Refresh log objects instead of the whole wellbore

### DIFF
--- a/Src/WitsmlExplorer.Api/Models/EntityType.cs
+++ b/Src/WitsmlExplorer.Api/Models/EntityType.cs
@@ -9,6 +9,7 @@ namespace WitsmlExplorer.Api.Models
         Wellbore,
         BhaRuns,
         LogObject,
+        LogObjects,
         MessageObjects,
         Rigs,
         Risks,

--- a/Src/WitsmlExplorer.Api/Models/RefreshAction.cs
+++ b/Src/WitsmlExplorer.Api/Models/RefreshAction.cs
@@ -97,6 +97,22 @@ namespace WitsmlExplorer.Api.Models
             RefreshType = refreshType;
         }
     }
+
+    public class RefreshLogObjects : RefreshAction
+    {
+        public override EntityType EntityType => EntityType.LogObjects;
+        public string WellUid { get; }
+        public string WellboreUid { get; }
+        public RefreshType RefreshType { get; }
+
+        public RefreshLogObjects(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
+        {
+            WellUid = wellUid;
+            WellboreUid = wellboreUid;
+            RefreshType = refreshType;
+        }
+    }
+
     public class RefreshMessageObjects : RefreshAction
     {
         public override EntityType EntityType => EntityType.MessageObjects;

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
@@ -63,7 +63,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshLogObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
             string copiedLogsMessage = (sourceLogs.Length == 1 ? $"Copied log object {sourceLogs[0].Name}" : $"Copied {sourceLogs.Length} logs") + $" to: {targetWellbore.Name}";
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, copiedLogsMessage);
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteLogObjectsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteLogObjectsWorker.cs
@@ -39,7 +39,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                 UidWellbore = wellboreUid,
                 Uid = uid
             });
-            RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+            RefreshLogObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
@@ -42,6 +42,9 @@ const RefreshHandler = (): React.ReactElement => {
           case EntityType.LogObject:
             await refreshLogObject(refreshAction, modificationType);
             break;
+          case EntityType.LogObjects:
+            await refreshLogObjects(refreshAction, ModificationType.UpdateLogObjects);
+            break;
           case EntityType.MessageObjects:
             await refreshMessageObjects(refreshAction, modificationType);
             break;
@@ -124,6 +127,15 @@ const RefreshHandler = (): React.ReactElement => {
       const log = await LogObjectService.getLog(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.logObjectUid);
       if (log) {
         dispatchNavigation({ type: modificationType, payload: { log } });
+      }
+    }
+  }
+
+  async function refreshLogObjects(refreshAction: RefreshAction, modificationType: ModificationType) {
+    if (modificationType === ModificationType.UpdateLogObjects) {
+      const logs = await LogObjectService.getLogs(refreshAction.wellUid, refreshAction.wellboreUid);
+      if (logs) {
+        dispatchNavigation({ type: modificationType, payload: { logs, wellUid: refreshAction.wellUid, wellboreUid: refreshAction.wellboreUid } });
       }
     }
   }

--- a/Src/WitsmlExplorer.Frontend/models/entityType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/entityType.ts
@@ -3,6 +3,7 @@ enum EntityType {
   Wellbore = "Wellbore",
   BhaRuns = "BhaRuns",
   LogObject = "LogObject",
+  LogObjects = "LogObjects",
   MessageObjects = "MessageObjects",
   Risks = "Risks",
   Tubular = "Tubular",

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteLogObjectsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteLogObjectsWorkerTests.cs
@@ -57,7 +57,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 }
             };
             (WorkerResult result, RefreshAction refreshAction) = await _worker.Execute(job);
-            Assert.True(result.IsSuccess && ((RefreshWellbore)refreshAction).WellboreUid == WellboreUid);
+            Assert.True(result.IsSuccess && ((RefreshLogObjects)refreshAction).WellboreUid == WellboreUid);
         }
     }
 }


### PR DESCRIPTION
## Fixes
This pull request fixes WE-619

## Description
Refresh log objects instead of the whole wellbore on copy and delete logs.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
