### PR TITLE
WE-700 Use DateTimeField in properties modals

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/BhaRunPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/BhaRunPropertiesModal.tsx
@@ -30,6 +30,10 @@ const BhaRunPropertiesModal = (props: BhaRunPropertiesModalProps): React.ReactEl
     operationState: { timeZone }
   } = useContext(OperationContext);
   const [editableBhaRun, setEditableBhaRun] = useState<BhaRun>(null);
+  const [dTimStartValid, setDTimStartValid] = useState<boolean>(true);
+  const [dTimStopValid, setDTimStopValid] = useState<boolean>(true);
+  const [dTimStartDrillingValid, setDTimStartDrillingValid] = useState<boolean>(true);
+  const [dTimStopDrillingValid, setDTimStopDrillingValid] = useState<boolean>(true);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const editMode = mode === PropertiesModalMode.Edit;
 
@@ -111,25 +115,37 @@ const BhaRunPropertiesModal = (props: BhaRunPropertiesModalProps): React.ReactEl
               <DateTimeField
                 value={editableBhaRun.dTimStart}
                 label="dTimStart"
-                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStart: dateTime })}
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableBhaRun({ ...editableBhaRun, dTimStart: dateTime });
+                  setDTimStartValid(valid);
+                }}
                 timeZone={timeZone}
               />
               <DateTimeField
                 value={editableBhaRun.dTimStop}
                 label="dTimStop"
-                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStop: dateTime })}
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableBhaRun({ ...editableBhaRun, dTimStop: dateTime });
+                  setDTimStopValid(valid);
+                }}
                 timeZone={timeZone}
               />
               <DateTimeField
                 value={editableBhaRun.dTimStartDrilling}
                 label="dTimStartDrilling"
-                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStartDrilling: dateTime })}
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableBhaRun({ ...editableBhaRun, dTimStartDrilling: dateTime });
+                  setDTimStartDrillingValid(valid);
+                }}
                 timeZone={timeZone}
               />
               <DateTimeField
                 value={editableBhaRun.dTimStopDrilling}
                 label="dTimStopDrilling"
-                updateObject={(dateTime: string) => setEditableBhaRun({ ...editableBhaRun, dTimStopDrilling: dateTime })}
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableBhaRun({ ...editableBhaRun, dTimStopDrilling: dateTime });
+                  setDTimStopDrillingValid(valid);
+                }}
                 timeZone={timeZone}
               />
               <TextField
@@ -275,7 +291,7 @@ const BhaRunPropertiesModal = (props: BhaRunPropertiesModalProps): React.ReactEl
               />
             </>
           }
-          confirmDisabled={!validText(editableBhaRun.name)}
+          confirmDisabled={!validText(editableBhaRun.name) || !dTimStopValid || !dTimStartValid || !dTimStartDrillingValid || !dTimStopDrillingValid}
           onSubmit={() => onSubmit(editableBhaRun)}
           isLoading={isLoading}
         />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/DateTimeField.tsx
@@ -8,7 +8,7 @@ import formatDateString, { validateIsoDateString } from "../DateFormatter";
 interface DateTimeFieldProps {
   value: string;
   label: string;
-  updateObject: (dateTime: string) => void;
+  updateObject: (dateTime: string, valid: boolean) => void;
   timeZone: TimeZone;
 }
 
@@ -40,8 +40,8 @@ export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => 
     }
     return "";
   };
-
-  const isValid = validateIsoDateString(value) || (initiallyEmpty && (value == null || value === ""));
+  const validate = (current: string) => validateIsoDateString(current) || (initiallyEmpty && (current == null || current === ""));
+  const isValid = validate(value);
   return (
     <Layout>
       <TextField
@@ -49,10 +49,10 @@ export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => 
         label={label}
         value={value}
         helperText={getHelperText()}
-        variant={isValid ? undefined : "error"}
+        variant={validate(value) ? undefined : "error"}
         autoComplete="off"
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
-          updateObject(e.target.value);
+          updateObject(e.target.value, validate(e.target.value));
         }}
       />
       <PickerIcon name="calendar" />
@@ -72,7 +72,7 @@ export const DateTimeField = (props: DateTimeFieldProps): React.ReactElement => 
             toFormat += slice;
           }
           const formatted = formatDateString(toFormat, timeZone);
-          updateObject(formatted);
+          updateObject(formatted, validate(formatted));
         }}
       />
     </Layout>

--- a/Src/WitsmlExplorer.Frontend/components/Modals/RigPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/RigPropertiesModal.tsx
@@ -1,13 +1,14 @@
 ﻿import { Autocomplete } from "@equinor/eds-core-react";
 import { TextField } from "@material-ui/core";
-import moment from "moment";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import OperationContext from "../../contexts/operationContext";
 import { HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { itemStateTypes } from "../../models/itemStateTypes";
 import Rig from "../../models/rig";
 import { rigType } from "../../models/rigType";
 import JobService, { JobType } from "../../services/jobService";
+import { DateTimeField } from "./DateTimeField";
 import ModalDialog from "./ModalDialog";
 import { PropertiesModalMode, validPhoneNumber, validText } from "./ModalParts";
 
@@ -19,8 +20,13 @@ export interface RigPropertiesModalProps {
 
 const RigPropertiesModal = (props: RigPropertiesModalProps): React.ReactElement => {
   const { mode, rig, dispatchOperation } = props;
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const [editableRig, setEditableRig] = useState<Rig>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [dTimStartOpValid, setDTimStartOpValid] = useState<boolean>(true);
+  const [dTimEndOpValid, setDTimEndOpValid] = useState<boolean>(true);
   const editMode = mode === PropertiesModalMode.Edit;
 
   useEffect(() => {
@@ -69,30 +75,23 @@ const RigPropertiesModal = (props: RigPropertiesModalProps): React.ReactElement 
                   setEditableRig({ ...editableRig, typeRig: selectedItems[0] });
                 }}
               />
-
-              <TextField
-                id="dTimStart"
-                label="dTimStart"
-                type="datetime-local"
-                fullWidth
-                InputLabelProps={{
-                  shrink: true
+              <DateTimeField
+                value={editableRig.dTimStartOp}
+                label="dTimStartOp"
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableRig({ ...editableRig, dTimStartOp: dateTime });
+                  setDTimStartOpValid(valid);
                 }}
-                disabled={!editableRig.dTimStartOp}
-                value={editableRig.dTimStartOp ? moment(editableRig.dTimStartOp).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableRig({ ...editableRig, dTimStartOp: e.target.value })}
+                timeZone={timeZone}
               />
-              <TextField
-                id={"dTimEnd"}
-                label={"dTimEnd"}
-                fullWidth
-                type="datetime-local"
-                InputLabelProps={{
-                  shrink: true
+              <DateTimeField
+                value={editableRig.dTimEndOp}
+                label="dTimEndOp"
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableRig({ ...editableRig, dTimEndOp: dateTime });
+                  setDTimEndOpValid(valid);
                 }}
-                disabled={!editableRig.dTimEndOp}
-                value={editableRig.dTimEndOp ? moment(editableRig.dTimEndOp).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableRig({ ...editableRig, dTimEndOp: e.target.value })}
+                timeZone={timeZone}
               />
               <TextField
                 id={"yearEntService"}
@@ -200,7 +199,7 @@ const RigPropertiesModal = (props: RigPropertiesModalProps): React.ReactElement 
               />
             </>
           }
-          confirmDisabled={!validText(editableRig.name)}
+          confirmDisabled={!validText(editableRig.name) || !dTimStartOpValid || !dTimEndOpValid}
           onSubmit={() => onSubmit(editableRig)}
           isLoading={isLoading}
         />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
@@ -1,7 +1,7 @@
 import { Autocomplete } from "@equinor/eds-core-react";
 import { InputAdornment, TextField } from "@material-ui/core";
-import moment from "moment";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import OperationContext from "../../contexts/operationContext";
 import { HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { itemStateTypes } from "../../models/itemStateTypes";
@@ -11,6 +11,7 @@ import RiskObject from "../../models/riskObject";
 import { riskSubCategory } from "../../models/riskSubCategory";
 import { riskType } from "../../models/riskType";
 import JobService, { JobType } from "../../services/jobService";
+import { DateTimeField } from "./DateTimeField";
 import ModalDialog from "./ModalDialog";
 import { PropertiesModalMode, validText } from "./ModalParts";
 
@@ -22,8 +23,13 @@ export interface RiskPropertiesModalProps {
 
 const RiskPropertiesModal = (props: RiskPropertiesModalProps): React.ReactElement => {
   const { mode, riskObject, dispatchOperation } = props;
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const [editableRiskObject, setEditableRiskObject] = useState<RiskObject>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [dTimStartValid, setDTimStartValid] = useState<boolean>(true);
+  const [dTimEndValid, setDTimEndValid] = useState<boolean>(true);
   const editMode = mode === PropertiesModalMode.Edit;
 
   useEffect(() => {
@@ -111,29 +117,23 @@ const RiskPropertiesModal = (props: RiskPropertiesModalProps): React.ReactElemen
                   setEditableRiskObject({ ...editableRiskObject, affectedPersonnel: selectedItems.join(", ") });
                 }}
               />
-              <TextField
-                id="dTimStart"
+              <DateTimeField
+                value={editableRiskObject.dTimStart}
                 label="dTimStart"
-                type="datetime-local"
-                fullWidth
-                InputLabelProps={{
-                  shrink: true
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableRiskObject({ ...editableRiskObject, dTimStart: dateTime });
+                  setDTimStartValid(valid);
                 }}
-                disabled={!editableRiskObject.dTimStart}
-                value={editableRiskObject.dTimStart ? moment(editableRiskObject.dTimStart).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableRiskObject({ ...editableRiskObject, dTimStart: e.target.value })}
+                timeZone={timeZone}
               />
-              <TextField
-                id={"dTimEnd"}
-                label={"dTimEnd"}
-                fullWidth
-                type="datetime-local"
-                InputLabelProps={{
-                  shrink: true
+              <DateTimeField
+                value={editableRiskObject.dTimEnd}
+                label="dTimEnd"
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableRiskObject({ ...editableRiskObject, dTimEnd: dateTime });
+                  setDTimEndValid(valid);
                 }}
-                disabled={!editableRiskObject.dTimEnd}
-                value={editableRiskObject.dTimEnd ? moment(editableRiskObject.dTimEnd).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableRiskObject({ ...editableRiskObject, dTimEnd: e.target.value })}
+                timeZone={timeZone}
               />
               <TextField
                 id={"mdBitStart"}
@@ -233,7 +233,7 @@ const RiskPropertiesModal = (props: RiskPropertiesModalProps): React.ReactElemen
               />
             </>
           }
-          confirmDisabled={!validText(editableRiskObject.name)}
+          confirmDisabled={!validText(editableRiskObject.name) || !dTimStartValid || !dTimEndValid}
           onSubmit={() => onSubmit(editableRiskObject)}
           isLoading={isLoading}
         />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrajectoryStationPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrajectoryStationPropertiesModal.tsx
@@ -1,6 +1,6 @@
 import { InputAdornment, TextField } from "@material-ui/core";
-import moment from "moment";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import OperationContext from "../../contexts/operationContext";
 import { HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import ObjectReference from "../../models/jobs/objectReference";
@@ -8,6 +8,7 @@ import { toObjectReference } from "../../models/objectOnWellbore";
 import Trajectory from "../../models/trajectory";
 import TrajectoryStation from "../../models/trajectoryStation";
 import JobService, { JobType } from "../../services/jobService";
+import { DateTimeField } from "./DateTimeField";
 import ModalDialog from "./ModalDialog";
 
 export interface TrajectoryStationPropertiesModalInterface {
@@ -18,8 +19,12 @@ export interface TrajectoryStationPropertiesModalInterface {
 
 const TrajectoryStationPropertiesModal = (props: TrajectoryStationPropertiesModalInterface): React.ReactElement => {
   const { trajectoryStation, trajectory, dispatchOperation } = props;
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const [editableTrajectoryStation, setEditableTrajectoryStation] = useState<TrajectoryStation>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [dTimStnValid, setDTimStnValid] = useState<boolean>(true);
 
   const onSubmit = async (updatedTrajectoryStation: TrajectoryStation) => {
     setIsLoading(true);
@@ -45,17 +50,14 @@ const TrajectoryStationPropertiesModal = (props: TrajectoryStationPropertiesModa
             <>
               <TextField disabled id="uid" label="uid" defaultValue={editableTrajectoryStation.uid} fullWidth />
               <TextField disabled id="typeTrajStation" label="type trajectory station" defaultValue={editableTrajectoryStation.typeTrajStation} fullWidth />
-              <TextField
-                id={"dTimStn"}
-                label={"datetime kickoff"}
-                fullWidth
-                type="datetime-local"
-                InputLabelProps={{
-                  shrink: true
+              <DateTimeField
+                value={editableTrajectoryStation.dTimStn}
+                label="dTimStn"
+                updateObject={(dateTime: string, valid: boolean) => {
+                  setEditableTrajectoryStation({ ...editableTrajectoryStation, dTimStn: dateTime });
+                  setDTimStnValid(valid);
                 }}
-                disabled={!editableTrajectoryStation.dTimStn}
-                value={editableTrajectoryStation.dTimStn ? moment(editableTrajectoryStation.dTimStn).format("YYYY-MM-DDTHH:MM") : undefined}
-                onChange={(e) => setEditableTrajectoryStation({ ...editableTrajectoryStation, dTimStn: e.target.value })}
+                timeZone={timeZone}
               />
               <TextField
                 id={"md"}
@@ -127,6 +129,7 @@ const TrajectoryStationPropertiesModal = (props: TrajectoryStationPropertiesModa
               />
             </>
           }
+          confirmDisabled={!dTimStnValid}
           onSubmit={() => onSubmit(editableTrajectoryStation)}
           isLoading={isLoading}
         />

--- a/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
@@ -21,7 +21,7 @@ export interface WellboreProperties {
   suffixAPI?: string;
   numGovt?: string;
   shape?: string;
-  dTimeKickoff?: Date;
+  dTimeKickoff?: string;
   md?: Measure;
   tvd?: Measure;
   mdKickoff?: Measure;


### PR DESCRIPTION
## Fixes
This pull request fixes WE-700

## Description
* Use DateTimeField in properties modals.
* Adjust DateTimeField to return whether the input is valid on change.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
