### PR TITLE
WE-644 clip too long content view columns

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -12,6 +12,7 @@ import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import JobInfoContextMenu, { JobInfoContextMenuProps } from "../ContextMenus/JobInfoContextMenu";
 import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentType, Order } from "./table";
+import { clipLongString } from "./ViewUtils";
 
 export const JobsView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
@@ -94,10 +95,10 @@ export const JobsView = (): React.ReactElement => {
   const jobInfoRows = jobInfos.map((jobInfo) => {
     return {
       ...jobInfo,
-      failedReason: clipLongString(jobInfo.failedReason, 20),
-      wellName: clipLongString(jobInfo.wellName, 20),
-      wellboreName: clipLongString(jobInfo.wellboreName, 20),
-      objectName: clipLongString(jobInfo.objectName, 30),
+      failedReason: clipLongString(jobInfo.failedReason, 20, "-"),
+      wellName: clipLongString(jobInfo.wellName, 20, "-"),
+      wellboreName: clipLongString(jobInfo.wellboreName, 20, "-"),
+      objectName: clipLongString(jobInfo.objectName, 30, "-"),
       startTime: formatDateString(jobInfo.startTime, timeZone),
       endTime: formatDateString(jobInfo.endTime, timeZone),
       targetServer: serverUrlToName(servers, jobInfo.targetServer),
@@ -107,13 +108,6 @@ export const JobsView = (): React.ReactElement => {
   });
 
   return <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} />;
-};
-
-const clipLongString = (toClip: string, length: number): string => {
-  if (!toClip) {
-    return "-";
-  }
-  return toClip.length > length ? `${toClip.substring(0, length).trim()}…` : toClip;
 };
 
 const serverUrlToName = (servers: Server[], url: string): string => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -7,6 +7,7 @@ import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import MessageObjectContextMenu, { MessageObjectContextMenuProps } from "../ContextMenus/MessageObjectContextMenu";
 import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
+import { clipLongString } from "./ViewUtils";
 
 export interface MessageObjectRow extends ContentTableRow {
   message: MessageObject;
@@ -33,7 +34,7 @@ export const MessagesListView = (): React.ReactElement => {
         id: msg.uid,
         index: index + 1,
         dTim: formatDateString(msg.dTim, timeZone),
-        messageText: msg.messageText,
+        messageText: clipLongString(msg.messageText, 30),
         uid: msg.uid,
         name: msg.name,
         typeMessage: msg.typeMessage,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -7,6 +7,7 @@ import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import RiskObjectContextMenu, { RiskObjectContextMenuProps } from "../ContextMenus/RiskContextMenu";
 import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
+import { clipLongString } from "./ViewUtils";
 
 export interface RiskObjectRow extends ContentTableRow, RiskObject {
   risk: RiskObject;
@@ -39,6 +40,7 @@ export const RisksListView = (): React.ReactElement => {
         dTimEnd: formatDateString(risk.dTimEnd, timeZone),
         dTimCreation: formatDateString(risk.commonData.dTimCreation, timeZone),
         dTimLastChange: formatDateString(risk.commonData.dTimLastChange, timeZone),
+        details: clipLongString(risk.details, 30),
         risk: risk
       };
     });

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ViewUtils.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ViewUtils.ts
@@ -1,0 +1,6 @@
+export const clipLongString = (toClip: string, length: number, onNull?: string): string => {
+  if (!toClip) {
+    return onNull ?? "";
+  }
+  return toClip.length > length ? `${toClip.substring(0, length).trim()}…` : toClip;
+};

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MessagePropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MessagePropertiesModal.tsx
@@ -59,6 +59,7 @@ const MessagePropertiesModal = (props: MessagePropertiesModalProps): React.React
                 label="messageText"
                 value={editableMessageObject.messageText}
                 fullWidth
+                multiline
                 required
                 error={!validText(editableMessageObject.messageText)}
                 helperText={editableMessageObject.messageText.length === 0 ? "The message text must be 1-64 characters" : ""}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MessagePropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MessagePropertiesModal.tsx
@@ -62,8 +62,8 @@ const MessagePropertiesModal = (props: MessagePropertiesModalProps): React.React
                 multiline
                 required
                 error={!validText(editableMessageObject.messageText)}
-                helperText={editableMessageObject.messageText.length === 0 ? "The message text must be 1-64 characters" : ""}
-                inputProps={{ minLength: 1, maxLength: 64 }}
+                helperText={editableMessageObject.messageText.length === 0 ? "The message text must be 1-4000 characters" : ""}
+                inputProps={{ minLength: 1, maxLength: 4000 }}
                 onChange={(e) => setEditableMessageObject({ ...editableMessageObject, messageText: e.target.value })}
               />
               <TextField disabled id="wellUid" label="well uid" defaultValue={editableMessageObject.wellUid} fullWidth />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
@@ -206,6 +206,7 @@ const RiskPropertiesModal = (props: RiskPropertiesModalProps): React.ReactElemen
                 value={editableRiskObject.details ? editableRiskObject.details : ""}
                 error={editableRiskObject.details?.length === 0}
                 helperText={editableRiskObject.details?.length === 0 ? "The risk details must be at least 1 character" : ""}
+                multiline
                 fullWidth
                 inputProps={{ minLength: 1 }}
                 onChange={(e) => setEditableRiskObject({ ...editableRiskObject, details: e.target.value })}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
@@ -205,10 +205,10 @@ const RiskPropertiesModal = (props: RiskPropertiesModalProps): React.ReactElemen
                 label="details"
                 value={editableRiskObject.details ? editableRiskObject.details : ""}
                 error={editableRiskObject.details?.length === 0}
-                helperText={editableRiskObject.details?.length === 0 ? "The risk details must be at least 1 character" : ""}
                 multiline
+                helperText={editableRiskObject.details?.length === 0 ? "The risk details must be between 1 and 256 characters" : ""}
                 fullWidth
-                inputProps={{ minLength: 1 }}
+                inputProps={{ minLength: 1, maxLength: 256 }}
                 onChange={(e) => setEditableRiskObject({ ...editableRiskObject, details: e.target.value })}
               />
               <TextField


### PR DESCRIPTION
## Fixes
This pull request fixes WE-644
Mitigates #1667 

## Description
* Extract clipLongString from JobsView and add optional default value on null.
* Use clipLongString on message.MessageText and risk.Details to avoid having long celles.
* Add multiline to the respective fields in properties modals to improve their display.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
Should #1667 be closed or kept open in case someone finds a better solution?