### PR TITLE
WE-650 standardize list view column names

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,8 @@
     "scss.validate": false,
     "json.format.enable": false,
     "json.schemaDownload.enable": false,
+    "javascript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
+    "typescript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
     "[csharp]": {
       "editor.defaultFormatter": "ms-dotnettools.csharp",
       "editor.formatOnSave": true

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
@@ -45,16 +45,16 @@ export const BhaRunsListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "tubular", label: "Tubular", type: ContentType.String },
-    { property: "dTimStart", label: "Date Time start", type: ContentType.DateTime },
-    { property: "dTimStop", label: "Date Time stop", type: ContentType.DateTime },
-    { property: "dTimStartDrilling", label: "Date Time start drilling", type: ContentType.DateTime },
-    { property: "dTimStopDrilling", label: "Date Time stop drilling", type: ContentType.DateTime },
-    { property: "itemState", label: "Item State", type: ContentType.String },
-    { property: "sourceName", label: "Source Name", type: ContentType.String },
-    { property: "dTimCreation", label: "Created", type: ContentType.DateTime },
-    { property: "dTimLastChange", label: "Last changed", type: ContentType.DateTime }
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "tubular", label: "tubular", type: ContentType.String },
+    { property: "dTimStart", label: "dTimStart", type: ContentType.DateTime },
+    { property: "dTimStop", label: "dTimStop", type: ContentType.DateTime },
+    { property: "dTimStartDrilling", label: "dTimStartDrilling", type: ContentType.DateTime },
+    { property: "dTimStopDrilling", label: "dTimStopDrilling", type: ContentType.DateTime },
+    { property: "itemState", label: "itemState", type: ContentType.String },
+    { property: "sourceName", label: "commonData.sourceName", type: ContentType.String },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedBhaRunRows: BhaRunRow[]) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
@@ -105,13 +105,13 @@ export const LogCurveInfoListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    !isDepthIndex && { property: "isActive", label: "Active", type: ContentType.Icon },
-    { property: "mnemonic", label: "Mnemonic", type: ContentType.String },
-    { property: "minIndex", label: "MinIndex", type: isDepthIndex ? ContentType.Number : ContentType.DateTime },
-    { property: "maxIndex", label: "MaxIndex", type: isDepthIndex ? ContentType.Number : ContentType.DateTime },
-    { property: "classWitsml", label: "ClassWitsml", type: ContentType.String },
-    { property: "unit", label: "Unit", type: ContentType.String },
-    { property: "mnemAlias", label: "MnemAlias", type: ContentType.String },
+    !isDepthIndex && { property: "isActive", label: "active", type: ContentType.Icon },
+    { property: "mnemonic", label: "mnemonic", type: ContentType.String },
+    { property: "minIndex", label: "minIndex", type: isDepthIndex ? ContentType.Number : ContentType.DateTime },
+    { property: "maxIndex", label: "maxIndex", type: isDepthIndex ? ContentType.Number : ContentType.DateTime },
+    { property: "classWitsml", label: "classWitsml", type: ContentType.String },
+    { property: "unit", label: "unit", type: ContentType.String },
+    { property: "mnemAlias", label: "mnemAlias", type: ContentType.String },
     { property: "uid", label: "uid", type: ContentType.String }
   ];
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -60,12 +60,12 @@ export const LogsListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "runNumber", label: "Run Number", type: ContentType.String },
-    { property: "startIndex", label: "StartIndex", type: selectedWellbore ? getType() : ContentType.String },
-    { property: "endIndex", label: "EndIndex", type: selectedWellbore ? getType() : ContentType.String },
-    { property: "indexType", label: "IndexType", type: ContentType.String },
-    { property: "uid", label: "UID", type: ContentType.String }
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "runNumber", label: "runNumber", type: ContentType.String },
+    { property: "startIndex", label: "startIndex", type: selectedWellbore ? getType() : ContentType.String },
+    { property: "endIndex", label: "endIndex", type: selectedWellbore ? getType() : ContentType.String },
+    { property: "indexType", label: "indexType", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String }
   ];
 
   const onSelect = (log: LogObjectRow) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -51,7 +51,7 @@ export const MessagesListView = (): React.ReactElement => {
     { property: "index", label: "#", type: ContentType.Number },
     { property: "dTim", label: "dTim", type: ContentType.DateTime },
     { property: "messageText", label: "messageText", type: ContentType.String },
-    { property: "uid", label: "UID", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
     { property: "name", label: "name", type: ContentType.String },
     { property: "typeMessage", label: "typeMessage", type: ContentType.String },
     { property: "sourceName", label: "commonData.sourceName", type: ContentType.String },

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
@@ -44,25 +44,25 @@ export const RigsListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "uid", label: "Uid", type: ContentType.String },
-    { property: "owner", label: "Owner", type: ContentType.String },
-    { property: "typeRig", label: "TypeRig", type: ContentType.String },
-    { property: "manufacturer", label: "Manufacturer", type: ContentType.String },
-    { property: "yearEntService", label: "YearEntService", type: ContentType.String },
-    { property: "classRig", label: "ClassRig", type: ContentType.String },
-    { property: "approvals", label: "Approvals", type: ContentType.String },
-    { property: "registration", label: "Registration", type: ContentType.String },
-    { property: "telNumber", label: "TelNumber", type: ContentType.String },
-    { property: "faxNumber", label: "FaxNumber", type: ContentType.String },
-    { property: "emailAddress", label: "EmailAddress", type: ContentType.String },
-    { property: "nameContact", label: "NameContact", type: ContentType.String },
-    { property: "ratingDrillDepth", label: "RatingDrillDepth", type: ContentType.String },
-    { property: "ratingWaterDepth", label: "RatingWaterDepth", type: ContentType.String },
-    { property: "isOffshore", label: "IsOffshore", type: ContentType.String },
-    { property: "airGap", label: "AirGap", type: ContentType.String },
-    { property: "dTimStartOp", label: "DateTimeStartOperating", type: ContentType.DateTime },
-    { property: "dTimEndOp", label: "DateTimeEndOperating", type: ContentType.DateTime }
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "owner", label: "owner", type: ContentType.String },
+    { property: "typeRig", label: "typeRig", type: ContentType.String },
+    { property: "manufacturer", label: "manufacturer", type: ContentType.String },
+    { property: "yearEntService", label: "yearEntService", type: ContentType.String },
+    { property: "classRig", label: "classRig", type: ContentType.String },
+    { property: "approvals", label: "approvals", type: ContentType.String },
+    { property: "registration", label: "registration", type: ContentType.String },
+    { property: "telNumber", label: "telNumber", type: ContentType.String },
+    { property: "faxNumber", label: "faxNumber", type: ContentType.String },
+    { property: "emailAddress", label: "emailAddress", type: ContentType.String },
+    { property: "nameContact", label: "nameContact", type: ContentType.String },
+    { property: "ratingDrillDepth", label: "ratingDrillDepth", type: ContentType.String },
+    { property: "ratingWaterDepth", label: "ratingWaterDepth", type: ContentType.String },
+    { property: "isOffshore", label: "isOffshore", type: ContentType.String },
+    { property: "airGap", label: "airGap", type: ContentType.String },
+    { property: "dTimStartOp", label: "dTimStartOp", type: ContentType.DateTime },
+    { property: "dTimEndOp", label: "dTimEndOp", type: ContentType.DateTime }
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedRigRows: RigRow[]) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -47,24 +47,24 @@ export const RisksListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "dTimCreation", label: "Created", type: ContentType.DateTime },
-    { property: "dTimLastChange", label: "Last changed", type: ContentType.DateTime },
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "type", label: "Type", type: ContentType.String },
-    { property: "category", label: "Category", type: ContentType.String },
-    { property: "subCategory", label: "Sub Category", type: ContentType.String },
-    { property: "extendCategory", label: "Extend Category", type: ContentType.String },
-    { property: "affectedPersonnel", label: "Affected Personnel", type: ContentType.String },
-    { property: "dTimStart", label: "Date Time start", type: ContentType.DateTime },
-    { property: "dTimEnd", label: "Date Time end", type: ContentType.DateTime },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime },
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "type", label: "type", type: ContentType.String },
+    { property: "category", label: "category", type: ContentType.String },
+    { property: "subCategory", label: "subCategory", type: ContentType.String },
+    { property: "extendCategory", label: "extendCategory", type: ContentType.String },
+    { property: "affectedPersonnel", label: "affectedPersonnel", type: ContentType.String },
+    { property: "dTimStart", label: "dTimStart", type: ContentType.DateTime },
+    { property: "dTimEnd", label: "dTimEnd", type: ContentType.DateTime },
     { property: "mdBitStart", label: "mdBitStart", type: ContentType.String },
     { property: "mdBitEnd", label: "mdBitEnd", type: ContentType.String },
-    { property: "severityLevel", label: "Severity Level", type: ContentType.String },
-    { property: "probabilityLevel", label: "Probability Level", type: ContentType.String },
-    { property: "summary", label: "Summary", type: ContentType.String },
-    { property: "details", label: "Details", type: ContentType.String },
-    { property: "itemState", label: "Item State", type: ContentType.String },
-    { property: "sourceName", label: "Source Name", type: ContentType.String }
+    { property: "severityLevel", label: "severityLevel", type: ContentType.String },
+    { property: "probabilityLevel", label: "probabilityLevel", type: ContentType.String },
+    { property: "summary", label: "summary", type: ContentType.String },
+    { property: "details", label: "details", type: ContentType.String },
+    { property: "itemState", label: "commonData.itemState", type: ContentType.String },
+    { property: "sourceName", label: "commonData.sourceName", type: ContentType.String }
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedRiskObjectRows: RiskObjectRow[]) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
@@ -31,15 +31,15 @@ export const TrajectoriesListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
+    { property: "name", label: "name", type: ContentType.String },
     { property: "mdMin", label: "mdMin", type: ContentType.Number },
     { property: "mdMax", label: "mdMax", type: ContentType.Number },
     { property: "aziRef", label: "aziRef", type: ContentType.String },
     { property: "dTimTrajStart", label: "dTimTrajStart", type: ContentType.DateTime },
     { property: "dTimTrajEnd", label: "dTimTrajEnd", type: ContentType.DateTime },
-    { property: "uid", label: "UID", type: ContentType.String },
-    { property: "dateTimeCreation", label: "Creation date", type: ContentType.DateTime },
-    { property: "dateTimeLastChange", label: "Last changed", type: ContentType.DateTime }
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "dateTimeCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dateTimeLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onSelect = (trajectory: any) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
@@ -64,7 +64,7 @@ export const TrajectoryView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "uid", label: "Uid", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
     { property: "dTimStn", label: "dTimStn", type: ContentType.DateTime },
     { property: "typeTrajStation", label: "typeTrajStation", type: ContentType.String },
     { property: "md", label: "md", type: ContentType.Number },

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
@@ -59,14 +59,14 @@ export const TubularView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "sequence", label: "Sequence", type: ContentType.Number },
-    { property: "typeTubularComponent", label: "typeTubularComponent", type: ContentType.String },
+    { property: "sequence", label: "sequence", type: ContentType.Number },
+    { property: "typeTubularComponent", label: "typeTubularComp", type: ContentType.String },
     { property: "innerDiameter", label: "id", type: ContentType.String },
     { property: "od", label: "od", type: ContentType.String },
     { property: "len", label: "len", type: ContentType.String },
-    { property: "tubularName", label: "tubularName", type: ContentType.String },
-    { property: "typeTubularAssy", label: "typeTubularAssy", type: ContentType.String },
-    { property: "uid", label: "Uid", type: ContentType.String }
+    { property: "tubularName", label: "tubular.name", type: ContentType.String },
+    { property: "typeTubularAssy", label: "tubular.typeTubularAssy", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String }
   ];
 
   const tubularComponentRows = tubularComponents.map((tubularComponent) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -27,9 +27,9 @@ export const TubularsListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Tubular name", type: ContentType.String },
+    { property: "name", label: "name", type: ContentType.String },
     { property: "typeTubularAssy", label: "typeTubularAssy", type: ContentType.String },
-    { property: "uid", label: "UID", type: ContentType.String }
+    { property: "uid", label: "uid", type: ContentType.String }
   ];
 
   const onSelect = (tubular: any) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
@@ -53,7 +53,7 @@ export const WbGeometryView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "uid", label: "Uid", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
     { property: "typeHoleCasing", label: "typeHoleCasing", type: ContentType.String },
     { property: "mdTop", label: "mdTop", type: ContentType.String },
     { property: "mdBottom", label: "mdBottom", type: ContentType.String },

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometrysListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometrysListView.tsx
@@ -43,9 +43,9 @@ export const WbGeometrysListView = (): React.ReactElement => {
   };
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "uid", label: "Uid", type: ContentType.String },
-    { property: "itemState", label: "Item State", type: ContentType.String }
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "itemState", label: "commonData.itemState", type: ContentType.String }
   ];
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedWbGeometryObjectRows: WbGeometryObjectRow[]) => {
     const contextProps: WbGeometryObjectContextMenuProps = {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -26,12 +26,12 @@ export const WellboresListView = (): React.ReactElement => {
   } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "wellType", label: "Well Type", type: ContentType.String },
-    { property: "wellStatus", label: "Well Status", type: ContentType.String },
-    { property: "uid", label: "UID Wellbore", type: ContentType.String },
-    { property: "dateTimeCreation", label: "Creation date", type: ContentType.DateTime },
-    { property: "dateTimeLastChange", label: "Last changed", type: ContentType.DateTime }
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "wellType", label: "typeWellbore", type: ContentType.String },
+    { property: "wellStatus", label: "statusWellbore", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "dateTimeCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dateTimeLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -21,13 +21,13 @@ export const WellsListView = (): React.ReactElement => {
   } = useContext(OperationContext);
 
   const columns: ContentTableColumn[] = [
-    { property: "name", label: "Name", type: ContentType.String },
-    { property: "field", label: "Field", type: ContentType.String },
-    { property: "operator", label: "Operator", type: ContentType.String },
-    { property: "timeZone", label: "Time zone", type: ContentType.String },
-    { property: "uid", label: "UID Well", type: ContentType.String },
-    { property: "dateTimeCreation", label: "Creation date", type: ContentType.DateTime },
-    { property: "dateTimeLastChange", label: "Last changed", type: ContentType.DateTime }
+    { property: "name", label: "name", type: ContentType.String },
+    { property: "field", label: "field", type: ContentType.String },
+    { property: "operator", label: "operator", type: ContentType.String },
+    { property: "timeZone", label: "timeZone", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "dateTimeCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dateTimeLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onSelect = (well: any) => {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-650 

## Description
Standardize the column headers in list views to follow the WITSML specification.
Set insertSpaceAfterOpeningAndBeforeClosingEmptyBraces to false in settings.json because the space was automatically removed by linting anyway (ref https://stackoverflow.com/questions/61670561/eslint-adds-unnecessary-space-between-braces-prettier-shows-error).

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
