### PR TITLE
WE-703 show all jobs as admin

### DIFF
--- a/Src/WitsmlExplorer.Api/Extensions/BuilderExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/BuilderExtensions.cs
@@ -28,5 +28,6 @@ namespace WitsmlExplorer.Api.Extensions
     {
         public const string ADMIN = "admin";
         public const string DEVELOPER = "developer";
+        public const string ADMINORDEVELOPER = "admin_or_developer";
     }
 }

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -33,7 +33,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
         }
 
         [Produces(typeof(IEnumerable<JobInfo>))]
-        public static IResult GetJobInfosByAuthorizedUser(IJobCache jobCache, HttpRequest httpRequest, IConfiguration configuration, ICredentialsService credentialsService)
+        public static IResult GetUserJobInfos(IJobCache jobCache, HttpRequest httpRequest, IConfiguration configuration, ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpRequest);
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
@@ -43,7 +43,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
         }
 
         [Produces(typeof(IEnumerable<JobInfo>))]
-        public static IResult GetJobInfosOfAllUsers(IJobCache jobCache, IConfiguration configuration)
+        public static IResult GetAllJobInfos(IJobCache jobCache, IConfiguration configuration)
         {
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
             if (!useOAuth2)

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -41,5 +41,16 @@ namespace WitsmlExplorer.Api.HttpHandlers
             string userName = useOAuth2 ? credentialsService.GetClaimFromToken(eh, "upn") : targetCreds.UserId;
             return TypedResults.Ok(jobCache.GetJobInfosByUser(userName));
         }
+
+        [Produces(typeof(IEnumerable<JobInfo>))]
+        public static IResult GetJobInfosOfAllUsers(IJobCache jobCache, IConfiguration configuration)
+        {
+            bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
+            if (!useOAuth2)
+            {
+                return TypedResults.Unauthorized();
+            }
+            return TypedResults.Ok(jobCache.GetAllJobInfos());
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -56,8 +56,8 @@ namespace WitsmlExplorer.Api
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/wbgeometrys/{wbGeometryUid}/wbgeometrysections", WbGeometryHandler.GetWbGeometrySections, useOAuth2);
 
             app.MapPost("/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
-            app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
-            app.MapGet("/jobs/jobinfosallusers", JobHandler.GetJobInfosOfAllUsers, useOAuth2, AuthorizationPolicyRoles.ADMIN);
+            app.MapGet("/jobs/userjobinfos", JobHandler.GetUserJobInfos, useOAuth2);
+            app.MapGet("/jobs/alljobinfos", JobHandler.GetAllJobInfos, useOAuth2, AuthorizationPolicyRoles.ADMINORDEVELOPER);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -57,6 +57,7 @@ namespace WitsmlExplorer.Api
 
             app.MapPost("/jobs/{jobType}", JobHandler.CreateJob, useOAuth2);
             app.MapGet("/jobs/jobinfos", JobHandler.GetJobInfosByAuthorizedUser, useOAuth2);
+            app.MapGet("/jobs/jobinfosallusers", JobHandler.GetJobInfosOfAllUsers, useOAuth2, AuthorizationPolicyRoles.ADMIN);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -14,6 +14,7 @@ namespace WitsmlExplorer.Api.Services
     {
         void CacheJob(JobInfo jobInfo);
         IEnumerable<JobInfo> GetJobInfosByUser(string username);
+        IEnumerable<JobInfo> GetAllJobInfos();
     }
 
     public class JobCache : IJobCache
@@ -48,6 +49,11 @@ namespace WitsmlExplorer.Api.Services
         public IEnumerable<JobInfo> GetJobInfosByUser(string username)
         {
             return _jobs.Values.Where(job => job.Username == username);
+        }
+
+        public IEnumerable<JobInfo> GetAllJobInfos()
+        {
+            return _jobs.Values;
         }
 
         private void Cleanup()

--- a/Src/WitsmlExplorer.Api/Startup.cs
+++ b/Src/WitsmlExplorer.Api/Startup.cs
@@ -14,6 +14,7 @@ using Serilog;
 using Witsml.Data;
 
 using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Middleware;
 using WitsmlExplorer.Api.Services;
 using WitsmlExplorer.Api.Swagger;
@@ -72,6 +73,11 @@ namespace WitsmlExplorer.Api
                 {
                     services.AddAuthorization(options => options.AddPolicy(policyRole, authBuilder => authBuilder.RequireRole(policyRole)));
                 }
+                services.AddAuthorization(options =>
+                    options.AddPolicy(AuthorizationPolicyRoles.ADMINORDEVELOPER, authBuilder =>
+                        authBuilder.RequireRole(new string[] { AuthorizationPolicyRoles.ADMIN, AuthorizationPolicyRoles.DEVELOPER })
+                    )
+                );
             }
 
         }

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -1,10 +1,11 @@
-import React, { useContext, useEffect, useState } from "react";
+import { Switch } from "@equinor/eds-core-react";
+import React, { ChangeEvent, useContext, useEffect, useState } from "react";
 import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import JobInfo from "../../models/jobs/jobInfo";
 import { Server } from "../../models/server";
-import { getUsername, msalEnabled } from "../../msal/MsalAuthProvider";
+import { adminRole, getUserAppRoles, getUsername, msalEnabled } from "../../msal/MsalAuthProvider";
 import CredentialsService from "../../services/credentialsService";
 import JobService from "../../services/jobService";
 import NotificationService, { Notification } from "../../services/notificationService";
@@ -23,6 +24,7 @@ export const JobsView = (): React.ReactElement => {
   const { selectedServer, servers } = navigationState;
   const [jobInfos, setJobInfos] = useState<JobInfo[]>([]);
   const [shouldRefresh, setShouldRefresh] = useState<boolean>(true);
+  const [showAll, setShowAll] = useState(false);
 
   const credentials = CredentialsService.getCredentials();
   const username = msalEnabled ? getUsername() : credentials.find((creds) => creds.server.id == selectedServer.id)?.username;
@@ -30,7 +32,8 @@ export const JobsView = (): React.ReactElement => {
   const fetchJobs = () => {
     const abortController = new AbortController();
     const getJobInfos = async () => {
-      setJobInfos(await JobService.getJobInfos(abortController.signal));
+      const jobInfos = showAll ? JobService.getAllJobInfos(abortController.signal) : JobService.getUsersJobInfos(abortController.signal);
+      setJobInfos(await jobInfos);
     };
 
     getJobInfos();
@@ -59,7 +62,7 @@ export const JobsView = (): React.ReactElement => {
 
   useEffect(() => {
     return setShouldRefresh(true);
-  }, [username]);
+  }, [username, showAll]);
 
   useEffect(() => {
     if (shouldRefresh) {
@@ -107,7 +110,19 @@ export const JobsView = (): React.ReactElement => {
     };
   });
 
-  return <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} />;
+  return (
+    <>
+      {msalEnabled && getUserAppRoles().includes(adminRole) && (
+        <Switch
+          label="Show all users' jobs"
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            setShowAll(e.target.checked);
+          }}
+        />
+      )}
+      <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} />
+    </>
+  );
 };
 
 const serverUrlToName = (servers: Server[], url: string): string => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -5,7 +5,7 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import JobInfo from "../../models/jobs/jobInfo";
 import { Server } from "../../models/server";
-import { adminRole, getUserAppRoles, getUsername, msalEnabled } from "../../msal/MsalAuthProvider";
+import { adminRole, developerRole, getUserAppRoles, getUsername, msalEnabled } from "../../msal/MsalAuthProvider";
 import CredentialsService from "../../services/credentialsService";
 import JobService from "../../services/jobService";
 import NotificationService, { Notification } from "../../services/notificationService";
@@ -32,7 +32,7 @@ export const JobsView = (): React.ReactElement => {
   const fetchJobs = () => {
     const abortController = new AbortController();
     const getJobInfos = async () => {
-      const jobInfos = showAll ? JobService.getAllJobInfos(abortController.signal) : JobService.getUsersJobInfos(abortController.signal);
+      const jobInfos = showAll ? JobService.getAllJobInfos(abortController.signal) : JobService.getUserJobInfos(abortController.signal);
       setJobInfos(await jobInfos);
     };
 
@@ -112,7 +112,7 @@ export const JobsView = (): React.ReactElement => {
 
   return (
     <>
-      {msalEnabled && getUserAppRoles().includes(adminRole) && (
+      {msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) && (
         <Switch
           label="Show all users' jobs"
           onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -13,6 +13,7 @@ export enum SecurityScheme {
 }
 
 export const adminRole = "admin";
+export const developerRole = "developer";
 
 const msalConfig: Configuration = {
   auth: {

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -12,6 +12,8 @@ export enum SecurityScheme {
   Basic = "Basic"
 }
 
+export const adminRole = "admin";
+
 const msalConfig: Configuration = {
   auth: {
     authority: `https://login.microsoftonline.com/${process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID}`,

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -35,8 +35,17 @@ export default class JobService {
     }
   }
 
-  public static async getJobInfos(abortSignal?: AbortSignal): Promise<JobInfo[]> {
+  public static async getUsersJobInfos(abortSignal?: AbortSignal): Promise<JobInfo[]> {
     const response = await ApiClient.get(`/api/jobs/jobinfos`, abortSignal);
+    if (response.ok) {
+      return response.json();
+    } else {
+      return [];
+    }
+  }
+
+  public static async getAllJobInfos(abortSignal?: AbortSignal): Promise<JobInfo[]> {
+    const response = await ApiClient.get(`/api/jobs/jobinfosallusers`, abortSignal);
     if (response.ok) {
       return response.json();
     } else {

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -35,8 +35,8 @@ export default class JobService {
     }
   }
 
-  public static async getUsersJobInfos(abortSignal?: AbortSignal): Promise<JobInfo[]> {
-    const response = await ApiClient.get(`/api/jobs/jobinfos`, abortSignal);
+  public static async getUserJobInfos(abortSignal?: AbortSignal): Promise<JobInfo[]> {
+    const response = await ApiClient.get(`/api/jobs/userjobinfos`, abortSignal);
     if (response.ok) {
       return response.json();
     } else {
@@ -45,7 +45,7 @@ export default class JobService {
   }
 
   public static async getAllJobInfos(abortSignal?: AbortSignal): Promise<JobInfo[]> {
-    const response = await ApiClient.get(`/api/jobs/jobinfosallusers`, abortSignal);
+    const response = await ApiClient.get(`/api/jobs/alljobinfos`, abortSignal);
     if (response.ok) {
       return response.json();
     } else {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-703

## Description
Add a toggle in jobs view only in msalEnabled mode for users with the 'admin' or the 'developer' role.
The toggle allows browsing all job infos stored on the server, regardless of the user.

## Type of change

* New feature (non-breaking change which adds functionality)

## Impacted Areas in Application

* Frontend, API

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
Should users with the 'developer' role also be allowed to view all jobs to ease debugging?
