### PR TITLE
WE-690 Add requestLatestValues to OptionsIn

### DIFF
--- a/Src/Witsml/ServiceReference/OptionsIn.cs
+++ b/Src/Witsml/ServiceReference/OptionsIn.cs
@@ -5,7 +5,8 @@ namespace Witsml.ServiceReference
 {
     public record OptionsIn(
         ReturnElements ReturnElements,
-        int? MaxReturnNodes = null)
+        int? MaxReturnNodes = null,
+        int? RequestLatestValues = null)
     {
         public string GetKeywords()
         {
@@ -14,6 +15,10 @@ namespace Witsml.ServiceReference
             if (MaxReturnNodes is > 0)
             {
                 keywords.Append($";maxReturnNodes={MaxReturnNodes.Value}");
+            }
+            if (RequestLatestValues is > 0)
+            {
+                keywords.Append($";requestLatestValues={RequestLatestValues.Value}");
             }
 
             return keywords.ToString();

--- a/Tests/Witsml.Tests/ServiceReference/OptionsInTests.cs
+++ b/Tests/Witsml.Tests/ServiceReference/OptionsInTests.cs
@@ -9,7 +9,7 @@ namespace Witsml.Tests.ServiceReference
         [Fact]
         public void GetKeywords_WithReturnElementsAll_ReturnsCorrectValue()
         {
-            var optionsIn = new OptionsIn(ReturnElements.All);
+            OptionsIn optionsIn = new(ReturnElements.All);
 
             Assert.Equal("returnElements=all", optionsIn.GetKeywords());
         }
@@ -17,9 +17,23 @@ namespace Witsml.Tests.ServiceReference
         [Fact]
         public void GetKeyWords_WithReturnElementsDataOnly_And_MaxReturnNodes50_ReturnsCorrectValue()
         {
-            var optionsIn = new OptionsIn(ReturnElements.DataOnly, 50);
+            OptionsIn optionsIn = new(ReturnElements.DataOnly, 50);
 
             Assert.Equal("returnElements=data-only;maxReturnNodes=50", optionsIn.GetKeywords());
+        }
+
+        [Fact]
+        public void GetKeyWords_MaxReturnNodes50ReturnLatestValues100_ReturnsCorrectValue()
+        {
+            OptionsIn optionsIn = new(ReturnElements.DataOnly, 50, 100);
+            Assert.Equal("returnElements=data-only;maxReturnNodes=50;requestLatestValues=100", optionsIn.GetKeywords());
+        }
+
+        [Fact]
+        public void GetKeyWords_ReturnLatestValues10_ReturnsCorrectValue()
+        {
+            OptionsIn optionsIn = new(ReturnElements.DataOnly, null, 10);
+            Assert.Equal("returnElements=data-only;requestLatestValues=10", optionsIn.GetKeywords());
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -66,7 +66,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME);
             List<WitsmlLogs> updatedLogs = SetupUpdateInStoreAsync();
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null)))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null, null)))
                 .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
                 .ReturnsAsync(() => GetSourceLogData(query.Logs.First().StartDateTimeIndex, query.Logs.First().EndDateTimeIndex));
 
@@ -101,7 +101,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD);
             SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD);
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null)))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null, null)))
                 .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
@@ -131,7 +131,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD);
 
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null)))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null, null)))
                 .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
@@ -176,7 +176,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD);
 
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null)))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null, null)))
                 .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
@@ -198,12 +198,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, DepthStart, DepthEnd));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, TimeStart, TimeEnd));
                     break;
                 default:
@@ -217,12 +217,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                         .ReturnsAsync(targetLogs ?? GetTargetLogs(WitsmlLog.WITSML_INDEX_TYPE_MD));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                         .ReturnsAsync(targetLogs ?? GetTargetLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME));
                     break;
                 default:
@@ -234,14 +234,14 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             List<WitsmlLogs> updatedLogs = new();
             _witsmlClient.Setup(client =>
-                    client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>())).Callback<WitsmlLogs>(witsmlLogs => updatedLogs.Add(witsmlLogs))
+                    client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>())).Callback<WitsmlLogs>(updatedLogs.Add)
                 .ReturnsAsync(new QueryResult(true));
             return updatedLogs;
         }
 
         private void SetupGetDepthIndexed(WitsmlLogs query = null)
         {
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null)))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null, null)))
                 .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
                 .ReturnsAsync(() =>
                 {

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -102,12 +102,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, DepthStart, DepthEnd));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, TimeStart, TimeEnd));
                     break;
                 default:
@@ -118,7 +118,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null, null)))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>
@@ -138,7 +138,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             List<WitsmlLogs> addedLog = new();
             _witsmlClient.Setup(client => client.AddToStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>((witsmlLogs) => addedLog.Add(witsmlLogs))
+                .Callback<WitsmlLogs>(addedLog.Add)
                 .ReturnsAsync(new QueryResult(true));
             return addedLog;
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTrajectoryWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTrajectoryWorkerTests.cs
@@ -49,7 +49,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             CopyTrajectoryJob copyTrajectoryJob = CreateJobTemplate();
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlTrajectories>(witsmlTrajectories => witsmlTrajectories.Trajectories.First().Uid == TrajectoryUid), new OptionsIn(ReturnElements.All, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlTrajectories>(witsmlTrajectories => witsmlTrajectories.Trajectories.First().Uid == TrajectoryUid), new OptionsIn(ReturnElements.All, null, null)))
                 .ReturnsAsync(GetSourceTrajectories());
             SetupGetWellbore();
             List<WitsmlTrajectories> copyTrajectoryQuery = SetupAddInStoreAsync();
@@ -63,7 +63,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null, null)))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>
@@ -83,7 +83,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             List<WitsmlTrajectories> addedTrajectory = new();
             _witsmlClient.Setup(client => client.AddToStoreAsync(It.IsAny<WitsmlTrajectories>()))
-                .Callback<WitsmlTrajectories>(witsmlTrajectories => addedTrajectory.Add(witsmlTrajectories))
+                .Callback<WitsmlTrajectories>(addedTrajectory.Add)
                 .ReturnsAsync(new QueryResult(true));
             return addedTrajectory;
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularComponentTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularComponentTests.cs
@@ -49,10 +49,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             CopyTubularComponentsJob copyTubularComponentJob = CreateJobTemplate();
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlTubulars>(witsmlTubulars => witsmlTubulars.Tubulars.First().Uid == SourceTubularUid), new OptionsIn(ReturnElements.All, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlTubulars>(witsmlTubulars => witsmlTubulars.Tubulars.First().Uid == SourceTubularUid), new OptionsIn(ReturnElements.All, null, null)))
                 .ReturnsAsync(GetSourceTubulars());
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlTubulars>(witsmlTubulars => witsmlTubulars.Tubulars.First().Uid == TargetTubularUid), new OptionsIn(ReturnElements.All, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlTubulars>(witsmlTubulars => witsmlTubulars.Tubulars.First().Uid == TargetTubularUid), new OptionsIn(ReturnElements.All, null, null)))
                 .ReturnsAsync(GetTargetTubulars());
             List<WitsmlTubulars> copyTubularComponentQuery = SetupUpdateInStoreAsync();
 
@@ -71,7 +71,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             List<WitsmlTubulars> updatedTubulars = new();
             _witsmlClient.Setup(client => client.UpdateInStoreAsync(It.IsAny<WitsmlTubulars>()))
-                .Callback<WitsmlTubulars>(witsmlTubulars => updatedTubulars.Add(witsmlTubulars))
+                .Callback<WitsmlTubulars>(updatedTubulars.Add)
                 .ReturnsAsync(new QueryResult(true));
             return updatedTubulars;
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyTubularWorkerTests.cs
@@ -47,7 +47,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             CopyTubularJob copyTubularJob = CreateJobTemplate();
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlTubulars>(witsmlTubulars => witsmlTubulars.Tubulars.First().Uid == TubularUid), new OptionsIn(ReturnElements.All, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlTubulars>(witsmlTubulars => witsmlTubulars.Tubulars.First().Uid == TubularUid), new OptionsIn(ReturnElements.All, null, null)))
                 .ReturnsAsync(GetSourceTubulars());
             SetupGetWellbore();
             List<WitsmlTubulars> copyTubularQuery = SetupAddInStoreAsync();
@@ -59,7 +59,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null, null)))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>
@@ -79,7 +79,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             List<WitsmlTubulars> addedTubular = new();
             _witsmlClient.Setup(client => client.AddToStoreAsync(It.IsAny<WitsmlTubulars>()))
-                .Callback<WitsmlTubulars>(witsmlTubulars => addedTubular.Add(witsmlTubulars))
+                .Callback<WitsmlTubulars>(addedTubular.Add)
                 .ReturnsAsync(new QueryResult(true));
             return addedTubular;
         }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyWbGeometrySectionsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyWbGeometrySectionsWorkerTests.cs
@@ -88,10 +88,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetFromStoreAsync(string[] sourceSectionUids, string[] targetSectionUids)
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlWbGeometrys>(witsmlWbGeometrys => witsmlWbGeometrys.WbGeometrys.First().Uid == SourceWbGeometryUid), new OptionsIn(ReturnElements.All, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlWbGeometrys>(witsmlWbGeometrys => witsmlWbGeometrys.WbGeometrys.First().Uid == SourceWbGeometryUid), new OptionsIn(ReturnElements.All, null, null)))
                 .ReturnsAsync(GetSourceWbGeometrys(sourceSectionUids));
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlWbGeometrys>(witsmlWbGeometrys => witsmlWbGeometrys.WbGeometrys.First().Uid == TargetWbGeometryUid), new OptionsIn(ReturnElements.All, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlWbGeometrys>(witsmlWbGeometrys => witsmlWbGeometrys.WbGeometrys.First().Uid == TargetWbGeometryUid), new OptionsIn(ReturnElements.All, null, null)))
                 .ReturnsAsync(GetTargetWbGeometrys(targetSectionUids));
         }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CreateLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CreateLogWorkerTests.cs
@@ -51,7 +51,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             List<WitsmlLogs> createdLogs = new();
             _witsmlClient.Setup(client =>
                     client.AddToStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => createdLogs.Add(logs))
+                .Callback<WitsmlLogs>(createdLogs.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -78,7 +78,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             List<WitsmlLogs> createdLogs = new();
             _witsmlClient.Setup(client =>
                     client.AddToStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => createdLogs.Add(logs))
+                .Callback<WitsmlLogs>(createdLogs.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -105,7 +105,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             List<WitsmlLogs> createdLogs = new();
             _witsmlClient.Setup(client =>
                     client.AddToStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => createdLogs.Add(logs))
+                .Callback<WitsmlLogs>(createdLogs.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -133,7 +133,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null, null)))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteCurveValuesWorkerTest.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteCurveValuesWorkerTest.cs
@@ -65,7 +65,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             DeleteCurveValuesJob job = CreateJobTemplate() with { IndexRanges = Array.Empty<IndexRange>() };
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -81,7 +81,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -98,7 +98,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             job.LogReference.Uid = "NOT_A_LOG";
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.False(result.IsSuccess);
         }
@@ -110,7 +110,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             DeleteCurveValuesJob job = CreateJobTemplate();
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Once());
             Assert.True(result.IsSuccess);
         }
@@ -130,7 +130,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Exactly(2));
             Assert.True(result.IsSuccess);
         }
@@ -161,7 +161,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Exactly(2));
             Assert.True(result.IsSuccess);
         }
@@ -184,7 +184,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -210,7 +210,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null)), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -219,11 +219,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupLog(string indexType, Index startIndex, Index endIndex)
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                 .ReturnsAsync(GetLogs(indexType, startIndex, endIndex));
 
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid != LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid != LogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                 .ReturnsAsync(new WitsmlLogs());
 
             _witsmlClient.Setup(client =>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/ImportLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/ImportLogDataWorkerTests.cs
@@ -76,7 +76,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
 
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null))).ReturnsAsync(returnedWitsmlLog);
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null))).ReturnsAsync(returnedWitsmlLog);
             _witsmlClient.Setup(client =>
                 client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>())).ReturnsAsync(new QueryResult(true));
 
@@ -120,7 +120,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
 
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null))).ReturnsAsync(returnedWitsmlLog);
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.HeaderOnly, null, null))).ReturnsAsync(returnedWitsmlLog);
             _witsmlClient.Setup(client =>
                 client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>())).ReturnsAsync(new QueryResult(true));
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/TrimLogObjectWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/TrimLogObjectWorkerTests.cs
@@ -117,7 +117,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             List<WitsmlLogs> deleteQueries = new();
             _witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => deleteQueries.Add(logs))
+                .Callback<WitsmlLogs>(deleteQueries.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -144,7 +144,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             List<WitsmlLogs> deleteQueries = new();
             _witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => deleteQueries.Add(logs))
+                .Callback<WitsmlLogs>(deleteQueries.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -169,7 +169,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             List<WitsmlLogs> deleteQueries = new();
             _witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => deleteQueries.Add(logs))
+                .Callback<WitsmlLogs>(deleteQueries.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -196,7 +196,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             List<WitsmlLogs> deleteQueries = new();
             _witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => deleteQueries.Add(logs))
+                .Callback<WitsmlLogs>(deleteQueries.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -222,7 +222,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             List<WitsmlLogs> deleteQueries = new();
             _witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => deleteQueries.Add(logs))
+                .Callback<WitsmlLogs>(deleteQueries.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -255,7 +255,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             List<WitsmlLogs> deleteQueries = new();
             _witsmlClient.Setup(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
-                .Callback<WitsmlLogs>(logs => deleteQueries.Add(logs))
+                .Callback<WitsmlLogs>(deleteQueries.Add)
                 .ReturnsAsync(new QueryResult(true));
 
             await _worker.Execute(job);
@@ -274,7 +274,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupLog(string indexType, Index startIndex, Index endIndex)
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null)))
+                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), new OptionsIn(ReturnElements.HeaderOnly, null, null)))
                 .ReturnsAsync(GetLogs(indexType, startIndex, endIndex));
         }
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-690

## Description
Add optional parameter requestLatestValues to OptionsIn in the WITSML project.
Add one more null to all tests mocking methods taking in OptionsIn due to "An expression tree may not contain a call or invocation that uses optional arguments".

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* WITSML

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests
