### PR TITLE
WE-716 fix crash on refresh action

### DIFF
--- a/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
@@ -462,8 +462,8 @@ const getCurrentSelectedObjectIfRemoved = (
 ) => {
   const fetchedSelectedObject = objects.find((value) => value.uid === selectedObject?.uid);
   const isCurrentlySelectedObjectRemoved =
-    state.selectedWell.uid == updatedWellUid &&
-    state.selectedWellbore.uid == updatedWellboreUid && // the update happened on the wellbore that is currently being browsed
+    state.selectedWell?.uid == updatedWellUid &&
+    state.selectedWellbore?.uid == updatedWellboreUid && // the update happened on the wellbore that is currently being browsed
     selectedObject && // there exists a selected object of the same type as the object type that was updated
     !fetchedSelectedObject && // the selected object does not exist among the objects fetched from the server, implying deletion
     state.currentSelected == selectedObject; // the object that is currently selected was deleted, requiring update of currently selected object


### PR DESCRIPTION
## Fixes
This pull request fixes WE-716

## Description
Fix crash on refresh action due to missing null check.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests