### PR TITLE
WE-626 fix navigation on deletion of currently selected object

### DIFF
--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -283,12 +283,13 @@ it("Should update logs for selected wellbore", () => {
 });
 
 it("Should update trajectories for selected wellbore", () => {
+  const updatedTrajectory = { ...TRAJECTORY_1, name: "Updated" };
   const updateTrajectoryOnWellbore = {
     type: ModificationType.UpdateTrajectoriesOnWellbore,
     payload: {
       wellUid: WELL_1.uid,
       wellboreUid: WELLBORE_1.uid,
-      trajectories: [{ ...TRAJECTORY_1, name: "Updated" }]
+      trajectories: [updatedTrajectory]
     }
   };
   const initialState = {
@@ -298,17 +299,51 @@ it("Should update trajectories for selected wellbore", () => {
     selectedTrajectoryGroup: TRAJECTORY_GROUP_1,
     selectedTrajectory: { ...TRAJECTORY_1 }
   };
-  const updatedWellbore = { ...WELLBORE_1, trajectories: [{ ...TRAJECTORY_1, name: "Updated" }] };
+  const updatedWellbore = { ...WELLBORE_1, trajectories: [updatedTrajectory] };
   const actual = reducer(initialState, updateTrajectoryOnWellbore);
 
   const updatedWell = { ...WELL_1, wellbores: [updatedWellbore] };
-  const selectedTrajectory: Trajectory = null;
   expect(actual).toStrictEqual({
     ...getInitialState(),
     selectedWell: updatedWell,
     selectedWellbore: updatedWellbore,
     selectedTrajectoryGroup: TRAJECTORY_GROUP_1,
-    selectedTrajectory,
+    selectedTrajectory: updatedTrajectory,
+    wells: [updatedWell, WELL_2, WELL_3],
+    filteredWells: [updatedWell, WELL_2, WELL_3]
+  });
+});
+
+it("Should update currentSelected if deleted", () => {
+  const newTrajectories: Trajectory[] = [];
+  const trajectoryGroup = calculateTrajectoryGroupId(WELLBORE_1);
+  const updateTrajectoryOnWellbore = {
+    type: ModificationType.UpdateTrajectoriesOnWellbore,
+    payload: {
+      wellUid: WELL_1.uid,
+      wellboreUid: WELLBORE_1.uid,
+      trajectories: newTrajectories
+    }
+  };
+  const initialState = {
+    ...getInitialState(),
+    selectedWell: { ...WELL_1 },
+    selectedWellbore: { ...WELLBORE_1 },
+    selectedTrajectoryGroup: trajectoryGroup,
+    selectedTrajectory: TRAJECTORY_1,
+    currentSelected: TRAJECTORY_1
+  };
+  const updatedWellbore = { ...WELLBORE_1, trajectories: newTrajectories };
+  const actual = reducer(initialState, updateTrajectoryOnWellbore);
+
+  const updatedWell = { ...WELL_1, wellbores: [updatedWellbore] };
+  expect(actual).toStrictEqual({
+    ...getInitialState(),
+    selectedWell: updatedWell,
+    selectedWellbore: updatedWellbore,
+    selectedTrajectoryGroup: trajectoryGroup,
+    selectedTrajectory: null,
+    currentSelected: trajectoryGroup,
     wells: [updatedWell, WELL_2, WELL_3],
     filteredWells: [updatedWell, WELL_2, WELL_3]
   });

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -3,7 +3,7 @@ import { LogCurveInfoRow } from "../components/ContentViews/LogCurveInfoListView
 import BhaRun from "../models/bhaRun";
 import LogObject from "../models/logObject";
 import MessageObject from "../models/messageObject";
-import { getObjectOnWellboreProperties } from "../models/objectOnWellbore";
+import ObjectOnWellbore, { getObjectOnWellboreProperties } from "../models/objectOnWellbore";
 import { ObjectType } from "../models/objectType";
 import Rig from "../models/rig";
 import RiskObject from "../models/riskObject";
@@ -457,10 +457,14 @@ const updateWellboreLogs = (state: NavigationState, { payload }: UpdateWellboreL
   const { wells } = state;
   const { logs, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { logs });
+  const calculateGroup = (wellbore: Wellbore) => calculateLogTypeId(wellbore, state.selectedLog.indexType);
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, calculateGroup, logs, state.selectedLog, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
-    wells: freshWells
+    wells: freshWells,
+    currentSelected,
+    selectedLog: newSelectedObject
   };
 };
 
@@ -512,11 +516,12 @@ const updateWellboreTrajectories = (state: NavigationState, { payload }: UpdateW
   const { wells } = state;
   const { trajectories, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { trajectories });
-  const selectedTrajectory: Trajectory = null;
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, calculateTrajectoryGroupId, trajectories, state.selectedTrajectory, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
-    selectedTrajectory,
+    selectedTrajectory: newSelectedObject,
+    currentSelected,
     wells: freshWells
   };
 };
@@ -525,11 +530,12 @@ const updateWellboreTubulars = (state: NavigationState, { payload }: UpdateWellb
   const { wells } = state;
   const { tubulars, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { tubulars });
-  const selectedTubular = tubulars.find((value) => value.uid === state.selectedTubular?.uid) ?? null;
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, calculateTubularGroupId, tubulars, state.selectedTubular, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
-    selectedTubular,
+    selectedTubular: newSelectedObject,
+    currentSelected,
     wells: freshWells
   };
 };
@@ -567,6 +573,31 @@ const updateWellboreWbGeometrys = (state: NavigationState, { payload }: UpdateWe
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
     wells: freshWells
+  };
+};
+
+//update the current selected object if the current selected object was deleted
+const getCurrentSelectedObjectIfRemoved = (
+  state: NavigationState,
+  calculateGroupId: (wellbore: Wellbore) => string,
+  objects: ObjectOnWellbore[],
+  selectedObject: ObjectOnWellbore,
+  updatedWellboreUid: string,
+  updatedWellUid: string
+) => {
+  const fetchedSelectedObject = objects.find((value) => value.uid === selectedObject?.uid);
+  const isCurrentlySelectedObjectRemoved =
+    state.selectedWell.uid == updatedWellUid &&
+    state.selectedWellbore.uid == updatedWellboreUid && // the update happened on the wellbore that is currently being browsed
+    selectedObject && // there exists a selected object of the same type as the object type that was updated
+    !fetchedSelectedObject && // the selected object does not exist among the objects fetched from the server, implying deletion
+    state.currentSelected == selectedObject; // the object that is currently selected was deleted, requiring update of currently selected object
+  //navigate from the currently selected object to its object group if it was deleted
+  const currentSelected = isCurrentlySelectedObjectRemoved ? calculateGroupId(state.selectedWellbore) : state.currentSelected;
+  return {
+    currentSelected,
+    //update the selected object if it was fetched
+    newSelectedObject: isCurrentlySelectedObjectRemoved ? null : fetchedSelectedObject ?? selectedObject
   };
 };
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-626

## Description
Navigate out of the currently selected object if a refresh action does not return the matching object. This concerns selectable objects such: Log, Tubular, Trajectory. The logic is quite complicated and there might be ways to simplify it.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests
