### PR TITLE
WE-643 reset checked messages on messages view changes

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -66,7 +66,7 @@ export const MessagesListView = (): React.ReactElement => {
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <MessageObjectContextMenu {...contextProps} />, position } });
   };
 
-  return <ContentTable columns={columns} data={getTableData()} onContextMenu={onContextMenu} checkableRows />;
+  return Object.is(selectedWellbore?.messages, messages) && <ContentTable columns={columns} data={getTableData()} onContextMenu={onContextMenu} checkableRows />;
 };
 
 export default MessagesListView;


### PR DESCRIPTION
## Fixes
This pull request fixes WE-643

## Description
Reset checked messages in MessagesListView to:
* fix stale values in properties modal after editing,
* uncheck messages on navigating to a different wellbore.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests