### PR TITLE
WE-752 fetch usernames with servers

### DIFF
--- a/Src/WitsmlExplorer.Api/Models/Connection.cs
+++ b/Src/WitsmlExplorer.Api/Models/Connection.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WitsmlExplorer.Api.Models
+{
+    public class Connection : Server
+    {
+        public Connection(Server server)
+        {
+            Name = server.Name;
+            Url = server.Url;
+            Description = server.Description;
+            SecurityScheme = server.SecurityScheme;
+            Roles = server.Roles;
+            Id = server.Id;
+        }
+
+        [JsonPropertyName("username")]
+        public string Username { get; set; }
+
+        public override string ToString()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -5,8 +5,7 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import JobInfo from "../../models/jobs/jobInfo";
 import { Server } from "../../models/server";
-import { adminRole, developerRole, getUserAppRoles, getUsername, msalEnabled } from "../../msal/MsalAuthProvider";
-import CredentialsService from "../../services/credentialsService";
+import { adminRole, developerRole, getUserAppRoles, msalEnabled } from "../../msal/MsalAuthProvider";
 import JobService from "../../services/jobService";
 import NotificationService, { Notification } from "../../services/notificationService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
@@ -21,13 +20,10 @@ export const JobsView = (): React.ReactElement => {
     dispatchOperation,
     operationState: { timeZone }
   } = useContext(OperationContext);
-  const { selectedServer, servers } = navigationState;
+  const { servers } = navigationState;
   const [jobInfos, setJobInfos] = useState<JobInfo[]>([]);
   const [shouldRefresh, setShouldRefresh] = useState<boolean>(true);
   const [showAll, setShowAll] = useState(false);
-
-  const credentials = CredentialsService.getCredentials();
-  const username = msalEnabled ? getUsername() : credentials.find((creds) => creds.server.id == selectedServer.id)?.username;
 
   const fetchJobs = () => {
     const abortController = new AbortController();
@@ -61,7 +57,7 @@ export const JobsView = (): React.ReactElement => {
 
   useEffect(() => {
     return setShouldRefresh(true);
-  }, [username, showAll]);
+  }, [showAll]);
 
   useEffect(() => {
     if (shouldRefresh) {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -84,7 +84,6 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
     setDisplayUrlError(!isUrlValid(server.url));
   };
 
-  // Uncomment to enable user edit of server list
   const validateForm = () => {
     return server.name.length !== 0 && isUrlValid(server.url);
   };

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -121,7 +121,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       confirmText={confirmText ?? mode === CredentialsMode.SAVE ? "Login" : "Test"}
       onSubmit={mode === CredentialsMode.SAVE ? onSave : onVerifyConnection}
       onCancel={() => {
-        CredentialsService.onAuthorizationChanged.dispatch({ server, status: AuthorizationStatus.Cancel });
+        CredentialsService.onAuthorizationChangeDispatch({ server, status: AuthorizationStatus.Cancel });
         dispatchOperation({ type: OperationType.HideModal });
         if (props.onCancel) {
           props.onCancel();

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/AuthorizationManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/AuthorizationManager.tsx
@@ -9,7 +9,7 @@ const AuthorizationManager = (): React.ReactElement => {
   const { dispatchOperation } = useContext(OperationContext);
 
   useEffect(() => {
-    const unsubscribe = CredentialsService.onAuthorizationChanged.subscribe(async (authorizationState: AuthorizationState) => {
+    const unsubscribe = CredentialsService.onAuthorizationChangeEvent.subscribe(async (authorizationState: AuthorizationState) => {
       if (authorizationState.status == AuthorizationStatus.Unauthorized && !CredentialsService.serverIsAwaitingAuthorization(authorizationState.server)) {
         showCredentialsModal(authorizationState.server);
         CredentialsService.awaitServerAuthorization(authorizationState.server);

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -42,7 +42,7 @@ const TopRightCornerMenu = (): React.ReactElement => {
   }, []);
 
   useEffect(() => {
-    const unsubscribeFromCredentialsEvents = CredentialsService.onAuthorizationChanged.subscribe(() => {
+    const unsubscribeFromCredentialsEvents = CredentialsService.onAuthorizationChangeEvent.subscribe(() => {
       setUsername(CredentialsService.getCredentials()[0]?.username);
     });
     return () => {
@@ -163,7 +163,7 @@ const SelectTypography = styled(Typography)<{ selected: boolean }>`
   }
 `;
 
-const TimeZoneTypography = styled(SelectTypography)<{ selected: boolean }>`
+const TimeZoneTypography = styled(SelectTypography)`
   && {
     font-feature-settings: "tnum";
   }

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -1,7 +1,8 @@
 import { Button, Typography } from "@equinor/eds-core-react";
 import { MenuItem } from "@material-ui/core";
-import React, { ReactElement, useContext, useEffect, useState } from "react";
+import React, { ReactElement, useContext, useEffect } from "react";
 import styled from "styled-components";
+import NavigationContext from "../contexts/navigationContext";
 import OperationContext from "../contexts/operationContext";
 import { TimeZone, UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
@@ -25,7 +26,9 @@ const timeZoneLabels: Record<TimeZone, string> = {
 };
 
 const TopRightCornerMenu = (): React.ReactElement => {
-  const [username, setUsername] = useState<string>("");
+  const {
+    navigationState: { selectedServer }
+  } = useContext(NavigationContext);
   const {
     operationState: { theme, timeZone },
     dispatchOperation
@@ -39,15 +42,6 @@ const TopRightCornerMenu = (): React.ReactElement => {
       const storedTimeZone = (localStorage.getItem("selectedTimeZone") as TimeZone) ?? timeZone;
       dispatchOperation({ type: OperationType.SetTimeZone, payload: storedTimeZone });
     }
-  }, []);
-
-  useEffect(() => {
-    const unsubscribeFromCredentialsEvents = CredentialsService.onAuthorizationChangeEvent.subscribe(() => {
-      setUsername(CredentialsService.getCredentials()[0]?.username);
-    });
-    return () => {
-      unsubscribeFromCredentialsEvents();
-    };
   }, []);
 
   const onSelectTimeZone = (selectedTimeZone: TimeZone) => {
@@ -118,10 +112,10 @@ const TopRightCornerMenu = (): React.ReactElement => {
 
   return (
     <Layout>
-      {username && (
+      {selectedServer?.username && (
         <StyledButton variant="ghost" disabled>
           <Icon name="person" />
-          {username}
+          {selectedServer.username}
         </StyledButton>
       )}
       <ServerManagerButton />

--- a/Src/WitsmlExplorer.Frontend/models/server.ts
+++ b/Src/WitsmlExplorer.Frontend/models/server.ts
@@ -5,6 +5,7 @@ export interface Server {
   url: string;
   securityscheme: string;
   roles: string[];
+  username?: string;
 }
 
 export function emptyServer(): Server {
@@ -14,6 +15,7 @@ export function emptyServer(): Server {
     description: "",
     url: "",
     securityscheme: "Basic",
-    roles: []
+    roles: [],
+    username: undefined
   };
 }

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -47,6 +47,10 @@ class CredentialsService {
     this.server = server;
   }
 
+  public get selectedServer(): Server {
+    return this.server;
+  }
+
   public setSourceServer(server: Server) {
     this.sourceServer = server;
   }
@@ -80,6 +84,9 @@ class CredentialsService {
   }
 
   public saveCredentials(serverCredentials: BasicServerCredentials) {
+    // TODO: username will be set on the server properly as part of WE-744
+    // username on first login with system user is not set yet, will be fixed as part of WE-749
+    serverCredentials.server.username = serverCredentials.username;
     const index = this.credentials.findIndex((c) => c.server.id === serverCredentials.server.id);
     if (index === -1) {
       this.credentials.push(serverCredentials);

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -22,7 +22,6 @@ export interface AuthorizationState {
 
 class CredentialsService {
   private static _instance: CredentialsService;
-  private _onServerChanged = new SimpleEventDispatcher<{ server: Server }>();
   private _onAuthorizationChange = new SimpleEventDispatcher<AuthorizationState>();
   private credentials: BasicServerCredentials[] = [];
   private server?: Server;
@@ -46,7 +45,6 @@ class CredentialsService {
 
   public setSelectedServer(server: Server) {
     this.server = server;
-    this._onServerChanged.dispatch({ server: server });
   }
 
   public setSourceServer(server: Server) {
@@ -88,7 +86,6 @@ class CredentialsService {
     } else {
       this.credentials[index] = serverCredentials;
     }
-    this._onServerChanged.dispatch({ server: serverCredentials.server });
     this._onAuthorizationChange.dispatch({ server: serverCredentials.server, status: AuthorizationStatus.Authorized });
   }
 
@@ -127,7 +124,7 @@ class CredentialsService {
     } catch {
       // ignore unavailable local storage
     }
-    const response = await ApiClient.get(`/api/credentials/authorize?keep=` + keep, abortSignal, [credentials], false);
+    const response = await ApiClient.get(`/api/credentials/authorize?keep=` + keep, abortSignal, [credentials], false, false);
     if (!response.ok) {
       const { message }: ErrorDetails = await response.json();
       CredentialsService.throwError(response.status, message);
@@ -135,7 +132,7 @@ class CredentialsService {
   }
 
   public async deauthorize(abortSignal?: AbortSignal): Promise<any> {
-    const response = await ApiClient.get(`/api/credentials/deauthorize`, abortSignal, undefined, true);
+    const response = await ApiClient.get(`/api/credentials/deauthorize`, abortSignal, undefined);
     if (!response.ok) {
       const { message }: ErrorDetails = await response.json();
       CredentialsService.throwError(response.status, message);
@@ -153,12 +150,12 @@ class CredentialsService {
     }
   }
 
-  public get onServerChanged() {
-    return this._onServerChanged.asEvent();
+  public onAuthorizationChangeDispatch(authorizationState: AuthorizationState) {
+    return this._onAuthorizationChange.dispatch(authorizationState);
   }
 
-  public get onAuthorizationChanged() {
-    return this._onAuthorizationChange;
+  public get onAuthorizationChangeEvent() {
+    return this._onAuthorizationChange.asEvent();
   }
 
   public static get Instance() {

--- a/Src/WitsmlExplorer.Frontend/services/wellService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/wellService.tsx
@@ -4,7 +4,7 @@ import { ApiClient } from "./apiClient";
 
 export default class WellService {
   public static async getWells(abortSignal: AbortSignal = null): Promise<Well[]> {
-    const response = await ApiClient.get(`api/wells`, abortSignal, undefined, undefined, false);
+    const response = await ApiClient.get(`api/wells`, abortSignal);
 
     if (response.ok) {
       return response.json();


### PR DESCRIPTION
## Fixes
This pull request fixes WE-752

## Description
Return usernames on the get-servers route with a new Connection class (to make it different from the Server class that gets saved to the database).
Show usernames in the ServerManager (to be improved later).
Clean up ServerManager a bit.
Split onAuthorizationChange into Event and Dispatch to make it easier to see where we listen for change vs where we fire events.
Clone the response in handleUnauthorized in apiClient to properly return the response on UserCredentialsModal cancellation.

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
