### PR TITLE
Fix-1647: Changed from using MapMethods to MapPatch in Routes.cs

### DIFF
--- a/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -67,15 +66,15 @@ namespace WitsmlExplorer.Api.Extensions
             }
         }
 
-        public static void MapMethods(this IEndpointRouteBuilder endpoints, string pattern, IEnumerable<string> httpMethods, Delegate handler, bool useOAuth2, params string[] policyNames)
+        public static void MapPatch(this IEndpointRouteBuilder endpoints, string pattern, Delegate handler, bool useOAuth2, params string[] policyNames)
         {
             if (useOAuth2)
             {
-                endpoints.MapMethods(ApiPath + pattern, httpMethods, handler).RequireAuthorization(policyNames);
+                endpoints.MapPatch(ApiPath + pattern, handler).RequireAuthorization(policyNames);
             }
             else
             {
-                endpoints.MapMethods(ApiPath + pattern, httpMethods, handler);
+                endpoints.MapPatch(ApiPath + pattern, handler);
             }
         }
     }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 
 using WitsmlExplorer.Api.Configuration;
@@ -17,7 +16,7 @@ namespace WitsmlExplorer.Api
 
             app.MapGet("/witsml-servers", WitsmlServerHandler.GetWitsmlServers, useOAuth2);
             app.MapPost("/witsml-servers", WitsmlServerHandler.CreateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
-            app.MapMethods("/witsml-servers/{witsmlServerId}", new[] { HttpMethods.Patch }, WitsmlServerHandler.UpdateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapPatch("/witsml-servers/{witsmlServerId}", WitsmlServerHandler.UpdateWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
             app.MapDelete("/witsml-servers/{witsmlServerId}", WitsmlServerHandler.DeleteWitsmlServer, useOAuth2, AuthorizationPolicyRoles.ADMIN);
 
             app.MapGet("/wells", WellHandler.GetAllWells, useOAuth2);


### PR DESCRIPTION
## Fixes
This pull request fixes #1647

## Description
Replaced the generic ``MapMethods`` in ``Routes.cs`` with the new ``MapPatch`` method. 
Also made corresponding changes in ``WitsmlExplorer.Api/Extensions/WebApplicationExtensions.cs``

## Type of change
* Enhancement of existing functionality

## Impacted Areas in Application

* Api

## Checklist:

*Communication*
* [X] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [X] I have self-reviewed my code
* [X] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [ ] New code is covered by passing tests

