### PR TITLE
WE-637 bump version to 7

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -4,9 +4,7 @@
   "tools": {
     "dotnet-format": {
       "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
+      "commands": ["dotnet-format"]
     }
   }
 }

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,8 +3,10 @@
   "isRoot": true,
   "tools": {
     "dotnet-format": {
-      "version": "5.1.225507",
-      "commands": ["dotnet-format"]
+      "version": "5.1.250801",
+      "commands": [
+        "dotnet-format"
+      ]
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET 6
+      - name: Setup .NET 7
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
       - name: Build
         run: dotnet build /warnaserror --configuration Release
       - name: Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET 6
+      - name: Setup .NET 7
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
           source-url: https://nuget.pkg.github.com/equinor/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .vscode/*
 **/.vscode/*
 !.vscode/settings.json
+.eslintcache
 
 # User-specific files
 *.rsuser

--- a/Src/Witsml/Witsml.csproj
+++ b/Src/Witsml/Witsml.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
   </PropertyGroup>
 

--- a/Src/WitsmlExplorer.Api/Program.cs
+++ b/Src/WitsmlExplorer.Api/Program.cs
@@ -31,7 +31,7 @@ if (StringHelpers.ToBoolean(builder.Configuration[ConfigConstants.OAuth2Enabled]
 {
     builder.Configuration.AddAzureWitsmlServerCreds();
 }
-builder.Host.ConfigureLogging(logging => logging.ClearProviders());
+builder.Logging.ClearProviders();
 builder.Host.UseSerilog((hostingContext, loggerConfiguration) => loggerConfiguration.ReadFrom.Configuration(hostingContext.Configuration));
 
 Startup startup = new(builder.Configuration);

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -17,10 +17,7 @@ namespace WitsmlExplorer.Api.Swagger
         {
             List<string> emptyHeader = new() { typeof(WitsmlServerHandler).ToString() };
             List<string> witsmlSourceHeader = new() { typeof(JobHandler).ToString() };
-            if (operation.Parameters == null)
-            {
-                operation.Parameters = new List<OpenApiParameter>();
-            }
+            operation.Parameters ??= new List<OpenApiParameter>();
             bool noHeader = emptyHeader.Contains(context.MethodInfo.DeclaringType.FullName);
             bool sourceServerHeader = witsmlSourceHeader.Contains(context.MethodInfo.DeclaringType.FullName);
             if (!noHeader)

--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <IsPackable>false</IsPackable>
     <UserSecretsId>5de2e6cd-e42c-4fca-905c-39f60e8b2ea8</UserSecretsId>

--- a/Src/WitsmlExplorer.Console/WitsmlExplorer.Console.csproj
+++ b/Src/WitsmlExplorer.Console/WitsmlExplorer.Console.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/Src/WitsmlExplorer.Frontend/WitsmlExplorer.Frontend.csproj
+++ b/Src/WitsmlExplorer.Frontend/WitsmlExplorer.Frontend.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="build\**" />

--- a/Tests/Witsml.Tests/Witsml.Tests.csproj
+++ b/Tests/Witsml.Tests/Witsml.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>latestMajor</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Tests/WitsmlExplorer.Api.Tests/WitsmlExplorer.Api.Tests.csproj
+++ b/Tests/WitsmlExplorer.Api.Tests/WitsmlExplorer.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <LangVersion>latestMajor</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
@@ -23,7 +23,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         [GeneratedRegex("<dTimCreation>.+?<\\/dTimCreation>")]
         private static partial Regex DTimCreationRegex();
         [GeneratedRegex(">\\s+<")]
-        private static partial Regex FileTrajectoryRegex();
+        private static partial Regex WhitespaceBetweenElementsRegex();
         public BhaRunTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -47,7 +47,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 
             string fileBhaRunXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/bhaRun.xml"));
             //handle whitespace
-            fileBhaRunXml = FileTrajectoryRegex().Replace(fileBhaRunXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileBhaRunXml = WhitespaceBetweenElementsRegex().Replace(fileBhaRunXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileBhaRunXml, serverBhaRunXml);
         }
     }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
@@ -13,11 +13,17 @@ using Xunit;
 
 namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 {
-    public class BhaRunTests
+    public partial class BhaRunTests
     {
         private readonly WitsmlClient _client;
         private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
+        [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
+        private static partial Regex DTimLastChangeRegex();
+        [GeneratedRegex("<dTimCreation>.+?<\\/dTimCreation>")]
+        private static partial Regex DTimCreationRegex();
+        [GeneratedRegex(">\\s+<")]
+        private static partial Regex FileTrajectoryRegex();
         public BhaRunTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -36,14 +42,13 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             WitsmlBhaRuns serverBhaRun = await _client.GetFromStoreAsync(queryExisting, new OptionsIn(ReturnElements.All));
             string serverBhaRunXml = XmlHelper.Serialize(serverBhaRun);
             //disregard commonData times as they are handled by the Witsml Server
-            serverBhaRunXml = Regex.Replace(serverBhaRunXml, "<dTimCreation>.+?<\\/dTimCreation>", "");
-            serverBhaRunXml = Regex.Replace(serverBhaRunXml, "<dTimLastChange>.+?<\\/dTimLastChange>", "");
+            serverBhaRunXml = DTimCreationRegex().Replace(serverBhaRunXml, "");
+            serverBhaRunXml = DTimLastChangeRegex().Replace(serverBhaRunXml, "");
 
             string fileBhaRunXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/bhaRun.xml"));
             //handle whitespace
-            fileBhaRunXml = Regex.Replace(fileBhaRunXml, ">\\s+<", "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileBhaRunXml = FileTrajectoryRegex().Replace(fileBhaRunXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileBhaRunXml, serverBhaRunXml);
         }
-
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
@@ -24,7 +24,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
         private static partial Regex DTimLastChangeRegex();
         [GeneratedRegex(">\\s+<")]
-        private static partial Regex FileTrajectoryRegex();
+        private static partial Regex WhitespaceBetweenElementsRegex();
         public RigTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -48,7 +48,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 
             string fileRigXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/rig.xml"));
             //handle whitespace
-            fileRigXml = FileTrajectoryRegex().Replace(fileRigXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileRigXml = WhitespaceBetweenElementsRegex().Replace(fileRigXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileRigXml, serverRigXml);
         }
     }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
@@ -14,11 +14,17 @@ using Xunit;
 
 namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 {
-    public class RigTests
+    public partial class RigTests
     {
         private readonly WitsmlClient _client;
         private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
+        [GeneratedRegex("<dTimCreation>.+?<\\/dTimCreation>")]
+        private static partial Regex DTimCreationRegex();
+        [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
+        private static partial Regex DTimLastChangeRegex();
+        [GeneratedRegex(">\\s+<")]
+        private static partial Regex FileTrajectoryRegex();
         public RigTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -37,14 +43,13 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             WitsmlRigs serverRig = await _client.GetFromStoreAsync(queryExisting, new OptionsIn(ReturnElements.All));
             string serverRigXml = XmlHelper.Serialize(serverRig);
             //disregard commonData times as they are handled by the Witsml Server
-            serverRigXml = Regex.Replace(serverRigXml, "<dTimCreation>.+?<\\/dTimCreation>", "");
-            serverRigXml = Regex.Replace(serverRigXml, "<dTimLastChange>.+?<\\/dTimLastChange>", "");
+            serverRigXml = DTimCreationRegex().Replace(serverRigXml, "");
+            serverRigXml = DTimLastChangeRegex().Replace(serverRigXml, "");
 
             string fileRigXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/rig.xml"));
             //handle whitespace
-            fileRigXml = Regex.Replace(fileRigXml, ">\\s+<", "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileRigXml = FileTrajectoryRegex().Replace(fileRigXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileRigXml, serverRigXml);
         }
-
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
@@ -23,7 +23,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
         private static partial Regex DTimLastChangeRegex();
         [GeneratedRegex(">\\s+<")]
-        private static partial Regex FileTrajectoryRegex();
+        private static partial Regex WhitespaceBetweenElementsRegex();
         public TrajectoryTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -47,7 +47,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 
             string fileTrajectoryXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/trajectory.xml"));
             //handle whitespace
-            fileTrajectoryXml = FileTrajectoryRegex().Replace(fileTrajectoryXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileTrajectoryXml = WhitespaceBetweenElementsRegex().Replace(fileTrajectoryXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileTrajectoryXml, serverTrajectoryXml);
         }
     }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
@@ -13,11 +13,17 @@ using Xunit;
 
 namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 {
-    public class TrajectoryTests
+    public partial class TrajectoryTests
     {
         private readonly WitsmlClient _client;
         private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
+        [GeneratedRegex("<dTimCreation>.+?<\\/dTimCreation>")]
+        private static partial Regex DTimCreationRegex();
+        [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
+        private static partial Regex DTimLastChangeRegex();
+        [GeneratedRegex(">\\s+<")]
+        private static partial Regex FileTrajectoryRegex();
         public TrajectoryTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -36,14 +42,13 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             WitsmlTrajectories serverTrajectory = await _client.GetFromStoreAsync(queryExisting, new OptionsIn(ReturnElements.All));
             string serverTrajectoryXml = XmlHelper.Serialize(serverTrajectory);
             //disregard commonData times as they are handled by the Witsml Server
-            serverTrajectoryXml = Regex.Replace(serverTrajectoryXml, "<dTimCreation>.+?<\\/dTimCreation>", "");
-            serverTrajectoryXml = Regex.Replace(serverTrajectoryXml, "<dTimLastChange>.+?<\\/dTimLastChange>", "");
+            serverTrajectoryXml = DTimCreationRegex().Replace(serverTrajectoryXml, "");
+            serverTrajectoryXml = DTimLastChangeRegex().Replace(serverTrajectoryXml, "");
 
             string fileTrajectoryXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/trajectory.xml"));
             //handle whitespace
-            fileTrajectoryXml = Regex.Replace(fileTrajectoryXml, ">\\s+<", "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileTrajectoryXml = FileTrajectoryRegex().Replace(fileTrajectoryXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileTrajectoryXml, serverTrajectoryXml);
         }
-
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
@@ -14,11 +14,17 @@ using Xunit;
 
 namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 {
-    public class TubularTests
+    public partial class TubularTests
     {
         private readonly WitsmlClient _client;
         private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
+        [GeneratedRegex("<dTimCreation>.+?<\\/dTimCreation>")]
+        private static partial Regex DTimCreationRegex();
+        [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
+        private static partial Regex DTimLastChangeRegex();
+        [GeneratedRegex(">\\s+<")]
+        private static partial Regex FileTrajectoryRegex();
         public TubularTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -37,14 +43,13 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             WitsmlTubulars serverTubular = await _client.GetFromStoreAsync(queryExisting, new OptionsIn(ReturnElements.All));
             string serverTubularXml = XmlHelper.Serialize(serverTubular);
             //disregard commonData times as they are handled by the Witsml Server
-            serverTubularXml = Regex.Replace(serverTubularXml, "<dTimCreation>.+?<\\/dTimCreation>", "");
-            serverTubularXml = Regex.Replace(serverTubularXml, "<dTimLastChange>.+?<\\/dTimLastChange>", "");
+            serverTubularXml = DTimCreationRegex().Replace(serverTubularXml, "");
+            serverTubularXml = DTimLastChangeRegex().Replace(serverTubularXml, "");
 
             string fileTubularXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/tubular.xml"));
             //handle whitespace
-            fileTubularXml = Regex.Replace(fileTubularXml, ">\\s+<", "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileTubularXml = FileTrajectoryRegex().Replace(fileTubularXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileTubularXml, serverTubularXml);
         }
-
     }
 }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
@@ -24,7 +24,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         [GeneratedRegex("<dTimLastChange>.+?<\\/dTimLastChange>")]
         private static partial Regex DTimLastChangeRegex();
         [GeneratedRegex(">\\s+<")]
-        private static partial Regex FileTrajectoryRegex();
+        private static partial Regex WhitespaceBetweenElementsRegex();
         public TubularTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
@@ -48,7 +48,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
 
             string fileTubularXml = File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "../../../Resources/tubular.xml"));
             //handle whitespace
-            fileTubularXml = FileTrajectoryRegex().Replace(fileTubularXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
+            fileTubularXml = WhitespaceBetweenElementsRegex().Replace(fileTubularXml, "><").Replace("\t", " ").Replace("\n", "").Replace("\r", "");
             Assert.Equal(fileTubularXml, serverTubularXml);
         }
     }

--- a/Tests/WitsmlExplorer.IntegrationTests/WitsmlExplorer.IntegrationTests.csproj
+++ b/Tests/WitsmlExplorer.IntegrationTests/WitsmlExplorer.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>WitsmlExplorer.IntegrationTests</RootNamespace>


### PR DESCRIPTION
## Fixes
This pull request fixes #1646  and WE-637

## Description

- Bump version number from 6 to 7
- Add `.eslintcache` to .gitignore
- Fix build errors related to best practice using logging and minimal webapi
- Bump dotnet tool `dotnet-format`version
- Fix net7 Regex handling
