### PR TITLE
change white-space to wrap instead of nowrap

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -172,7 +172,7 @@ const TableDataCell = styled(MuiTableCell)<{ type?: ContentType; clickable?: str
   ${({ type }) =>
     type === ContentType.String &&
     `
-    white-space: nowrap;
+    white-space: wrap;
     overflow: hidden;
     text-overflow: ellipsis;
   `};


### PR DESCRIPTION
## Fixes
This pull request fixes #1667 

## Description
Fixed issue where Content tables did not word-wrap on long inputs

## Type of change
* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [X] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [X] Code follows the style guidelines
* [X] I have self-reviewed my code
* [X] No new warnings are generated

*Test coverage*
* [X] Existing tests pass
* [ ] New code is covered by passing tests
