### PR TITLE
WE-669 Add sortable EDS table and use it in log comparison

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/SortableEdsTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/SortableEdsTable.tsx
@@ -23,7 +23,14 @@ export interface SortableEdsTableProps {
   caption: React.ReactNode;
 }
 
-//Source: equinor/design-system/packages/eds-core-react/src/components/Table/Table.stories.tsx v0.27.0 bde787d
+/**
+Source: github.com/equinor/design-system/packages/eds-core-react/src/components/Table/Table.stories.tsx v0.27.0 bde787d
+@param columns An array of columns including at least the name shown in the header and an accessor corresponding to the respective propert name in the data paremeter.
+Can optionally include sortDirection to pick a default column to sort on.
+@param data An array of data rows with property names matching accessors found in columns. The object in the array can optionally include [accessor]+'Value' properties,
+which will be displayed in the table without affecting sorting.
+@param caption A string or a ReactNode element representing the caption above the table.
+*/
 const SortableEdsTable = (props: SortableEdsTableProps): React.ReactElement => {
   const { columns, data, caption } = props;
 
@@ -31,8 +38,7 @@ const SortableEdsTable = (props: SortableEdsTableProps): React.ReactElement => {
     columns.map((col) => {
       return {
         ...col,
-        ...(col.isSorted === undefined ? { isSorted: false } : { isSorted: col.isSorted }),
-        ...(col.sortDirection === undefined ? { sortDirection: "none" } : { sortDirection: col.sortDirection })
+        ...(col.sortDirection === undefined ? { sortDirection: "none", isSorted: false } : { sortDirection: col.sortDirection, isSorted: true })
       };
     });
   const [state, setState] = useState<State>({ columns: initColumns() });
@@ -74,10 +80,10 @@ const SortableEdsTable = (props: SortableEdsTableProps): React.ReactElement => {
         }
         const { sortDirection, accessor } = sortedCol;
         if (sortDirection === "ascending") {
-          return left[accessor] > right[accessor] ? 1 : -1;
+          return left[accessor] > right[accessor] ? 1 : left[accessor] < right[accessor] ? -1 : 0;
         }
         if (sortDirection === "descending") {
-          return left[accessor] < right[accessor] ? 1 : -1;
+          return left[accessor] < right[accessor] ? 1 : left[accessor] > right[accessor] ? -1 : 0;
         }
       }),
     [state.columns]
@@ -118,7 +124,15 @@ const SortableEdsTable = (props: SortableEdsTableProps): React.ReactElement => {
 };
 
 const toCellValues = (data: Record<string, any>[], columns: Column[]): string[][] =>
-  data.map((item) => columns.map((column) => (typeof item[column.accessor] !== "undefined" ? (item[column.accessor] as string) : "")));
+  data.map((item) =>
+    columns.map((column) =>
+      typeof item[column.accessor + "Value"] !== "undefined"
+        ? (item[column.accessor + "Value"] as string)
+        : typeof item[column.accessor] !== "undefined"
+        ? (item[column.accessor] as string)
+        : ""
+    )
+  );
 
 const SortCell = styled(Table.Cell)<{ isSorted: boolean } & CellProps>`
   svg {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/SortableEdsTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/SortableEdsTable.tsx
@@ -1,0 +1,134 @@
+import { CellProps, Table } from "@equinor/eds-core-react";
+import { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
+import Icon from "../../../styles/Icons";
+
+export type SortDirection = "ascending" | "descending" | "none";
+
+export type Column = {
+  name: string | React.ReactNode;
+  accessor: string;
+  sortDirection?: SortDirection;
+  isSorted?: boolean;
+};
+
+type State = {
+  columns: Column[];
+  cellValues?: string[][];
+};
+
+export interface SortableEdsTableProps {
+  columns: Column[];
+  data: Record<string, any>[];
+  caption: React.ReactNode;
+}
+
+//Source: equinor/design-system/packages/eds-core-react/src/components/Table/Table.stories.tsx v0.27.0 bde787d
+const SortableEdsTable = (props: SortableEdsTableProps): React.ReactElement => {
+  const { columns, data, caption } = props;
+
+  const initColumns = (): Column[] =>
+    columns.map((col) => {
+      return {
+        ...col,
+        ...(col.isSorted === undefined ? { isSorted: false } : { isSorted: col.isSorted }),
+        ...(col.sortDirection === undefined ? { sortDirection: "none" } : { sortDirection: col.sortDirection })
+      };
+    });
+  const [state, setState] = useState<State>({ columns: initColumns() });
+
+  const onSortClick = (sortCol: Column) => {
+    const updateColumns = state.columns.map((col) => {
+      if (sortCol.accessor === col.accessor) {
+        let sortDirection: SortDirection = "none";
+        switch (sortCol.sortDirection) {
+          case "ascending":
+            sortDirection = "descending";
+            break;
+          default:
+            sortDirection = "ascending";
+            break;
+        }
+        return {
+          ...sortCol,
+          isSorted: true,
+          sortDirection
+        };
+      }
+      return {
+        ...col,
+        isSorted: false,
+        sortDirection: col.sortDirection ? ("none" as SortDirection) : undefined
+      };
+    });
+
+    setState({ ...state, columns: updateColumns });
+  };
+
+  const sortData = useCallback(
+    (data: Record<string, any>[]) =>
+      data.sort((left, right) => {
+        const sortedCol = state.columns.find((col) => col.isSorted);
+        if (!sortedCol) {
+          return 1;
+        }
+        const { sortDirection, accessor } = sortedCol;
+        if (sortDirection === "ascending") {
+          return left[accessor] > right[accessor] ? 1 : -1;
+        }
+        if (sortDirection === "descending") {
+          return left[accessor] < right[accessor] ? 1 : -1;
+        }
+      }),
+    [state.columns]
+  );
+
+  useEffect(() => {
+    if (state.columns) {
+      const sorted = sortData(data);
+      const cellValues = toCellValues(sorted, columns);
+      setState((prevState) => ({ ...prevState, cellValues }));
+    }
+  }, [state.columns, setState, sortData]);
+
+  return (
+    <Table>
+      <Table.Caption>{caption}</Table.Caption>
+      <Table.Head>
+        <Table.Row>
+          {state.columns.map((col) => (
+            <SortCell sort={col.sortDirection} key={`head-${col.accessor}`} onClick={col.sortDirection ? () => onSortClick(col) : undefined} isSorted={col.isSorted}>
+              {col.name}
+              <Icon name={col.sortDirection === "descending" ? "arrowDown" : "arrowUp"} />
+            </SortCell>
+          ))}
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {state.cellValues?.map((row) => (
+          <Table.Row key={row.toString()}>
+            {row.map((cellValue, i) => (
+              <Table.Cell key={i}>{cellValue}</Table.Cell>
+            ))}
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  );
+};
+
+const toCellValues = (data: Record<string, any>[], columns: Column[]): string[][] =>
+  data.map((item) => columns.map((column) => (typeof item[column.accessor] !== "undefined" ? (item[column.accessor] as string) : "")));
+
+const SortCell = styled(Table.Cell)<{ isSorted: boolean } & CellProps>`
+  svg {
+    visibility: ${({ isSorted }) => (isSorted ? "visible" : "hidden")};
+  }
+  &:hover {
+    svg {
+      visibility: visible;
+    }
+  }
+`;
+
+export default SortableEdsTable;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
@@ -1,5 +1,5 @@
-import { Button, Popover, Table, TextField, Typography } from "@equinor/eds-core-react";
-import { Dispatch, MutableRefObject, SetStateAction, useEffect, useRef, useState } from "react";
+import { Button, Popover, TextField, Typography } from "@equinor/eds-core-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import OperationType from "../../contexts/operationType";
 import LogCurveInfo from "../../models/logCurveInfo";
@@ -8,81 +8,12 @@ import { Server } from "../../models/server";
 import CredentialsService from "../../services/credentialsService";
 import LogObjectService from "../../services/logObjectService";
 import Icon from "../../styles/Icons";
+import SortableEdsTable, { Column } from "../ContentViews/table/SortableEdsTable";
 import { DispatchOperation } from "../ContextMenus/ContextMenuUtils";
 import { displayMissingLogModal } from "../Modals/MissingObjectModals";
 import ProgressSpinner from "../ProgressSpinner";
+import { calculateMismatchedIndexes, Indexes } from "./LogComparisonUtils";
 import ModalDialog, { ModalContentLayout, ModalWidth } from "./ModalDialog";
-
-interface Indexes {
-  mnemonic: string;
-  sourceStart: string;
-  targetStart: string;
-  sourceEnd: string;
-  targetEnd: string;
-}
-
-function logCurveInfoToIndexes(sourceLogCurveInfo?: LogCurveInfo, targetLogCurveInfo?: LogCurveInfo): Indexes {
-  return {
-    mnemonic: sourceLogCurveInfo ? sourceLogCurveInfo.mnemonic : targetLogCurveInfo.mnemonic,
-    sourceStart: getStartIndex(sourceLogCurveInfo),
-    targetStart: getStartIndex(targetLogCurveInfo),
-    sourceEnd: getEndIndex(sourceLogCurveInfo),
-    targetEnd: getEndIndex(targetLogCurveInfo)
-  };
-}
-
-function getStartIndex(logCurveInfo?: LogCurveInfo): string {
-  if (!logCurveInfo) {
-    return "-";
-  }
-  if (logCurveInfo.minDepthIndex != null) {
-    return logCurveInfo.minDepthIndex.toString();
-  }
-  if (logCurveInfo.minDateTimeIndex != null) {
-    return logCurveInfo.minDateTimeIndex.toString();
-  }
-  return "undefined";
-}
-
-function getEndIndex(logCurveInfo?: LogCurveInfo): string {
-  if (!logCurveInfo) {
-    return "-";
-  }
-  if (logCurveInfo.maxDepthIndex != null) {
-    return logCurveInfo.maxDepthIndex.toString();
-  }
-  if (logCurveInfo.maxDateTimeIndex != null) {
-    return logCurveInfo.maxDateTimeIndex.toString();
-  }
-  return "undefined";
-}
-
-function areMismatched(sourceLogCurveInfo: LogCurveInfo, targetLogCurveInfo: LogCurveInfo): boolean {
-  return (
-    sourceLogCurveInfo.minDateTimeIndex != targetLogCurveInfo.minDateTimeIndex ||
-    sourceLogCurveInfo.maxDateTimeIndex != targetLogCurveInfo.maxDateTimeIndex ||
-    sourceLogCurveInfo.minDepthIndex != targetLogCurveInfo.minDepthIndex ||
-    sourceLogCurveInfo.maxDepthIndex != targetLogCurveInfo.maxDepthIndex
-  );
-}
-
-export function calculateMismatchedIndexes(sourceLogCurveInfo: LogCurveInfo[], targetLogCurveInfo: LogCurveInfo[]): Indexes[] {
-  const mismatchedIndexes = [];
-
-  for (const sourceCurve of sourceLogCurveInfo) {
-    const targetCurve = targetLogCurveInfo.find((targetCurve) => targetCurve.mnemonic == sourceCurve.mnemonic);
-    if (!targetCurve || areMismatched(sourceCurve, targetCurve)) {
-      mismatchedIndexes.push(logCurveInfoToIndexes(sourceCurve, targetCurve));
-    }
-  }
-  for (const targetCurve of targetLogCurveInfo) {
-    const sourceCurve = sourceLogCurveInfo.find((sourceCurve) => sourceCurve.mnemonic == targetCurve.mnemonic);
-    if (!sourceCurve) {
-      mismatchedIndexes.push(logCurveInfoToIndexes(sourceCurve, targetCurve));
-    }
-  }
-  return mismatchedIndexes;
-}
 
 export interface LogComparisonModalProps {
   sourceLog: LogObject;
@@ -99,8 +30,6 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
   const [sourceType, setSourceType] = useState<string>();
   const [targetType, setTargetType] = useState<string>();
   const [indexTypesMatch, setIndexTypesMatch] = useState<boolean>();
-  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
-  const popoverAnchorRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const setCurves = async () => {
@@ -150,6 +79,22 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
     setIndexesToShow(mismatchedIndexes);
   }, [sourceLogCurveInfo, targetLogCurveInfo]);
 
+  const data = useMemo(
+    () =>
+      indexesToShow.map((indexes) => {
+        const startDifferent = indexes.sourceStart != indexes.targetStart;
+        const endDifferent = indexes.sourceEnd != indexes.targetEnd;
+        return {
+          mnemonic: indexes.mnemonic,
+          sourceStart: startDifferent ? <b>{indexes.sourceStart}</b> : indexes.sourceStart,
+          targetStart: startDifferent ? <b>{indexes.targetStart}</b> : indexes.targetStart,
+          sourceEnd: endDifferent ? <b>{indexes.sourceEnd} </b> : indexes.sourceEnd,
+          targetEnd: endDifferent ? <b>{indexes.targetEnd}</b> : indexes.targetEnd
+        };
+      }),
+    [indexesToShow]
+  );
+
   return (
     <ModalDialog
       heading={`Log comparison`}
@@ -167,7 +112,11 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
                   Unable to compare the logs due to different log types. Source is a {sourceType} log and target is a {targetType} log.
                 </span>
               )}
-              {indexesToShow.length != 0 && mismatchTable(indexesToShow, isPopoverOpen, setIsPopoverOpen, popoverAnchorRef)}
+              {indexesToShow.length != 0 && (
+                <TableLayout>
+                  <SortableEdsTable caption={<Caption />} columns={columns} data={data} />
+                </TableLayout>
+              )}
               {indexesToShow.length == 0 && indexTypesMatch && (
                 <span>
                   All the {sourceLogCurveInfo.length} source mnemonics match the {targetLogCurveInfo.length} target mnemonics.
@@ -187,57 +136,41 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
   );
 };
 
-function mismatchTable(mismatchedIndexes: Indexes[], isPopoverOpen: boolean, setIsPopoverOpen: Dispatch<SetStateAction<boolean>>, anchorRef: MutableRefObject<HTMLButtonElement>) {
+const columns: Column[] = [
+  { name: "Curve mnemonic", accessor: "mnemonic", sortDirection: "ascending", isSorted: true },
+  { name: "Source start", accessor: "sourceStart" },
+  { name: "Target start", accessor: "targetStart" },
+  { name: "Source end", accessor: "sourceEnd" },
+  { name: "Target end", accessor: "targetEnd" }
+];
+
+const Caption = (): React.ReactElement => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+
   return (
-    <>
-      <TableLayout>
-        <Table>
-          <Table.Caption>
-            <StyledTypography variant="h5">
-              <span style={{ paddingTop: "0.2rem" }}>Listing of Log Curves where the source indexes and end indexes do not match</span>
-              <Popover anchorEl={anchorRef.current} onClose={() => setIsPopoverOpen(false)} open={isPopoverOpen} placement="top">
-                <Popover.Content>
-                  <Typography variant="body_short">
-                    {"The following comparison is based on the logCurveInfo elements and does not look at the logData element itself. " +
-                      "The table shows only the mnemonics where the indexes do not match. " +
-                      "Mnemonics that are found in only one of the logs are also included. " +
-                      "Missing mnemonics are indicated by dashes as their index values. " +
-                      "Mnemonics that have a logCurveInfo element but have empty indexes are specifed as undefined. " +
-                      "Mnemonics that have equal index values are not shown. " +
-                      "Differing index values are shown in bold."}
-                  </Typography>
-                </Popover.Content>
-              </Popover>
-              <Button variant="ghost_icon" onClick={() => setIsPopoverOpen(true)} ref={anchorRef}>
-                <Icon name="infoCircle" />
-              </Button>
-            </StyledTypography>
-          </Table.Caption>
-          <Table.Head>
-            <Table.Row>
-              <Table.Cell>Curve mnemonic</Table.Cell>
-              <Table.Cell>Source start</Table.Cell>
-              <Table.Cell>Target start</Table.Cell>
-              <Table.Cell>Source end</Table.Cell>
-              <Table.Cell>Target end</Table.Cell>
-            </Table.Row>
-          </Table.Head>
-          <Table.Body>
-            {mismatchedIndexes.map((indexes, i) => (
-              <Table.Row key={i}>
-                <Table.Cell>{indexes.mnemonic}</Table.Cell>
-                <Table.Cell>{(indexes.sourceStart != indexes.targetStart && <b>{indexes.sourceStart}</b>) || indexes.sourceStart}</Table.Cell>
-                <Table.Cell>{(indexes.sourceStart != indexes.targetStart && <b>{indexes.targetStart}</b>) || indexes.targetStart}</Table.Cell>
-                <Table.Cell>{(indexes.sourceEnd != indexes.targetEnd && <b>{indexes.sourceEnd}</b>) || indexes.sourceEnd}</Table.Cell>
-                <Table.Cell>{(indexes.sourceEnd != indexes.targetEnd && <b>{indexes.targetEnd}</b>) || indexes.targetEnd}</Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      </TableLayout>
-    </>
+    <StyledTypography variant="h5">
+      <span style={{ paddingTop: "0.2rem" }}>Listing of Log Curves where the source indexes and end indexes do not match</span>
+      <Popover anchorEl={anchorRef.current} onClose={() => setIsPopoverOpen(false)} open={isPopoverOpen} placement="top">
+        <Popover.Content>
+          <Typography variant="body_short">
+            {"The following comparison is based on the logCurveInfo elements and does not look at the logData element itself. " +
+              "The table shows only the mnemonics where the indexes do not match. " +
+              "Mnemonics that are found in only one of the logs are also included. " +
+              "Missing mnemonics are indicated by dashes as their index values. " +
+              "Mnemonics that have a logCurveInfo element but have empty indexes are specifed as undefined. " +
+              "Mnemonics that have equal index values are not shown. " +
+              "Differing index values are shown in bold."}
+          </Typography>
+        </Popover.Content>
+      </Popover>
+      <Button variant="ghost_icon" onClick={() => setIsPopoverOpen(true)} ref={anchorRef}>
+        <Icon name="infoCircle" />
+      </Button>
+    </StyledTypography>
   );
-}
+};
+
 const TableLayout = styled.div`
   display: flex;
   flex-direction: column;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
@@ -81,7 +81,7 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
 
   const data = useMemo(
     () =>
-      indexesToShow.map((indexes) => {
+      indexesToShow?.map((indexes) => {
         const startDifferent = indexes.sourceStart != indexes.targetStart;
         const endDifferent = indexes.sourceEnd != indexes.targetEnd;
         return {
@@ -112,7 +112,7 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
                   Unable to compare the logs due to different log types. Source is a {sourceType} log and target is a {targetType} log.
                 </span>
               )}
-              {indexesToShow.length != 0 && (
+              {indexesToShow.length != 0 && data && (
                 <TableLayout>
                   <SortableEdsTable caption={<Caption />} columns={columns} data={data} />
                 </TableLayout>

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
@@ -85,11 +85,11 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
         const startDifferent = indexes.sourceStart != indexes.targetStart;
         const endDifferent = indexes.sourceEnd != indexes.targetEnd;
         return {
-          mnemonic: indexes.mnemonic,
-          sourceStart: startDifferent ? <b>{indexes.sourceStart}</b> : indexes.sourceStart,
-          targetStart: startDifferent ? <b>{indexes.targetStart}</b> : indexes.targetStart,
-          sourceEnd: endDifferent ? <b>{indexes.sourceEnd} </b> : indexes.sourceEnd,
-          targetEnd: endDifferent ? <b>{indexes.targetEnd}</b> : indexes.targetEnd
+          ...indexes,
+          sourceStartValue: startDifferent ? <b>{indexes.sourceStart}</b> : indexes.sourceStart,
+          targetStartValue: startDifferent ? <b>{indexes.targetStart}</b> : indexes.targetStart,
+          sourceEndValue: endDifferent ? <b>{indexes.sourceEnd} </b> : indexes.sourceEnd,
+          targetEndValue: endDifferent ? <b>{indexes.targetEnd}</b> : indexes.targetEnd
         };
       }),
     [indexesToShow]
@@ -137,7 +137,7 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
 };
 
 const columns: Column[] = [
-  { name: "Curve mnemonic", accessor: "mnemonic", sortDirection: "ascending", isSorted: true },
+  { name: "Curve mnemonic", accessor: "mnemonic", sortDirection: "ascending" },
   { name: "Source start", accessor: "sourceStart" },
   { name: "Target start", accessor: "targetStart" },
   { name: "Source end", accessor: "sourceEnd" },

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonUtils.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonUtils.ts
@@ -2,10 +2,10 @@ import LogCurveInfo from "../../models/logCurveInfo";
 
 export interface Indexes {
   mnemonic: string;
-  sourceStart: string;
-  targetStart: string;
-  sourceEnd: string;
-  targetEnd: string;
+  sourceStart: string | number;
+  targetStart: string | number;
+  sourceEnd: string | number;
+  targetEnd: string | number;
 }
 
 function logCurveInfoToIndexes(sourceLogCurveInfo?: LogCurveInfo, targetLogCurveInfo?: LogCurveInfo): Indexes {
@@ -18,28 +18,28 @@ function logCurveInfoToIndexes(sourceLogCurveInfo?: LogCurveInfo, targetLogCurve
   };
 }
 
-function getStartIndex(logCurveInfo?: LogCurveInfo): string {
+function getStartIndex(logCurveInfo?: LogCurveInfo): string | number {
   if (!logCurveInfo) {
     return "-";
   }
   if (logCurveInfo.minDepthIndex != null) {
-    return logCurveInfo.minDepthIndex.toString();
+    return logCurveInfo.minDepthIndex;
   }
   if (logCurveInfo.minDateTimeIndex != null) {
-    return logCurveInfo.minDateTimeIndex.toString();
+    return logCurveInfo.minDateTimeIndex;
   }
   return "undefined";
 }
 
-function getEndIndex(logCurveInfo?: LogCurveInfo): string {
+function getEndIndex(logCurveInfo?: LogCurveInfo): string | number {
   if (!logCurveInfo) {
     return "-";
   }
   if (logCurveInfo.maxDepthIndex != null) {
-    return logCurveInfo.maxDepthIndex.toString();
+    return logCurveInfo.maxDepthIndex;
   }
   if (logCurveInfo.maxDateTimeIndex != null) {
-    return logCurveInfo.maxDateTimeIndex.toString();
+    return logCurveInfo.maxDateTimeIndex;
   }
   return "undefined";
 }

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonUtils.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonUtils.ts
@@ -1,0 +1,72 @@
+import LogCurveInfo from "../../models/logCurveInfo";
+
+export interface Indexes {
+  mnemonic: string;
+  sourceStart: string;
+  targetStart: string;
+  sourceEnd: string;
+  targetEnd: string;
+}
+
+function logCurveInfoToIndexes(sourceLogCurveInfo?: LogCurveInfo, targetLogCurveInfo?: LogCurveInfo): Indexes {
+  return {
+    mnemonic: sourceLogCurveInfo ? sourceLogCurveInfo.mnemonic : targetLogCurveInfo.mnemonic,
+    sourceStart: getStartIndex(sourceLogCurveInfo),
+    targetStart: getStartIndex(targetLogCurveInfo),
+    sourceEnd: getEndIndex(sourceLogCurveInfo),
+    targetEnd: getEndIndex(targetLogCurveInfo)
+  };
+}
+
+function getStartIndex(logCurveInfo?: LogCurveInfo): string {
+  if (!logCurveInfo) {
+    return "-";
+  }
+  if (logCurveInfo.minDepthIndex != null) {
+    return logCurveInfo.minDepthIndex.toString();
+  }
+  if (logCurveInfo.minDateTimeIndex != null) {
+    return logCurveInfo.minDateTimeIndex.toString();
+  }
+  return "undefined";
+}
+
+function getEndIndex(logCurveInfo?: LogCurveInfo): string {
+  if (!logCurveInfo) {
+    return "-";
+  }
+  if (logCurveInfo.maxDepthIndex != null) {
+    return logCurveInfo.maxDepthIndex.toString();
+  }
+  if (logCurveInfo.maxDateTimeIndex != null) {
+    return logCurveInfo.maxDateTimeIndex.toString();
+  }
+  return "undefined";
+}
+
+function areMismatched(sourceLogCurveInfo: LogCurveInfo, targetLogCurveInfo: LogCurveInfo): boolean {
+  return (
+    sourceLogCurveInfo.minDateTimeIndex != targetLogCurveInfo.minDateTimeIndex ||
+    sourceLogCurveInfo.maxDateTimeIndex != targetLogCurveInfo.maxDateTimeIndex ||
+    sourceLogCurveInfo.minDepthIndex != targetLogCurveInfo.minDepthIndex ||
+    sourceLogCurveInfo.maxDepthIndex != targetLogCurveInfo.maxDepthIndex
+  );
+}
+
+export function calculateMismatchedIndexes(sourceLogCurveInfo: LogCurveInfo[], targetLogCurveInfo: LogCurveInfo[]): Indexes[] {
+  const mismatchedIndexes = [];
+
+  for (const sourceCurve of sourceLogCurveInfo) {
+    const targetCurve = targetLogCurveInfo.find((targetCurve) => targetCurve.mnemonic == sourceCurve.mnemonic);
+    if (!targetCurve || areMismatched(sourceCurve, targetCurve)) {
+      mismatchedIndexes.push(logCurveInfoToIndexes(sourceCurve, targetCurve));
+    }
+  }
+  for (const targetCurve of targetLogCurveInfo) {
+    const sourceCurve = sourceLogCurveInfo.find((sourceCurve) => sourceCurve.mnemonic == targetCurve.mnemonic);
+    if (!sourceCurve) {
+      mismatchedIndexes.push(logCurveInfoToIndexes(sourceCurve, targetCurve));
+    }
+  }
+  return mismatchedIndexes;
+}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/LogComparisonUtils.test.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/LogComparisonUtils.test.ts
@@ -1,5 +1,5 @@
 import LogCurveInfo from "../../../models/logCurveInfo";
-import { calculateMismatchedIndexes } from "../LogComparisonModal";
+import { calculateMismatchedIndexes } from "../LogComparisonUtils";
 
 const irrelevantProperties = {
   uid: "",

--- a/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/LogComparisonUtils.test.ts
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/LogComparisonUtils.test.ts
@@ -149,10 +149,10 @@ it("Should detect mismatched maxDepthIndex", () => {
   ];
   const result = calculateMismatchedIndexes(source, target);
   expect(result[0].mnemonic).toEqual(mnemonic);
-  expect(result[0].sourceStart).toEqual(matchingMinDepthIndex.toString());
-  expect(result[0].sourceEnd).toEqual(matchingMaxDepthIndex.toString());
-  expect(result[0].targetStart).toEqual(matchingMinDepthIndex.toString());
-  expect(result[0].targetEnd).toEqual(mismatchedDepth.toString());
+  expect(result[0].sourceStart).toEqual(matchingMinDepthIndex);
+  expect(result[0].sourceEnd).toEqual(matchingMaxDepthIndex);
+  expect(result[0].targetStart).toEqual(matchingMinDepthIndex);
+  expect(result[0].targetEnd).toEqual(mismatchedDepth);
 });
 
 it("Should detect mismatched minDepthIndex", () => {
@@ -169,10 +169,10 @@ it("Should detect mismatched minDepthIndex", () => {
   ];
   const result = calculateMismatchedIndexes(source, target);
   expect(result[0].mnemonic).toEqual(mnemonic);
-  expect(result[0].sourceStart).toEqual(matchingMinDepthIndex.toString());
-  expect(result[0].sourceEnd).toEqual(matchingMaxDepthIndex.toString());
-  expect(result[0].targetStart).toEqual(mismatchedDepth.toString());
-  expect(result[0].targetEnd).toEqual(matchingMaxDepthIndex.toString());
+  expect(result[0].sourceStart).toEqual(matchingMinDepthIndex);
+  expect(result[0].sourceEnd).toEqual(matchingMaxDepthIndex);
+  expect(result[0].targetStart).toEqual(mismatchedDepth);
+  expect(result[0].targetEnd).toEqual(matchingMaxDepthIndex);
 });
 
 it("Should disregard matching dateTime indexes", () => {

--- a/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
+++ b/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
@@ -3,6 +3,8 @@ import {
   accessible,
   account_circle as accountCircle,
   add,
+  arrow_down as arrowDown,
+  arrow_up as arrowUp,
   assignment,
   check,
   chevron_down as chevronDown,
@@ -43,7 +45,9 @@ const icons = {
   assignment,
   infoCircle,
   compare,
-  world
+  world,
+  arrowUp,
+  arrowDown
 };
 
 Icon.add(icons);


### PR DESCRIPTION
## Fixes
This pull request fixes WE-669

## Description
* Add a sortable EDS table component.
* Use the table in log comparison modal.
* Move out log comparison logic to its own file, rename tests file accordingly.


## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests