### PR TITLE
WE-623 show message on no wells matching filter

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -13,7 +13,7 @@ export interface WellRow extends ContentTableRow, Well {}
 
 export const WellsListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { servers, filteredWells } = navigationState;
+  const { servers, filteredWells, wells } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
@@ -44,7 +44,11 @@ export const WellsListView = (): React.ReactElement => {
 
   return (
     <WellProgress>
-      <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />
+      {wells.length > 0 && filteredWells.length == 0 ? (
+        <>No wells match the current filter</>
+      ) : (
+        <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} checkableRows />
+      )}
     </WellProgress>
   );
 };


### PR DESCRIPTION
## Fixes
This pull request fixes WE-623

## Description
Show a message that no wells match the current filter instead of showing an empty table. The message could have been presented more nicely but it should be better than showing an empty table anyway.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
