### PR TITLE
WE-736 rework delete confirmation dialog

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -47,14 +47,14 @@ export const LogsListView = (): React.ReactElement => {
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <LogObjectContextMenu {...contextProps} />, position } });
   };
 
-  const getTableData = () => {
-    return logs.map((log) => {
+  const getTableData = (): LogObjectRow[] => {
+    return logs.map((log, index) => {
       return {
         ...log,
-        id: log.uid,
+        id: index,
         startIndex: selectedWellbore && getType() == ContentType.DateTime ? formatDateString(log.startIndex, timeZone) : log.startIndex,
         endIndex: selectedWellbore && getType() == ContentType.DateTime ? formatDateString(log.endIndex, timeZone) : log.endIndex,
-        log: log
+        logObject: log
       };
     });
   };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -1,6 +1,8 @@
+import { TextField } from "@equinor/eds-core-react";
 import styled from "styled-components";
 import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
+import { getParentType } from "../../models/componentType";
 import ComponentReferences from "../../models/jobs/componentReferences";
 import { DeleteComponentsJob, DeleteObjectsJob } from "../../models/jobs/deleteJobs";
 import ObjectOnWellbore, { toObjectReferences } from "../../models/objectOnWellbore";
@@ -83,7 +85,9 @@ export const onClickDeleteObjects = async (dispatchOperation: DispatchOperation,
     pluralizedName,
     objectsOnWellbore.map((item) => item.name),
     orderDeleteJob,
-    dispatchOperation
+    dispatchOperation,
+    CredentialsService.getCredentials()[0].server.name,
+    objectsOnWellbore[0].wellboreName
   );
 };
 
@@ -97,17 +101,50 @@ export const onClickDeleteComponents = async (dispatchOperation: DispatchOperati
     await JobService.orderJob(jobType, job);
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
-  displayDeleteModal(pluralizedName, componentReferences.componentUids, orderDeleteJob, dispatchOperation);
+  displayDeleteModal(
+    pluralizedName,
+    componentReferences.componentUids,
+    orderDeleteJob,
+    dispatchOperation,
+    CredentialsService.getCredentials()[0].server.name,
+    componentReferences.parent.wellboreName,
+    componentReferences.parent.name,
+    getParentType(componentReferences.componentType)
+  );
 };
 
-const displayDeleteModal = (toDeleteTypeName: string, toDeleteNames: string[], onDelete: () => void, dispatchOperation: DispatchOperation) => {
+const displayDeleteModal = (
+  toDeleteTypeName: string,
+  toDeleteNames: string[],
+  onDelete: () => void,
+  dispatchOperation: DispatchOperation,
+  server: string,
+  wellbore: string,
+  parent?: string,
+  parentType?: string
+) => {
   const confirmation = (
     <ConfirmModal
       heading={`Delete ${toDeleteTypeName}?`}
       content={
-        <span>
-          This will permanently delete {toDeleteTypeName}: <strong>{toDeleteNames.join(", ")}</strong>
-        </span>
+        <Layout>
+          <TextField readOnly id="server" label="Server" defaultValue={server} tabIndex={-1} />
+          <TextField readOnly id="wellbore" label="Wellbore" defaultValue={wellbore} tabIndex={-1} />
+          {parent != null && <TextField readOnly id="parent_object" label={parentType} defaultValue={parent} tabIndex={-1} />}
+          <span>
+            This will permanently delete {toDeleteNames.length} {toDeleteTypeName}:
+            <strong>
+              {toDeleteNames.map((name) => {
+                return (
+                  <>
+                    <br />
+                    {name}
+                  </>
+                );
+              })}
+            </strong>
+          </span>
+        </Layout>
       }
       onConfirm={onDelete}
       confirmColor={"danger"}
@@ -116,3 +153,9 @@ const displayDeleteModal = (toDeleteTypeName: string, toDeleteNames: string[], o
   );
   dispatchOperation({ type: OperationType.DisplayModal, payload: confirmation });
 };
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+`;

--- a/Src/WitsmlExplorer.Frontend/models/componentType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/componentType.ts
@@ -1,6 +1,23 @@
+import { ObjectType } from "./objectType";
+
 export enum ComponentType {
   Mnemonic = "Mnemonic",
   TrajectoryStation = "Trajectory Station",
   TubularComponent = "Tubular Component",
   WbGeometrySection = "WbGeometry Section"
 }
+
+export const getParentType = (componentType: ComponentType): ObjectType => {
+  switch (componentType) {
+    case ComponentType.Mnemonic:
+      return ObjectType.Log;
+    case ComponentType.TrajectoryStation:
+      return ObjectType.Trajectory;
+    case ComponentType.TubularComponent:
+      return ObjectType.Tubular;
+    case ComponentType.WbGeometrySection:
+      return ObjectType.WbGeometry;
+    default:
+      return undefined;
+  }
+};


### PR DESCRIPTION
## Fixes
This pull request fixes WE-736

## Description
Add server name, wellbore name, and, for components, parent object name to delete confirmation modal.
Print a single object to delete per line.
Also fix crash on context menu actions in log list view.

## Type of change

* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
