### PR TITLE
WE-691 be sure to clear cache between tests

### DIFF
--- a/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
@@ -11,6 +11,7 @@ namespace WitsmlExplorer.Api.Services
         void SetItem(string cacheId, string encryptedCredentials, double ttl);
         public string GetItem(string cacheId);
         public long Count();
+        public void Clear();
         public void RemoveAllClientCredentials(string clientId);
     }
 
@@ -37,6 +38,11 @@ namespace WitsmlExplorer.Api.Services
         public long Count()
         {
             return _cache.GetCount();
+        }
+        public void Clear()
+        {
+            ((MemoryCache)_cache).Trim(100);
+
         }
 
         public void RemoveAllClientCredentials(string clientId)

--- a/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
@@ -35,14 +35,15 @@ namespace WitsmlExplorer.Api.Services
         {
             return _cache.Get(cacheId) as string;
         }
+
         public long Count()
         {
             return _cache.GetCount();
         }
+
         public void Clear()
         {
             ((MemoryCache)_cache).Trim(100);
-
         }
 
         public void RemoveAllClientCredentials(string clientId)

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -99,6 +99,11 @@ namespace WitsmlExplorer.Api.Services
             _credentialsCache.RemoveAllClientCredentials(clientId);
         }
 
+        public void RemoveAllCachedCredentials()
+        {
+            _credentialsCache.Clear();
+        }
+
         public void CacheCredentials(string clientId, ServerCredentials credentials, double ttl, Func<string, string> delEncrypt = null)
         {
             delEncrypt ??= Encrypt;

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -13,6 +13,7 @@ namespace WitsmlExplorer.Api.Services
         public ServerCredentials GetCredentialsFromCache(bool useOauth, IEssentialHeaders headers, string serverUrl, Func<string, string> delDecrypt = null);
         public void CacheCredentials(string clientId, ServerCredentials credentials, double ttl, Func<string, string> delEncrypt = null);
         public void RemoveCachedCredentials(string clientId);
+        public void RemoveAllCachedCredentials();
         public Task<ServerCredentials> GetSystemCredentialsByToken(string token, Uri server);
         public Task<ServerCredentials> GetCredentialsFromHeaderValue(string headerValue, string token = null);
         public (ServerCredentials targetServer, ServerCredentials sourceServer) GetWitsmlUsernamesFromCache(IEssentialHeaders headers);

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
@@ -27,6 +27,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             string clientId = Guid.NewGuid().ToString();
             string url = "https://somehost";
 
+            _credentialsCache.Clear();
             _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
             _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
             _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
@@ -36,6 +36,23 @@ namespace WitsmlExplorer.Api.Tests.Services
             long after = _credentialsCache.Count();
             Assert.Equal(3, before);
             Assert.Equal(1, after);
+            _credentialsCache.Clear();
+        }
+        [Fact]
+        public void Clear_SetThree_ReturnZero()
+        {
+            string clientId = Guid.NewGuid().ToString();
+            string url = "https://somehost";
+
+            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
+            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
+            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
+
+            long before = _credentialsCache.Count();
+            _credentialsCache.Clear();
+            long after = _credentialsCache.Count();
+            Assert.Equal(3, before);
+            Assert.Equal(0, after);
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -79,6 +79,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.UserId == "basicuser" && creds.Password == "basicpassword");
+            Cleanup();
         }
 
         [Fact]
@@ -89,6 +90,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.IsCredsNullOrEmpty());
+            Cleanup();
         }
 
         [Fact]
@@ -99,6 +101,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.IsCredsNullOrEmpty());
+            Cleanup();
         }
         [Fact]
         public void GetCredentialsFromHeaderValue_BasicAndTokenValidRolesHeaderValidURL_ReturnBasicCreds()
@@ -112,6 +115,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.UserId == "basicuser" && creds.Password == "basicpassword");
+            Cleanup();
         }
 
         [Fact]
@@ -127,6 +131,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.UserId == "systemuser" && creds.Password == "systempassword");
+            Cleanup();
         }
 
         [Fact]
@@ -137,6 +142,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.IsCredsNullOrEmpty());
+            Cleanup();
         }
 
         [Fact]
@@ -147,6 +153,7 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
             Assert.True(creds.IsCredsNullOrEmpty());
+            Cleanup();
         }
 
         [Fact]
@@ -165,6 +172,11 @@ namespace WitsmlExplorer.Api.Tests.Services
             _credentialsService.CacheCredentials(clientId, sc, 1.0, n => n);
             ServerCredentials fromCache = _credentialsService.GetCredentialsFromCache(false, headersMock.Object, headersMock.Object.TargetServer);
             Assert.Equal(sc, fromCache);
+            _credentialsService.RemoveAllCachedCredentials();
+            Cleanup();
+        }
+        private void Cleanup()
+        {
             _credentialsService.RemoveAllCachedCredentials();
         }
         private static string CreateBasicHeaderValue(string username, string dummypassword, string host)

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -165,6 +165,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             _credentialsService.CacheCredentials(clientId, sc, 1.0, n => n);
             ServerCredentials fromCache = _credentialsService.GetCredentialsFromCache(false, headersMock.Object, headersMock.Object.TargetServer);
             Assert.Equal(sc, fromCache);
+            _credentialsService.RemoveAllCachedCredentials();
         }
         private static string CreateBasicHeaderValue(string username, string dummypassword, string host)
         {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-691

## Description
Clear cache on subsequent tests to remove false positives

## Type of change

* Bugfix

## Impacted Areas in Application
Tests
WitsmlExplorer.API MemoryCache

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests

## Further comments
