### PR TITLE
WE-672 implement DateTimeField

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
+++ b/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
@@ -1,23 +1,71 @@
 import { format, formatInTimeZone, toDate } from "date-fns-tz";
 import { TimeZone } from "../contexts/operationStateReducer";
 
-const dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-
 //https://date-fns.org/v2.29.3/docs/format
+const dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+
+// Minus character U+2212 is preferred by ISO 8601 over hyphen minus '-' so we check both
+// date-fns-tz behaves weirdly with minus so we replace it
+const unicodeMinus = "\u2212";
+
 function formatDateString(dateString: string, timeZone: TimeZone) {
   if (dateString == null) {
     return null;
   }
 
+  const replaced = dateString.replace(unicodeMinus, "-");
+  const parsed = toDate(replaced);
+
   if (timeZone == TimeZone.Raw) {
-    return dateString.replace("+00:00", "Z");
+    const offset = getOffset(replaced) ?? "Z";
+    return formatInTimeZone(parsed, offset, dateTimeFormat);
   }
 
-  const parsed = toDate(dateString);
   if (timeZone == TimeZone.Local) {
     return format(parsed, dateTimeFormat);
   }
   return formatInTimeZone(parsed, timeZone, dateTimeFormat);
 }
-
 export default formatDateString;
+
+export function getOffsetFromTimeZone(timeZone: TimeZone): string {
+  return formatInTimeZone(new Date(), timeZone, "xxx");
+}
+
+function getOffset(dateString: string): string | null {
+  if (dateString.indexOf("Z") == dateString.length - 1) {
+    return "Z";
+  }
+
+  const replaced = dateString.replace(unicodeMinus, "-");
+  const charAtSignPosition = replaced.charAt(replaced.length - 6);
+  if (charAtSignPosition == "+" || charAtSignPosition == "-") {
+    const offset = dateString.slice(dateString.length - 6);
+    return validateOffset(offset) ? offset : null;
+  }
+
+  return null;
+}
+
+function validateOffset(offset: string): boolean {
+  try {
+    return offset.match(/[+-][0-2]\d:[0-5]\d|Z/)[0] == offset;
+  } catch {
+    return false;
+  }
+}
+
+export function validateIsoDateString(dateString: string): boolean {
+  try {
+    const replaced = dateString.replace(unicodeMinus, "-").replace("+00:00", "Z").replace("-00:00", "Z");
+    const offset = getOffset(replaced);
+    if (!offset) {
+      return false;
+    }
+    const parsed = toDate(replaced);
+    const formatted = formatInTimeZone(parsed, offset, dateTimeFormat);
+    return replaced == formatted;
+  } catch {
+    return false;
+  }
+}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/BhaRunPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/BhaRunPropertiesModal.tsx
@@ -1,15 +1,17 @@
 import { Autocomplete } from "@equinor/eds-core-react";
 import { InputAdornment, TextField } from "@material-ui/core";
-import moment from "moment";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { UpdateWellboreBhaRunsAction } from "../../contexts/modificationActions";
 import ModificationType from "../../contexts/modificationType";
+import OperationContext from "../../contexts/operationContext";
 import { HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import BhaRun from "../../models/bhaRun";
 import { itemStateTypes } from "../../models/itemStateTypes";
 import BhaRunService from "../../services/bhaRunService";
 import JobService, { JobType } from "../../services/jobService";
+import formatDateString from "../DateFormatter";
+import { DateTimeField } from "./DateTimeField";
 import ModalDialog from "./ModalDialog";
 import { PropertiesModalMode, validText } from "./ModalParts";
 
@@ -24,12 +26,26 @@ export interface BhaRunPropertiesModalProps {
 
 const BhaRunPropertiesModal = (props: BhaRunPropertiesModalProps): React.ReactElement => {
   const { mode, bhaRun, dispatchOperation, dispatchNavigation } = props;
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const [editableBhaRun, setEditableBhaRun] = useState<BhaRun>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const editMode = mode === PropertiesModalMode.Edit;
 
   useEffect(() => {
-    setEditableBhaRun(bhaRun);
+    setEditableBhaRun({
+      ...bhaRun,
+      dTimStart: bhaRun.dTimStart ? formatDateString(bhaRun.dTimStart, timeZone) : null,
+      dTimStop: bhaRun.dTimStop ? formatDateString(bhaRun.dTimStop, timeZone) : null,
+      dTimStartDrilling: bhaRun.dTimStartDrilling ? formatDateString(bhaRun.dTimStartDrilling, timeZone) : null,
+      dTimStopDrilling: bhaRun.dTimStopDrilling ? formatDateString(bhaRun.dTimStopDrilling, timeZone) : null,
+      commonData: {
+        ...bhaRun.commonData,
+        dTimCreation: bhaRun.commonData.dTimCreation ? formatDateString(bhaRun.commonData.dTimCreation, timeZone) : null,
+        dTimLastChange: bhaRun.commonData.dTimLastChange ? formatDateString(bhaRun.commonData.dTimLastChange, timeZone) : null
+      }
+    });
   }, [bhaRun]);
 
   const onSubmit = async (updatedBhaRun: BhaRun) => {
@@ -92,53 +108,29 @@ const BhaRunPropertiesModal = (props: BhaRunPropertiesModalProps): React.ReactEl
                 fullWidth
                 onChange={(e) => setEditableBhaRun({ ...editableBhaRun, tubularUidRef: e.target.value })}
               />
-              <TextField
-                id="dTimStart"
+              <DateTimeField
+                value={editableBhaRun.dTimStart}
                 label="dTimStart"
-                type="datetime-local"
-                fullWidth
-                InputLabelProps={{
-                  shrink: true
-                }}
-                disabled={!editableBhaRun.dTimStart}
-                value={editableBhaRun.dTimStart ? moment(editableBhaRun.dTimStart).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableBhaRun({ ...editableBhaRun, dTimStart: e.target.value })}
+                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStart: dateTime })}
+                timeZone={timeZone}
               />
-              <TextField
-                id={"dTimStop"}
-                label={"dTimStop"}
-                fullWidth
-                type="datetime-local"
-                InputLabelProps={{
-                  shrink: true
-                }}
-                disabled={!editableBhaRun.dTimStop}
-                value={editableBhaRun.dTimStop ? moment(editableBhaRun.dTimStop).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableBhaRun({ ...editableBhaRun, dTimStop: e.target.value })}
+              <DateTimeField
+                value={editableBhaRun.dTimStop}
+                label="dTimStop"
+                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStop: dateTime })}
+                timeZone={timeZone}
               />
-              <TextField
-                id="dTimStartDrilling"
+              <DateTimeField
+                value={editableBhaRun.dTimStartDrilling}
                 label="dTimStartDrilling"
-                type="datetime-local"
-                fullWidth
-                InputLabelProps={{
-                  shrink: true
-                }}
-                disabled={!editableBhaRun.dTimStartDrilling}
-                value={editableBhaRun.dTimStartDrilling ? moment(editableBhaRun.dTimStartDrilling).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableBhaRun({ ...editableBhaRun, dTimStartDrilling: e.target.value })}
+                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStartDrilling: dateTime })}
+                timeZone={timeZone}
               />
-              <TextField
-                id={"dTimStopDrilling"}
-                label={"dTimStopDrilling"}
-                fullWidth
-                type="datetime-local"
-                InputLabelProps={{
-                  shrink: true
-                }}
-                disabled={!editableBhaRun.dTimStopDrilling}
-                value={editableBhaRun.dTimStopDrilling ? moment(editableBhaRun.dTimStopDrilling).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableBhaRun({ ...editableBhaRun, dTimStopDrilling: e.target.value })}
+              <DateTimeField
+                value={editableBhaRun.dTimStopDrilling}
+                label="dTimStopDrilling"
+                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStopDrilling: dateTime })}
+                timeZone={timeZone}
               />
               <TextField
                 id={"planDogleg"}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
@@ -25,6 +25,7 @@ interface DateTimeFieldProps {
 export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => {
   const { value, label, updateObject, timeZone } = props;
   const [initiallyEmpty, setInitiallyEmpty] = useState(false);
+  const isFirefox = navigator.userAgent.includes("Firefox");
 
   useEffect(() => {
     setInitiallyEmpty(value == null || value === "");
@@ -59,12 +60,13 @@ export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => 
         id={label + "picker"}
         placeholder=""
         label=""
-        type="datetime-local"
+        value=""
+        type={isFirefox ? "date" : "datetime-local"}
         style={{ width: "44px" }}
         tabIndex={-1} //disable tab focus due to the native datepicker including multiple invisible fields that are not to be used
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-          // preserve the :mm:ss.SSSXXX part of the original value that the datepicker does not set
-          const slice = value.slice(16);
+          // preserve the ss.SSSXXX (and also HH:mm for Firefox) part of the original value that the datepicker does not set
+          const slice = isFirefox ? value.slice(10) : value.slice(16);
           const toFormat = e.target.value + slice;
           const formatted = formatDateString(toFormat, timeZone);
           updateObject(formatted);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
@@ -1,0 +1,95 @@
+import { TextField } from "@equinor/eds-core-react";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import { TimeZone } from "../../contexts/operationStateReducer";
+import Icon from "../../styles/Icons";
+import formatDateString, { validateIsoDateString } from "../DateFormatter";
+
+interface DateTimeFieldProps {
+  value: string;
+  label: string;
+  updateObject: (dateTime: string) => void;
+  timeZone: TimeZone;
+}
+
+/**
+ * A component to edit a date time, taking in a string in the DateFormatter.dateTimeFormat.
+ * One can either write/paste a string manually, or use the native datepicker.
+ * This component should be replaced if EDS ever gets a custom datepicker.
+ * @param value The current value of the field.
+ * @param label Label shown above the field.
+ * @param updateObject A lambda to update the value on the object to be modified.
+ * @param timeZone A TimeZone to use in formatting.
+ * @returns
+ */
+export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => {
+  const { value, label, updateObject, timeZone } = props;
+  const [initiallyEmpty, setInitiallyEmpty] = useState(false);
+
+  useEffect(() => {
+    setInitiallyEmpty(value == null || value === "");
+  }, []);
+
+  const getHelperText = () => {
+    if (!isValid) {
+      if (!initiallyEmpty && (value == null || value === "")) {
+        return "This field cannot be deleted.";
+      }
+      return "The input must be in the yyyy-MM-dd'T'HH:mm:ss.SSS±ZZ:ZZ format.";
+    }
+    return "";
+  };
+
+  const isValid = validateIsoDateString(value) || (initiallyEmpty && (value == null || value === ""));
+  return (
+    <Layout>
+      <TextField
+        id={label}
+        label={label}
+        value={value}
+        helperText={getHelperText()}
+        variant={isValid ? undefined : "error"}
+        autoComplete="off"
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+          updateObject(e.target.value);
+        }}
+      />
+      <PickerIcon name="calendar" />
+      <Picker
+        id={label + "picker"}
+        placeholder=""
+        label=""
+        type="datetime-local"
+        style={{ width: "44px" }}
+        tabIndex={-1} //disable tab focus due to the native datepicker including multiple invisible fields that are not to be used
+        onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+          // preserve the :mm:ss.SSSXXX part of the original value that the datepicker does not set
+          const slice = value.slice(16);
+          const toFormat = e.target.value + slice;
+          const formatted = formatDateString(toFormat, timeZone);
+          updateObject(formatted);
+        }}
+      />
+    </Layout>
+  );
+};
+
+const Layout = styled.div`
+  position: relative;
+  input[type="datetime-local"]::-webkit-calendar-picker-indicator {
+    cursor: pointer;
+  }
+`;
+
+const Picker = styled(TextField)`
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  top: 15px;
+`;
+
+const PickerIcon = styled(Icon)`
+  position: absolute;
+  right: 15px;
+  top: 22px;
+`;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
@@ -65,9 +65,12 @@ export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => 
         style={{ width: "44px" }}
         tabIndex={-1} //disable tab focus due to the native datepicker including multiple invisible fields that are not to be used
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-          // preserve the ss.SSSXXX (and also HH:mm for Firefox) part of the original value that the datepicker does not set
-          const slice = isFirefox ? value.slice(10) : value.slice(16);
-          const toFormat = e.target.value + slice;
+          let toFormat = e.target.value;
+          if (validateIsoDateString(value)) {
+            // preserve the ss.SSSXXX (and also HH:mm for Firefox) part of the original value that the datepicker does not set
+            const slice = isFirefox ? value.slice(10) : value.slice(16);
+            toFormat += slice;
+          }
           const formatted = formatDateString(toFormat, timeZone);
           updateObject(formatted);
         }}

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -1,5 +1,6 @@
 import { Button, Typography } from "@equinor/eds-core-react";
 import { MenuItem } from "@material-ui/core";
+import { format } from "date-fns-tz";
 import React, { ReactElement, useContext, useEffect } from "react";
 import styled from "styled-components";
 import OperationContext from "../contexts/operationContext";
@@ -9,16 +10,17 @@ import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
 import CredentialsService from "../services/credentialsService";
 import Icon from "../styles/Icons";
 import ContextMenu from "./ContextMenus/ContextMenu";
+import { getOffsetFromTimeZone } from "./DateFormatter";
 import JobsButton from "./JobsButton";
 
 const timeZoneLabels: Record<TimeZone, string> = {
   [TimeZone.Raw]: "Original Time",
-  [TimeZone.Local]: "Local Time",
-  [TimeZone.Brasilia]: "Brazil/Brasilia",
-  [TimeZone.Berlin]: "Europe/Berlin",
-  [TimeZone.London]: "Europe/London",
-  [TimeZone.NewDelhi]: "India/New Delhi",
-  [TimeZone.Houston]: "US/Houston"
+  [TimeZone.Local]: `${format(new Date(), "xxx")} Local Time`,
+  [TimeZone.Brasilia]: `${getOffsetFromTimeZone(TimeZone.Brasilia)} Brazil/Brasilia`,
+  [TimeZone.Berlin]: `${getOffsetFromTimeZone(TimeZone.Berlin)} Europe/Berlin`,
+  [TimeZone.London]: `${getOffsetFromTimeZone(TimeZone.London)} Europe/London`,
+  [TimeZone.NewDelhi]: `${getOffsetFromTimeZone(TimeZone.NewDelhi)} India/New Delhi`,
+  [TimeZone.Houston]: `${getOffsetFromTimeZone(TimeZone.Houston)} US/Houston`
 };
 
 const TopRightCornerMenu = (): React.ReactElement => {

--- a/Src/WitsmlExplorer.Frontend/components/__tests__/DateFormatter.test.ts
+++ b/Src/WitsmlExplorer.Frontend/components/__tests__/DateFormatter.test.ts
@@ -61,6 +61,16 @@ it("Should invalidate bad days", () => {
   expect(actual).toEqual(false);
 });
 
+it("Should invalidate bad leap year", () => {
+  const actual = validateIsoDateString("2022-02-29T00:00:00.000+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should validate good leap year", () => {
+  const actual = validateIsoDateString("2020-02-29T00:00:00.000+02:00");
+  expect(actual).toEqual(true);
+});
+
 it("Should invalidate bad month", () => {
   const actual = validateIsoDateString("2022-13-01T01:00:00.000+02:00");
   expect(actual).toEqual(false);
@@ -74,4 +84,14 @@ it("Should validate string with Z", () => {
 it("Should validate string with +00:00", () => {
   const actual = validateIsoDateString("2022-12-01T01:00:00.000+00:00");
   expect(actual).toEqual(true);
+});
+
+it("Should invalidate a string with bad negative offset", () => {
+  const actual = validateIsoDateString("2022-11-17T13:54:17.000-25:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate a string with bad positive offset", () => {
+  const actual = validateIsoDateString("2022-11-17T13:54:17.000+25:00");
+  expect(actual).toEqual(false);
 });

--- a/Src/WitsmlExplorer.Frontend/components/__tests__/DateFormatter.test.ts
+++ b/Src/WitsmlExplorer.Frontend/components/__tests__/DateFormatter.test.ts
@@ -1,5 +1,5 @@
 import { TimeZone } from "../../contexts/operationStateReducer";
-import formatDateString from "../DateFormatter";
+import formatDateString, { validateIsoDateString } from "../DateFormatter";
 
 it("Should replace +00:00 with Z when TimeZone is Raw", () => {
   const actual = formatDateString("2022-11-17T13:54:17.000+00:00", TimeZone.Raw);
@@ -13,5 +13,65 @@ it("Should keep the offset when TimeZone is Raw", () => {
 
 it("Should convert the time when a specific TimeZone is picked", () => {
   const actual = formatDateString("2022-11-17T13:54:17.000+02:00", TimeZone.Houston);
-  expect(actual).toEqual("2022-11-17T05:54:17.000");
+  expect(actual).toEqual("2022-11-17T05:54:17.000-06:00");
+});
+
+it("Should validate offset with minus", () => {
+  const actual = validateIsoDateString("2022-11-17T13:54:17.000\u{2212}02:00");
+  expect(actual).toEqual(true);
+});
+
+it("Should validate offset with hyphen minus", () => {
+  const actual = validateIsoDateString("2022-11-17T13:54:17.000-02:00");
+  expect(actual).toEqual(true);
+});
+
+it("Should validate offset with plus", () => {
+  const actual = validateIsoDateString("2022-11-17T13:54:17.000+02:00");
+  expect(actual).toEqual(true);
+});
+
+it("Should invalidate a string without offset", () => {
+  const actual = validateIsoDateString("2022-11-17T13:54:17.000");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate missing milliseconds", () => {
+  const actual = validateIsoDateString("2022-11-17T13:00:00+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate bad seconds", () => {
+  const actual = validateIsoDateString("2022-11-17T13:00:67.000+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate bad minutes", () => {
+  const actual = validateIsoDateString("2022-11-17T13:74:00.000+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate bad hours", () => {
+  const actual = validateIsoDateString("2022-11-17T25:00:00.000+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate bad days", () => {
+  const actual = validateIsoDateString("2022-11-32T00:00:00.000+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should invalidate bad month", () => {
+  const actual = validateIsoDateString("2022-13-01T01:00:00.000+02:00");
+  expect(actual).toEqual(false);
+});
+
+it("Should validate string with Z", () => {
+  const actual = validateIsoDateString("2022-12-01T01:00:00.000Z");
+  expect(actual).toEqual(true);
+});
+
+it("Should validate string with +00:00", () => {
+  const actual = validateIsoDateString("2022-12-01T01:00:00.000+00:00");
+  expect(actual).toEqual(true);
 });

--- a/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
+++ b/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
@@ -6,6 +6,7 @@ import {
   arrow_down as arrowDown,
   arrow_up as arrowUp,
   assignment,
+  calendar,
   check,
   chevron_down as chevronDown,
   chevron_right as chevronRight,
@@ -47,7 +48,8 @@ const icons = {
   compare,
   world,
   arrowUp,
-  arrowDown
+  arrowDown,
+  calendar
 };
 
 Icon.add(icons);


### PR DESCRIPTION
## Fixes
This pull request fixes WE-672

## Description
* Implement DateTimeField to use in properties modal to adjust dates based on time zone, and with ability to paste in ISO strings.
* Change formatDateString to always show time zone offset.
* Show time zone offsets in select time zone menu.
* Use DateTimeField in BhaRunPropertiesModal as an example (the rest will be done in WE-700)

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests
