### PR TITLE
WE-731 local time as default time zone

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -13,8 +13,8 @@ import { getOffsetFromTimeZone } from "./DateFormatter";
 import JobsButton from "./JobsButton";
 
 const timeZoneLabels: Record<TimeZone, string> = {
-  [TimeZone.Raw]: "Original Time",
   [TimeZone.Local]: `${getOffsetFromTimeZone(TimeZone.Local)} Local Time`,
+  [TimeZone.Raw]: "Original Time",
   [TimeZone.Utc]: `${getOffsetFromTimeZone(TimeZone.Utc)} UTC`,
   [TimeZone.Brasilia]: `${getOffsetFromTimeZone(TimeZone.Brasilia)} Brazil/Brasilia`,
   [TimeZone.Berlin]: `${getOffsetFromTimeZone(TimeZone.Berlin)} Europe/Berlin`,
@@ -48,7 +48,7 @@ const TopRightCornerMenu = (): React.ReactElement => {
   const timeZoneMenuItems = [];
   for (const key in timeZoneLabels) {
     timeZoneMenuItems.push(
-      <StyledMenuItem key={key} onClick={() => onSelectTimeZone(key as TimeZone)}>
+      <StyledMenuItem key={key} onClick={() => onSelectTimeZone(key as TimeZone)} style={{ width: "250px" }}>
         <TimeZoneTypography selected={timeZone === (key as TimeZone)}>{timeZoneLabels[key as TimeZone]}</TimeZoneTypography>
         {timeZone === key && <Icon name="check" />}
       </StyledMenuItem>

--- a/Src/WitsmlExplorer.Frontend/contexts/operationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/operationStateReducer.tsx
@@ -10,8 +10,8 @@ export enum UserTheme {
 //tz database time zone for each city was found through https://www.zeitverschiebung.net/en/
 // "Brasilia" is the "Brasília" one where the first i is "i-acute"
 export enum TimeZone {
-  Raw = "Original Timezone",
   Local = "Local Time",
+  Raw = "Original Timezone",
   Utc = "UTC",
   Brasilia = "America/Sao_Paulo",
   Berlin = "Europe/Berlin",
@@ -84,7 +84,7 @@ export const initOperationStateReducer = (): [OperationState, Dispatch<Action>] 
     progressIndicatorValue: 0,
     modal: null,
     theme: UserTheme.Compact,
-    timeZone: TimeZone.Raw
+    timeZone: TimeZone.Local
   };
   return useReducer(reducer, initialState);
 };


### PR DESCRIPTION
## Fixes
This pull request fixes WE-731

## Description
Set local time as the default time zone and put it at the top of the time zone menu.
Also size the menu items to have enough place for the checkmark.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests