### PR TITLE
WE-584 fix ordering of dependency injections

### DIFF
--- a/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
+++ b/Src/WitsmlExplorer.Api/Configuration/Dependencies.cs
@@ -21,13 +21,13 @@ namespace WitsmlExplorer.Api.Configuration
     {
         public static void ConfigureDependencies(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton<ICredentialsService, CredentialsService>();
-            services.AddScoped<IWitsmlClientProvider, WitsmlClientProvider>();
-            AddRepository<Server, Guid>(services, configuration);
             services.RegisterAssemblyPublicNonGenericClasses(Assembly.GetAssembly(typeof(Program)))
                 .IgnoreThisInterface<ICopyLogDataWorker>()
                 .IgnoreThisInterface<ICredentials>()
                 .AsPublicImplementedInterfaces();
+            AddRepository<Server, Guid>(services, configuration);
+            services.AddSingleton<ICredentialsService, CredentialsService>();
+            services.AddScoped<IWitsmlClientProvider, WitsmlClientProvider>();
             services.AddSingleton<IJobCache, JobCache>();
             services.AddSingleton<IJobQueue, JobQueue>();
             services.AddSingleton<IWitsmlSystemCredentials, WitsmlSystemCredentials>();


### PR DESCRIPTION
## Fixes
This pull request fixes WE-584

## Description
Reorder dependency injections to respect the scopes represented by the Add methods. Previous ordering made the scopes called above RegisterAssemblyPublicNonGenericClasses overshadowed by transient services.

## Type of change
* Bugfix

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
