### PR TITLE
WE-710 add files not to include in image to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,4 +13,3 @@ Dockerfile
 **/config.json
 **/mysettings.*
 **/.env*
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,9 @@ Dockerfile
 **/node_modules
 
 .DS_Store
+
+**/secrets.json
+**/config.json
+**/mysettings.*
+**/.env*
+


### PR DESCRIPTION
## Fixes
This pull request fixes WE-710

## Description
When building manually, secrets and local configuration was copied over to image.

`.dockerignore` has been updated to exclude these files

## Type of change

* Bugfix

## Impacted Areas in Application

* Toolset

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [ ] Code follows the style guidelines
* [ ] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
