### PR TITLE
WE-679 add net6 target framework for `Witsml` package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Test
         run: dotnet test ./Tests/Witsml.Tests/Witsml.Tests.csproj --configuration Release
       - name: Package
-        run: dotnet pack --configuration Release Src/Witsml -p:Version=2.0.${GITHUB_RUN_NUMBER}
+        run: dotnet pack --configuration Release Src/Witsml -p:Version=2.7.${GITHUB_RUN_NUMBER}
       - name: Publish
-        run: dotnet nuget push --api-key ${{secrets.NUGET_PUBLISH_KEY}} --source https://api.nuget.org/v3/index.json Src/Witsml/bin/Release/WitsmlClient.2.0.${GITHUB_RUN_NUMBER}.nupkg
+        run: dotnet nuget push --api-key ${{secrets.NUGET_PUBLISH_KEY}} --source https://api.nuget.org/v3/index.json Src/Witsml/bin/Release/WitsmlClient.2.7.${GITHUB_RUN_NUMBER}.nupkg

--- a/Src/Witsml/Witsml.csproj
+++ b/Src/Witsml/Witsml.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>latestMajor</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
## Fixes
This pull request fixes WE-679

## Description
Make `WitsmlClient` accessible for use in net6 environments

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application
package at [nuget.org/witsmlclient](https://www.nuget.org/packages/WitsmlClient)

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [ ] Code follows the style guidelines
* [ ] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
