### PR TITLE
WE-740 disable server list editing on no admin role

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
@@ -10,7 +10,7 @@ import NavigationType from "../../contexts/navigationType";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { emptyServer, Server } from "../../models/server";
-import { getUserAppRoles, msalEnabled, SecurityScheme } from "../../msal/MsalAuthProvider";
+import { adminRole, getUserAppRoles, msalEnabled, SecurityScheme } from "../../msal/MsalAuthProvider";
 import CredentialsService from "../../services/credentialsService";
 import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
@@ -28,6 +28,7 @@ const ServerManager = (): React.ReactElement => {
   const { dispatchOperation } = useContext(OperationContext);
   const [hasFetchedServers, setHasFetchedServers] = useState(false);
   const [currentWitsmlLoginState, setLoginState] = useState<{ username?: string; server?: Server }>({});
+  const editDisabled = msalEnabled && !getUserAppRoles().includes(adminRole);
 
   useEffect(() => {
     const unsubscribeFromCredentialsEvents = CredentialsService.onServerChanged.subscribe(async (credentialState) => {
@@ -101,7 +102,7 @@ const ServerManager = (): React.ReactElement => {
   };
 
   const onEditItem = (server: Server) => {
-    dispatchOperation({ type: OperationType.DisplayModal, payload: <ServerModal server={server} /> });
+    dispatchOperation({ type: OperationType.DisplayModal, payload: <ServerModal editDisabled server={server} /> });
   };
 
   const showCredentialsModal = (server: Server, errorMessage = "") => {
@@ -137,7 +138,7 @@ const ServerManager = (): React.ReactElement => {
         <Typography color={"primary"} bold={true}>
           Manage Connections
         </Typography>
-        <Button variant="outlined" value={NEW_SERVER_ID} key={NEW_SERVER_ID} onClick={() => onEditItem(emptyServer())}>
+        <Button variant="outlined" value={NEW_SERVER_ID} key={NEW_SERVER_ID} disabled={editDisabled} onClick={() => onEditItem(emptyServer())}>
           <Icon name="cloudDownload" />
           New server
         </Button>
@@ -181,7 +182,7 @@ const ServerManager = (): React.ReactElement => {
                   </Button>
                 </Table.Cell>
                 <Table.Cell style={CellHeaderStyle}>
-                  <Button variant="ghost" onClick={() => showDeleteServerModal(server, dispatchOperation, dispatchNavigation, selectedServer)}>
+                  <Button disabled={editDisabled} variant="ghost" onClick={() => showDeleteServerModal(server, dispatchOperation, dispatchNavigation, selectedServer)}>
                     <Icon name="deleteToTrash" size={24} />
                   </Button>
                 </Table.Cell>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
@@ -102,7 +102,7 @@ const ServerManager = (): React.ReactElement => {
   };
 
   const onEditItem = (server: Server) => {
-    dispatchOperation({ type: OperationType.DisplayModal, payload: <ServerModal editDisabled server={server} /> });
+    dispatchOperation({ type: OperationType.DisplayModal, payload: <ServerModal editDisabled={editDisabled} server={server} /> });
   };
 
   const showCredentialsModal = (server: Server, errorMessage = "") => {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -21,6 +21,7 @@ import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from
 
 export interface ServerModalProps {
   server: Server;
+  editDisabled: boolean;
 }
 
 const ServerModal = (props: ServerModalProps): React.ReactElement => {
@@ -120,6 +121,7 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
               onChange={onChangeUrl}
               onBlur={runUrlValidation}
               required
+              disabled={props.editDisabled}
             />
             {connectionVerified && <ThumbUpOutlinedIcon style={{ color: colors.interactive.successResting }} variant={"outlined"} fontSize={"large"} />}
             <TestServerButton disabled={displayUrlError || connectionVerified} onClick={showCredentialsModal} color={"primary"} variant="outlined">
@@ -137,6 +139,7 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
             onBlur={runServerNameValidation}
             onChange={onChangeName}
             required
+            disabled={props.editDisabled}
           />
           <TextField
             id="description"
@@ -145,6 +148,7 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
             fullWidth
             inputProps={{ maxLength: 64 }}
             onChange={(e) => setServer({ ...server, description: e.target.value })}
+            disabled={props.editDisabled}
           />
           <Autocomplete
             id="securityScheme"
@@ -155,6 +159,7 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
               setServer({ ...server, securityscheme: selectedItems[0] || schemeValues[0] });
             }}
             hideClearButton={true}
+            disabled={props.editDisabled}
           />
           <TextField
             id="role"
@@ -163,13 +168,14 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
             fullWidth
             inputProps={{ maxLength: 64 }}
             onChange={(e) => setServer({ ...server, roles: e.target.value.split(" ") })}
+            disabled={props.editDisabled}
           />
         </>
       }
       onSubmit={onSubmit}
       isLoading={isLoading}
-      onDelete={server.id ? showDeleteModal : null}
-      confirmDisabled={!validateForm()}
+      onDelete={server.id && !props.editDisabled ? showDeleteModal : null}
+      confirmDisabled={props.editDisabled || !validateForm()}
     />
   );
 };


### PR DESCRIPTION
## Fixes
This pull request fixes WE-740

## Description
Disable server list editing in server manager as it is not allowed through the API. Leave the editing modal accessible to allow for verifying the connection.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
