### PR TITLE
WE-744 Refactor CredentialsService to AuthorizationService

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
@@ -20,7 +20,7 @@ const Alerts = (): React.ReactElement => {
       }
     });
     const unsubscribeOnJobFinished = NotificationService.Instance.alertDispatcherAsEvent.subscribe((notification) => {
-      const shouldNotify = notification.serverUrl.toString() === navigationState.selectedServer?.url;
+      const shouldNotify = notification.serverUrl == null || notification.serverUrl.toString() === navigationState.selectedServer?.url;
       if (!shouldNotify) {
         return;
       }

--- a/Src/WitsmlExplorer.Frontend/components/ContentView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentView.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
-import NavigationContext, { listWellsFlag, selectedJobsFlag, selectedServerManagerFlag } from "../contexts/navigationContext";
+import NavigationContext, { selectedJobsFlag, selectedServerManagerFlag } from "../contexts/navigationContext";
 import { BhaRunsListView } from "./ContentViews/BhaRunsListView";
 import { CurveValuesView } from "./ContentViews/CurveValuesView";
 import JobsView from "./ContentViews/JobsView";
@@ -87,8 +87,6 @@ const ContentView = (): React.ReactElement => {
         setView(<JobsView />);
       } else if (currentSelected === selectedServerManagerFlag) {
         setView(<ServerManager />);
-      } else if (currentSelected === listWellsFlag) {
-        setView(<WellsListView />);
       } else {
         // eslint-disable-next-line no-console
         console.error(`Don't know how to render this item: ${JSON.stringify(currentSelected)}`);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
@@ -53,6 +53,7 @@ const ServerManager = (): React.ReactElement => {
           message: error.message,
           isSuccess: false
         });
+        dispatchNavigation({ type: NavigationType.SelectServer, payload: { server: null } });
       }
     };
     onCurrentLoginStateChange();
@@ -68,7 +69,6 @@ const ServerManager = (): React.ReactElement => {
       const getServers = async () => {
         const freshServers = await ServerService.getServers(abortController.signal);
         setHasFetchedServers(true);
-        CredentialsService.saveServers(freshServers);
         const action: UpdateServerListAction = { type: ModificationType.UpdateServerList, payload: { servers: freshServers } };
         dispatchNavigation(action);
       };
@@ -82,7 +82,6 @@ const ServerManager = (): React.ReactElement => {
 
   const onSelectItem = async (server: Server) => {
     const currentServer = server.id === selectedServer?.id ? null : server;
-    CredentialsService.setSelectedServer(currentServer);
     const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server: currentServer } };
     dispatchNavigation(action);
   };

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
@@ -11,7 +11,7 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { emptyServer, Server } from "../../models/server";
 import { adminRole, getUserAppRoles, msalEnabled } from "../../msal/MsalAuthProvider";
-import CredentialsService, { AuthorizationState, AuthorizationStatus } from "../../services/credentialsService";
+import AuthorizationService, { AuthorizationState, AuthorizationStatus } from "../../services/credentialsService";
 import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
 import WellService from "../../services/wellService";
@@ -30,7 +30,7 @@ const ServerManager = (): React.ReactElement => {
   const [authorizationState, setAuthorizationState] = useState<AuthorizationState>();
 
   useEffect(() => {
-    const unsubscribeFromCredentialsEvents = CredentialsService.onAuthorizationChangeEvent.subscribe(async (authorizationState) => {
+    const unsubscribeFromCredentialsEvents = AuthorizationService.onAuthorizationChangeEvent.subscribe(async (authorizationState) => {
       setAuthorizationState(authorizationState);
     });
     return () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -66,7 +66,6 @@ export const onClickDeleteObjects = async (dispatchOperation: DispatchOperation,
     objectsOnWellbore.map((item) => item.name),
     orderDeleteJob,
     dispatchOperation,
-    CredentialsService.getCredentials()[0].server.name,
     objectsOnWellbore[0].wellboreName
   );
 };
@@ -86,7 +85,6 @@ export const onClickDeleteComponents = async (dispatchOperation: DispatchOperati
     componentReferences.componentUids,
     orderDeleteJob,
     dispatchOperation,
-    CredentialsService.getCredentials()[0].server.name,
     componentReferences.parent.wellboreName,
     componentReferences.parent.name,
     getParentType(componentReferences.componentType)
@@ -98,7 +96,6 @@ const displayDeleteModal = (
   toDeleteNames: string[],
   onDelete: () => void,
   dispatchOperation: DispatchOperation,
-  server: string,
   wellbore: string,
   parent?: string,
   parentType?: string
@@ -108,7 +105,7 @@ const displayDeleteModal = (
       heading={`Delete ${toDeleteTypeName}?`}
       content={
         <Layout>
-          <TextField readOnly id="server" label="Server" defaultValue={server} tabIndex={-1} />
+          <TextField readOnly id="server" label="Server" defaultValue={CredentialsService.selectedServer?.name} tabIndex={-1} />
           <TextField readOnly id="wellbore" label="Wellbore" defaultValue={wellbore} tabIndex={-1} />
           {parent != null && <TextField readOnly id="parent_object" label={parentType} defaultValue={parent} tabIndex={-1} />}
           <span>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -9,7 +9,7 @@ import ObjectOnWellbore, { toObjectReferences } from "../../models/objectOnWellb
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
-import CredentialsService from "../../services/credentialsService";
+import AuthorizationService from "../../services/credentialsService";
 import JobService, { JobType } from "../../services/jobService";
 import Icon from "../../styles/Icons";
 import ConfirmModal from "../Modals/ConfirmModal";
@@ -105,7 +105,7 @@ const displayDeleteModal = (
       heading={`Delete ${toDeleteTypeName}?`}
       content={
         <Layout>
-          <TextField readOnly id="server" label="Server" defaultValue={CredentialsService.selectedServer?.name} tabIndex={-1} />
+          <TextField readOnly id="server" label="Server" defaultValue={AuthorizationService.selectedServer?.name} tabIndex={-1} />
           <TextField readOnly id="wellbore" label="Wellbore" defaultValue={wellbore} tabIndex={-1} />
           {parent != null && <TextField readOnly id="parent_object" label={parentType} defaultValue={parent} tabIndex={-1} />}
           <span>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
@@ -10,7 +10,7 @@ import LogObject from "../../models/logObject";
 import { toObjectReference } from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
-import CredentialsService, { BasicServerCredentials } from "../../services/credentialsService";
+import CredentialsService from "../../services/credentialsService";
 import JobService, { JobType } from "../../services/jobService";
 import LogObjectService from "../../services/logObjectService";
 import { LogCurveInfoRow } from "../ContentViews/LogCurveInfoListView";
@@ -33,23 +33,21 @@ export const onClickCopyCurveToServer = async (props: OnClickCopyCurveToServerPr
   const wellboreUid = curvesToCopy[0].wellboreUid;
   const logUid = curvesToCopy[0].logUid;
 
-  const targetCredentials = CredentialsService.getCredentialsForServer(targetServer);
-  const sourceCredentials = CredentialsService.getCredentialsForServer(sourceServer);
-  const targetLog = await LogObjectService.getLogFromServer(wellUid, wellboreUid, logUid, targetCredentials);
+  const targetLog = await LogObjectService.getLogFromServer(wellUid, wellboreUid, logUid, targetServer);
   if (targetLog.uid !== logUid) {
     displayMissingObjectModal(targetServer, wellUid, wellboreUid, logUid, dispatchOperation, "No curves will be copied.", ObjectType.Log);
     return;
   }
 
-  const allCurves = await LogObjectService.getLogCurveInfoFromServer(wellUid, wellboreUid, targetLog.uid, targetCredentials);
+  const allCurves = await LogObjectService.getLogCurveInfoFromServer(wellUid, wellboreUid, targetLog.uid, sourceServer);
   const existingCurves: LogCurveInfo[] = allCurves.filter((curve) => curvesToCopy.find((curveToCopy) => curveToCopy.uid === curve.uid));
   if (existingCurves.length > 0) {
-    const onConfirm = () => replaceCurves(sourceServer, [targetCredentials, sourceCredentials], curvesToCopy, existingCurves, dispatchOperation, targetLog, sourceLog);
+    const onConfirm = () => replaceCurves(targetServer, sourceServer, curvesToCopy, existingCurves, dispatchOperation, targetLog, sourceLog);
     displayReplaceModal(existingCurves, curvesToCopy, "curve", "log", dispatchOperation, onConfirm, printCurveInfo);
   } else {
     const copyJob = createCopyJob(sourceServer, curvesToCopy, targetLog, sourceLog);
     CredentialsService.setSourceServer(sourceServer);
-    JobService.orderJobAtServer(JobType.CopyLogData, copyJob, [targetCredentials, sourceCredentials]);
+    JobService.orderJobAtServer(JobType.CopyLogData, copyJob, targetServer, sourceServer);
   }
 };
 
@@ -66,8 +64,8 @@ const createCopyJob = (sourceServer: Server, curves: LogCurveInfoRow[], targetLo
 };
 
 const replaceCurves = async (
+  targetServer: Server,
   sourceServer: Server,
-  credentials: BasicServerCredentials[],
   curvesToCopy: LogCurveInfoRow[],
   curvesToDelete: LogCurveInfo[],
   dispatchOperation: DispatchOperation,
@@ -84,7 +82,7 @@ const replaceCurves = async (
   };
   const copyJob: CopyComponentsJob = createCopyJob(sourceServer, curvesToCopy, targetLog, sourceLog);
   const replaceJob: ReplaceLogDataJob = { deleteJob, copyJob };
-  await JobService.orderJobAtServer(JobType.ReplaceLogData, replaceJob, credentials);
+  await JobService.orderJobAtServer(JobType.ReplaceLogData, replaceJob, targetServer, sourceServer);
   dispatchOperation({ type: OperationType.HideContextMenu });
 };
 

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
@@ -10,7 +10,7 @@ import LogObject from "../../models/logObject";
 import { toObjectReference } from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
-import CredentialsService from "../../services/credentialsService";
+import AuthorizationService from "../../services/credentialsService";
 import JobService, { JobType } from "../../services/jobService";
 import LogObjectService from "../../services/logObjectService";
 import { LogCurveInfoRow } from "../ContentViews/LogCurveInfoListView";
@@ -46,7 +46,7 @@ export const onClickCopyCurveToServer = async (props: OnClickCopyCurveToServerPr
     displayReplaceModal(existingCurves, curvesToCopy, "curve", "log", dispatchOperation, onConfirm, printCurveInfo);
   } else {
     const copyJob = createCopyJob(sourceServer, curvesToCopy, targetLog, sourceLog);
-    CredentialsService.setSourceServer(sourceServer);
+    AuthorizationService.setSourceServer(sourceServer);
     JobService.orderJobAtServer(JobType.CopyLogData, copyJob, targetServer, sourceServer);
   }
 };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyLogToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyLogToServer.tsx
@@ -9,7 +9,7 @@ import { toObjectReferences } from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
-import CredentialsService from "../../services/credentialsService";
+import AuthorizationService from "../../services/credentialsService";
 import JobService, { JobType } from "../../services/jobService";
 import LogObjectService from "../../services/logObjectService";
 import WellboreService from "../../services/wellboreService";
@@ -41,7 +41,7 @@ export const onClickCopyLogToServer = async (targetServer: Server, sourceServer:
     displayReplaceModal(existingLogs, logsToCopy, "log", "wellbore", dispatchOperation, onConfirm, printLog);
   } else {
     const copyJob = createCopyJob(sourceServer, logsToCopy, wellbore);
-    CredentialsService.setSourceServer(sourceServer);
+    AuthorizationService.setSourceServer(sourceServer);
     JobService.orderJobAtServer(JobType.CopyLog, copyJob, targetServer, sourceServer);
   }
 };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
@@ -9,14 +9,14 @@ import ObjectOnWellbore, { toObjectReference, toObjectReferences } from "../../m
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
-import CredentialsService from "../../services/credentialsService";
+import AuthorizationService from "../../services/credentialsService";
 import JobService, { JobType } from "../../services/jobService";
 import { DispatchOperation } from "./ContextMenuUtils";
 
-export const onClickPaste = async (servers: Server[], sourceServerUrl: string, dispatchOperation: DispatchOperation, orderCopyJob: () => void) => {
+export const onClickPaste = async (servers: Server[], sourceServerUrl: string, orderCopyJob: () => void) => {
   const sourceServer = servers.find((server) => server.url === sourceServerUrl);
   if (sourceServer !== null) {
-    CredentialsService.setSourceServer(sourceServer);
+    AuthorizationService.setSourceServer(sourceServer);
     orderCopyJob();
   }
 };
@@ -34,7 +34,7 @@ export const pasteObjectOnWellbore = async (servers: Server[], objectReferences:
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
 
-  onClickPaste(servers, objectReferences?.serverUrl, dispatchOperation, orderCopyJob);
+  onClickPaste(servers, objectReferences?.serverUrl, orderCopyJob);
 };
 
 export const pasteComponents = async (
@@ -51,7 +51,7 @@ export const pasteComponents = async (
     dispatchOperation({ type: OperationType.HideContextMenu });
   };
 
-  onClickPaste(servers, sourceReferences?.serverUrl, dispatchOperation, orderCopyJob);
+  onClickPaste(servers, sourceReferences?.serverUrl, orderCopyJob);
 };
 
 export const copyObjectOnWellbore = async (selectedServer: Server, objectsOnWellbore: ObjectOnWellbore[], dispatchOperation: DispatchOperation, objectType: ObjectType) => {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
@@ -7,7 +7,6 @@ import LogCurveInfo from "../../models/logCurveInfo";
 import LogObject from "../../models/logObject";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
-import CredentialsService from "../../services/credentialsService";
 import LogObjectService from "../../services/logObjectService";
 import SortableEdsTable, { Column } from "../ContentViews/table/SortableEdsTable";
 import { DispatchOperation } from "../ContextMenus/ContextMenuUtils";
@@ -41,9 +40,8 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
       const wellUid = sourceLog.wellUid;
       const wellboreUid = sourceLog.wellboreUid;
       const fetchCurves = async () => {
-        const targetCredentials = CredentialsService.getCredentialsForServer(targetServer);
         const fetchSource = LogObjectService.getLogCurveInfo(wellUid, wellboreUid, sourceLog.uid);
-        const fetchTarget = LogObjectService.getLogCurveInfoFromServer(wellUid, wellboreUid, sourceLog.uid, targetCredentials);
+        const fetchTarget = LogObjectService.getLogCurveInfoFromServer(wellUid, wellboreUid, sourceLog.uid, targetServer);
         return {
           sourceLogCurveInfo: await fetchSource,
           targetLogCurveInfo: await fetchTarget

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MessageComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MessageComparisonModal.tsx
@@ -6,7 +6,6 @@ import OperationType from "../../contexts/operationType";
 import MessageObject from "../../models/messageObject";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
-import CredentialsService from "../../services/credentialsService";
 import MessageObjectService from "../../services/messageObjectService";
 import SortableEdsTable, { Column } from "../ContentViews/table/SortableEdsTable";
 import { DispatchOperation } from "../ContextMenus/ContextMenuUtils";
@@ -36,8 +35,7 @@ const MessageComparisonModal = (props: MessageComparisonModalProps): React.React
     const fetchTarget = async () => {
       const wellUid = sourceMessage.wellUid;
       const wellboreUid = sourceMessage.wellboreUid;
-      const targetCredentials = CredentialsService.getCredentialsForServer(targetServer);
-      const target = await MessageObjectService.getMessageFromServer(wellUid, wellboreUid, sourceMessage.uid, targetCredentials);
+      const target = await MessageObjectService.getMessageFromServer(wellUid, wellboreUid, sourceMessage.uid, targetServer);
       if (target == null) {
         dispatchOperation({ type: OperationType.HideModal });
         const failureMessageTarget = `Unable to compare the message as either the message with UID ${sourceMessage.uid} does not exist on the target server or it was not possible to fetch the message.`;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -12,7 +12,7 @@ import OperationContext from "../../contexts/operationContext";
 import { DisplayModalAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
-import CredentialsService, { BasicServerCredentials } from "../../services/credentialsService";
+import { BasicServerCredentials } from "../../services/credentialsService";
 import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
 import { colors } from "../../styles/Colors";
@@ -196,7 +196,6 @@ export const showDeleteServerModal = (
       if (server.id === selectedServer?.id) {
         const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server: null } };
         dispatchNavigation(action);
-        CredentialsService.setSelectedServer(null);
       }
     } catch (error) {
       NotificationService.Instance.alertDispatcher.dispatch({

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -43,15 +43,24 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
     const abortController = new AbortController();
 
     setIsLoading(true);
-    if (isAddingNewServer) {
-      const freshServer = await ServerService.addServer(server, abortController.signal);
-      dispatchNavigation({ type: ModificationType.AddServer, payload: { server: freshServer } });
-    } else {
-      const freshServer = await ServerService.updateServer(server, abortController.signal);
-      dispatchNavigation({ type: ModificationType.UpdateServer, payload: { server: freshServer } });
+    try {
+      if (isAddingNewServer) {
+        const freshServer = await ServerService.addServer(server, abortController.signal);
+        dispatchNavigation({ type: ModificationType.AddServer, payload: { server: freshServer } });
+      } else {
+        const freshServer = await ServerService.updateServer(server, abortController.signal);
+        dispatchNavigation({ type: ModificationType.UpdateServer, payload: { server: freshServer } });
+      }
+    } catch (error) {
+      NotificationService.Instance.alertDispatcher.dispatch({
+        serverUrl: null,
+        message: error.message,
+        isSuccess: false
+      });
+    } finally {
+      setIsLoading(false);
+      dispatchOperation({ type: OperationType.HideModal });
     }
-    setIsLoading(false);
-    dispatchOperation({ type: OperationType.HideModal });
   };
 
   const showCredentialsModal = () => {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, TextField, Typography } from "@equinor/eds-core-react";
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
@@ -9,7 +10,7 @@ import { validText } from "./ModalParts";
 
 export interface UserCredentialsModalProps {
   server: Server;
-  serverCredentials: BasicServerCredentials;
+  serverCredentials?: BasicServerCredentials;
   mode: CredentialsMode;
   errorMessage?: string;
   onConnectionVerified?: (credentials?: BasicServerCredentials) => void;
@@ -25,6 +26,7 @@ export enum CredentialsMode {
 const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElement => {
   const { mode, server, serverCredentials, confirmText } = props;
   const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchNavigation } = useContext(NavigationContext);
   const [username, setUsername] = useState<string>();
   const [password, setPassword] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
@@ -56,7 +58,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
     };
     try {
       await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
-      CredentialsService.saveCredentials({ ...credentials, password: "" });
+      CredentialsService.onAuthorized(server, username, dispatchNavigation);
     } catch (error) {
       setErrorMessage(error.message);
       setIsLoading(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -4,7 +4,7 @@ import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
-import CredentialsService, { AuthorizationStatus, BasicServerCredentials } from "../../services/credentialsService";
+import AuthorizationService, { AuthorizationStatus, BasicServerCredentials } from "../../services/credentialsService";
 import ModalDialog, { ModalWidth } from "./ModalDialog";
 import { validText } from "./ModalParts";
 
@@ -32,7 +32,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
   const shouldFocusPasswordInput = !!username;
-  const [keepLoggedIn, setKeepLoggedIn] = useState<boolean>(CredentialsService.getKeepLoggedInToServer(server.url));
+  const [keepLoggedIn, setKeepLoggedIn] = useState<boolean>(AuthorizationService.getKeepLoggedInToServer(server.url));
 
   useEffect(() => {
     if (serverCredentials) {
@@ -57,8 +57,8 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       password
     };
     try {
-      await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
-      CredentialsService.onAuthorized(server, username, dispatchNavigation);
+      await AuthorizationService.verifyCredentials(credentials, keepLoggedIn);
+      AuthorizationService.onAuthorized(server, username, dispatchNavigation);
     } catch (error) {
       setErrorMessage(error.message);
       setIsLoading(false);
@@ -74,7 +74,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       password
     };
     try {
-      await CredentialsService.verifyCredentials(credentials, keepLoggedIn);
+      await AuthorizationService.verifyCredentials(credentials, keepLoggedIn);
       props.onConnectionVerified({ ...credentials, password: "" });
     } catch (error) {
       setErrorMessage(error.message);
@@ -123,7 +123,7 @@ const UserCredentialsModal = (props: UserCredentialsModalProps): React.ReactElem
       confirmText={confirmText ?? mode === CredentialsMode.SAVE ? "Login" : "Test"}
       onSubmit={mode === CredentialsMode.SAVE ? onSave : onVerifyConnection}
       onCancel={() => {
-        CredentialsService.onAuthorizationChangeDispatch({ server, status: AuthorizationStatus.Cancel });
+        AuthorizationService.onAuthorizationChangeDispatch({ server, status: AuthorizationStatus.Cancel });
         dispatchOperation({ type: OperationType.HideModal });
         if (props.onCancel) {
           props.onCancel();

--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -34,7 +34,6 @@ import Wellbore, {
 } from "../models/wellbore";
 import { truncateAbortHandler } from "../services/apiClient";
 import BhaRunService from "../services/bhaRunService";
-import CredentialsService from "../services/credentialsService";
 import LogObjectService from "../services/logObjectService";
 import MessageObjectService from "../services/messageObjectService";
 import RigService from "../services/rigService";
@@ -112,7 +111,6 @@ const Routing = (): React.ReactElement => {
       if (server && !selectedServer) {
         const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server } };
         dispatchNavigation(action);
-        CredentialsService.setSelectedServer(server);
       }
     }
   }, [servers, urlParams]);

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/AuthorizationManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/AuthorizationManager.tsx
@@ -3,7 +3,7 @@ import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
-import CredentialsService, { AuthorizationState, AuthorizationStatus } from "../../services/credentialsService";
+import AuthorizationService, { AuthorizationState, AuthorizationStatus } from "../../services/credentialsService";
 import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
 
 const AuthorizationManager = (): React.ReactElement => {
@@ -11,12 +11,12 @@ const AuthorizationManager = (): React.ReactElement => {
   const { dispatchNavigation } = useContext(NavigationContext);
 
   useEffect(() => {
-    const unsubscribe = CredentialsService.onAuthorizationChangeEvent.subscribe(async (authorizationState: AuthorizationState) => {
-      if (authorizationState.status == AuthorizationStatus.Unauthorized && !CredentialsService.serverIsAwaitingAuthorization(authorizationState.server)) {
+    const unsubscribe = AuthorizationService.onAuthorizationChangeEvent.subscribe(async (authorizationState: AuthorizationState) => {
+      if (authorizationState.status == AuthorizationStatus.Unauthorized && !AuthorizationService.serverIsAwaitingAuthorization(authorizationState.server)) {
         showCredentialsModal(authorizationState.server);
-        CredentialsService.awaitServerAuthorization(authorizationState.server);
+        AuthorizationService.awaitServerAuthorization(authorizationState.server);
       } else if (authorizationState.status == AuthorizationStatus.Authorized || authorizationState.status == AuthorizationStatus.Cancel) {
-        CredentialsService.finishServerAuthorization(authorizationState.server);
+        AuthorizationService.finishServerAuthorization(authorizationState.server);
       }
     });
     return () => {
@@ -31,7 +31,7 @@ const AuthorizationManager = (): React.ReactElement => {
       confirmText: "Login",
       onConnectionVerified: (credentials) => {
         dispatchOperation({ type: OperationType.HideModal });
-        CredentialsService.onAuthorized(server, credentials.username, dispatchNavigation);
+        AuthorizationService.onAuthorized(server, credentials.username, dispatchNavigation);
       },
       errorMessage
     };

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/AuthorizationManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/AuthorizationManager.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect } from "react";
+import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
@@ -7,6 +8,7 @@ import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from
 
 const AuthorizationManager = (): React.ReactElement => {
   const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchNavigation } = useContext(NavigationContext);
 
   useEffect(() => {
     const unsubscribe = CredentialsService.onAuthorizationChangeEvent.subscribe(async (authorizationState: AuthorizationState) => {
@@ -23,15 +25,13 @@ const AuthorizationManager = (): React.ReactElement => {
   }, []);
 
   const showCredentialsModal = (server: Server, errorMessage = "") => {
-    const currentCredentials = CredentialsService.getCredentialsForServer(server);
     const userCredentialsModalProps: UserCredentialsModalProps = {
       server: server,
-      serverCredentials: currentCredentials,
       mode: CredentialsMode.TEST,
       confirmText: "Login",
       onConnectionVerified: (credentials) => {
         dispatchOperation({ type: OperationType.HideModal });
-        CredentialsService.saveCredentials({ ...credentials, password: "" });
+        CredentialsService.onAuthorized(server, credentials.username, dispatchNavigation);
       },
       errorMessage
     };

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -7,7 +7,7 @@ import OperationContext from "../contexts/operationContext";
 import { TimeZone, UserTheme } from "../contexts/operationStateReducer";
 import OperationType from "../contexts/operationType";
 import { getAccountInfo, msalEnabled, signOut } from "../msal/MsalAuthProvider";
-import CredentialsService from "../services/credentialsService";
+import AuthorizationService from "../services/credentialsService";
 import Icon from "../styles/Icons";
 import ContextMenu from "./ContextMenus/ContextMenu";
 import { getOffsetFromTimeZone } from "./DateFormatter";
@@ -92,7 +92,7 @@ const TopRightCornerMenu = (): React.ReactElement => {
           key={"signout"}
           onClick={() => {
             const logout = async () => {
-              await CredentialsService.deauthorize();
+              await AuthorizationService.deauthorize();
               signOut();
             };
             logout();

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
@@ -4,7 +4,7 @@ import Well from "../../models/well";
 import Wellbore, { calculateTrajectoryGroupId } from "../../models/wellbore";
 import { RemoveWellAction, RemoveWellboreAction, RemoveWitsmlServerAction } from "../modificationActions";
 import ModificationType from "../modificationType";
-import { EMPTY_NAVIGATION_STATE, NavigationState, Selectable, listWellsFlag } from "../navigationContext";
+import { EMPTY_NAVIGATION_STATE, NavigationState, Selectable } from "../navigationContext";
 import { reducer } from "../navigationStateReducer";
 import { getInitialState, LOG_1, SERVER_1, TRAJECTORY_1, TRAJECTORY_GROUP_1, WELLBORE_1, WELLBORE_2, WELLS, WELL_1, WELL_2, WELL_3 } from "../stateReducerTestUtils";
 
@@ -265,8 +265,7 @@ it("Should update wells", () => {
   const expectedState = {
     ...getInitialState(),
     wells: newWells,
-    filteredWells: newWells,
-    currentSelected: listWellsFlag
+    filteredWells: newWells
   };
   expect(afterUpdateWells).toStrictEqual(expectedState);
 });

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -20,7 +20,7 @@ import Wellbore, {
 import { EMPTY_FILTER } from "../filter";
 import { sortList } from "../modificationStateReducer";
 import { SelectServerAction, ToggleTreeNodeAction } from "../navigationActions";
-import { EMPTY_NAVIGATION_STATE, NavigationState, selectedServerManagerFlag } from "../navigationContext";
+import { EMPTY_NAVIGATION_STATE, NavigationState } from "../navigationContext";
 import { reducer } from "../navigationStateReducer";
 import NavigationType from "../navigationType";
 import {
@@ -75,7 +75,7 @@ it("Should update state when selecting another server", () => {
   expect(actual).toStrictEqual({
     ...initialState,
     selectedServer: SERVER_2,
-    currentSelected: selectedServerManagerFlag,
+    currentSelected: SERVER_2,
     wells: [],
     filteredWells: []
   });

--- a/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
@@ -8,6 +8,7 @@ import Trajectory from "../models/trajectory";
 import WbGeometryObject from "../models/wbGeometry";
 import Well from "../models/well";
 import Wellbore, { calculateLogTypeId, calculateTrajectoryGroupId, calculateTubularGroupId } from "../models/wellbore";
+import CredentialsService from "../services/credentialsService";
 import { filterWells } from "./filter";
 import {
   AddServerAction,
@@ -120,6 +121,12 @@ const updateServer = (state: NavigationState, { payload }: UpdateServerAction) =
   const { server } = payload;
   const index = state.servers.findIndex((s) => s.id === server.id);
   state.servers.splice(index, 1, server);
+  if (CredentialsService.selectedServer?.id == server.id) {
+    CredentialsService.setSelectedServer(server);
+  }
+  if (CredentialsService.getSourceServer()?.id == server.id) {
+    CredentialsService.setSourceServer(server);
+  }
   return {
     ...state,
     servers: [...state.servers],

--- a/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
@@ -8,7 +8,7 @@ import Trajectory from "../models/trajectory";
 import WbGeometryObject from "../models/wbGeometry";
 import Well from "../models/well";
 import Wellbore, { calculateLogTypeId, calculateTrajectoryGroupId, calculateTubularGroupId } from "../models/wellbore";
-import CredentialsService from "../services/credentialsService";
+import AuthorizationService from "../services/credentialsService";
 import { filterWells } from "./filter";
 import {
   AddServerAction,
@@ -38,7 +38,7 @@ import {
 } from "./modificationActions";
 import ModificationType from "./modificationType";
 import { Action } from "./navigationActions";
-import { allDeselected, listWellsFlag, NavigationState } from "./navigationContext";
+import { allDeselected, NavigationState } from "./navigationContext";
 
 export const performModificationAction = (state: NavigationState, action: Action) => {
   switch (action.type) {
@@ -121,11 +121,11 @@ const updateServer = (state: NavigationState, { payload }: UpdateServerAction) =
   const { server } = payload;
   const index = state.servers.findIndex((s) => s.id === server.id);
   state.servers.splice(index, 1, server);
-  if (CredentialsService.selectedServer?.id == server.id) {
-    CredentialsService.setSelectedServer(server);
+  if (AuthorizationService.selectedServer?.id == server.id) {
+    AuthorizationService.setSelectedServer(server);
   }
-  if (CredentialsService.getSourceServer()?.id == server.id) {
-    CredentialsService.setSourceServer(server);
+  if (AuthorizationService.sourceServer?.id == server.id) {
+    AuthorizationService.setSourceServer(server);
   }
   return {
     ...state,
@@ -533,7 +533,6 @@ const updateWells = (state: NavigationState, { payload }: UpdateWellsAction) => 
   return {
     ...state,
     wells: wells,
-    filteredWells: filterWells(wells, state.selectedFilter),
-    currentSelected: listWellsFlag
+    filteredWells: filterWells(wells, state.selectedFilter)
   };
 };

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationContext.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationContext.ts
@@ -26,7 +26,6 @@ export type Selectable = Server | Well | Wellbore | string | BhaRun | LogObject 
 
 export const selectedJobsFlag = "jobs";
 export const selectedServerManagerFlag = "serverManager";
-export const listWellsFlag = "listWells";
 
 export interface NavigationState {
   selectedServer: Server;

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -15,7 +15,7 @@ import {
   calculateWellboreNodeId,
   getWellboreProperties
 } from "../models/wellbore";
-import CredentialsService from "../services/credentialsService";
+import AuthorizationService from "../services/credentialsService";
 import { filterWells } from "./filter";
 import { performModificationAction } from "./modificationStateReducer";
 import ModificationType from "./modificationType";
@@ -119,15 +119,16 @@ const selectToggleTreeNode = (state: NavigationState, { payload }: ToggleTreeNod
 
 const selectServer = (state: NavigationState, { payload }: SelectServerAction) => {
   const { server } = payload;
+  const alreadySelected = server != null && server.id === state.selectedServer?.id;
   const expandedTreeNodes: string[] = [];
-  CredentialsService.setSelectedServer(server);
+  AuthorizationService.setSelectedServer(server);
   return {
     ...state,
     ...allDeselected,
     currentSelected: server ?? selectedServerManagerFlag,
     selectedServer: server,
-    wells: server ? state.wells : [],
-    filteredWells: server ? state.filteredWells : [],
+    wells: alreadySelected ? state.wells : [],
+    filteredWells: alreadySelected ? state.filteredWells : [],
     expandedTreeNodes
   };
 };

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -15,6 +15,7 @@ import {
   calculateWellboreNodeId,
   getWellboreProperties
 } from "../models/wellbore";
+import CredentialsService from "../services/credentialsService";
 import { filterWells } from "./filter";
 import { performModificationAction } from "./modificationStateReducer";
 import ModificationType from "./modificationType";
@@ -118,15 +119,15 @@ const selectToggleTreeNode = (state: NavigationState, { payload }: ToggleTreeNod
 
 const selectServer = (state: NavigationState, { payload }: SelectServerAction) => {
   const { server } = payload;
-  const alreadySelected = server != null && server.id === state.selectedServer?.id;
   const expandedTreeNodes: string[] = [];
+  CredentialsService.setSelectedServer(server);
   return {
     ...state,
     ...allDeselected,
-    currentSelected: alreadySelected ? server : selectedServerManagerFlag,
+    currentSelected: server ?? selectedServerManagerFlag,
     selectedServer: server,
-    wells: alreadySelected ? state.wells : [],
-    filteredWells: alreadySelected ? state.filteredWells : [],
+    wells: server ? state.wells : [],
+    filteredWells: server ? state.filteredWells : [],
     expandedTreeNodes
   };
 };

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -1,31 +1,24 @@
+import { Server } from "../models/server";
 import { getAccessToken, msalEnabled } from "../msal/MsalAuthProvider";
 
-import CredentialsService, { AuthorizationStatus, BasicServerCredentials } from "./credentialsService";
+import CredentialsService, { AuthorizationStatus } from "./credentialsService";
 
 export class ApiClient {
-  static async getCommonHeaders(credentials: BasicServerCredentials[], serverOnly: boolean): Promise<HeadersInit> {
+  private static async getCommonHeaders(targetServer: Server = undefined, sourceServer: Server = undefined): Promise<HeadersInit> {
     const authorizationHeader = await this.getAuthorizationHeader();
     return {
       "Content-Type": "application/json",
       ...(authorizationHeader ? { Authorization: authorizationHeader } : {}),
-      "WitsmlTargetServer": this.getServerHeader(credentials[0], serverOnly),
-      "WitsmlSourceServer": this.getServerHeader(credentials[1], serverOnly)
+      "WitsmlTargetServer": this.getServerHeader(targetServer),
+      "WitsmlSourceServer": this.getServerHeader(sourceServer)
     };
   }
 
-  private static getServerHeader(credentials: BasicServerCredentials | undefined, serverOnly: boolean): string {
-    let result = "";
-    if (!credentials) {
-      return result;
-    }
-    if (!serverOnly) {
-      result = btoa(credentials.username + ":" + credentials.password) + "@";
-    }
-    result += credentials.server.url.toString();
-    return result;
+  private static getServerHeader(server: Server | undefined): string {
+    return server?.url == null ? "" : server.url.toString();
   }
 
-  private static async getAuthorizationHeader(): Promise<string | null> {
+  public static async getAuthorizationHeader(): Promise<string | null> {
     if (msalEnabled) {
       const token = await getAccessToken([`${process.env.NEXT_PUBLIC_AZURE_AD_SCOPE_API}`]);
       return `Bearer ${token}`;
@@ -33,80 +26,73 @@ export class ApiClient {
     return null;
   }
 
-  public static async get(
-    pathName: string,
-    abortSignal: AbortSignal | null = null,
-    currentCredentials = CredentialsService.getCredentials(),
-    serverHeaderOnly = true,
-    rerun = true
-  ): Promise<Response> {
+  public static async get(pathName: string, abortSignal: AbortSignal | null = null, server = CredentialsService.selectedServer): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
-      headers: await ApiClient.getCommonHeaders(currentCredentials, serverHeaderOnly),
-      ...{ credentials: "include" }
+      headers: await ApiClient.getCommonHeaders(server),
+      credentials: "include"
     };
 
-    return ApiClient.runHttpRequest(pathName, requestInit, currentCredentials, serverHeaderOnly && rerun);
+    return ApiClient.runHttpRequest(pathName, requestInit, server);
   }
 
   public static async post(
     pathName: string,
     body: string,
     abortSignal: AbortSignal | null = null,
-    currentCredentials: BasicServerCredentials[] = CredentialsService.getCredentials()
+    targetServer = CredentialsService.selectedServer,
+    sourceServer = CredentialsService.getSourceServer()
   ): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
       method: "POST",
       body: body,
-      headers: await ApiClient.getCommonHeaders(currentCredentials, true),
-      ...{ credentials: "include" }
+      headers: await ApiClient.getCommonHeaders(targetServer, sourceServer),
+      credentials: "include"
     };
-    return ApiClient.runHttpRequest(pathName, requestInit, currentCredentials);
+    return ApiClient.runHttpRequest(pathName, requestInit, targetServer, sourceServer);
   }
 
   public static async patch(pathName: string, body: string, abortSignal: AbortSignal | null = null): Promise<Response> {
-    const currentCredentials = CredentialsService.getCredentials();
     const requestInit: RequestInit = {
       signal: abortSignal,
       method: "PATCH",
       body: body,
-      headers: await ApiClient.getCommonHeaders(currentCredentials, true),
-      ...{ credentials: "include" }
+      headers: await ApiClient.getCommonHeaders(),
+      credentials: "include"
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);
   }
 
   public static async delete(pathName: string, abortSignal: AbortSignal | null = null): Promise<Response> {
-    const currentCredentials = CredentialsService.getCredentials();
     const requestInit: RequestInit = {
       signal: abortSignal,
       method: "DELETE",
-      headers: await ApiClient.getCommonHeaders(currentCredentials, true),
-      ...{ credentials: "include" }
+      headers: await ApiClient.getCommonHeaders(),
+      credentials: "include"
     };
 
     return ApiClient.runHttpRequest(pathName, requestInit);
   }
 
-  private static runHttpRequest(pathName: string, requestInit: RequestInit, currentCredentials = CredentialsService.getCredentials(), rerun = true) {
+  public static runHttpRequest(pathName: string, requestInit: RequestInit, targetServer: Server = undefined, sourceServer: Server = undefined, rerun = true) {
     return new Promise<Response>((resolve, reject) => {
       if (!("Authorization" in requestInit.headers)) {
         if (msalEnabled) {
           reject("Not authorized");
         }
       }
-
       const url = new URL(getBasePathName() + pathName, getBaseUrl());
-      this.fetchWithRerun(url, requestInit, currentCredentials, rerun, resolve, reject);
+      this.fetchWithRerun(url, requestInit, targetServer, sourceServer, rerun, resolve, reject);
     });
   }
 
   private static fetchWithRerun(
     url: URL,
     requestInit: RequestInit,
-    currentCredentials: BasicServerCredentials[],
+    targetServer: Server,
+    sourceServer: Server,
     rerun: boolean,
     resolve: (value: Response | PromiseLike<Response>) => void,
     reject: (reason?: any) => void
@@ -114,7 +100,7 @@ export class ApiClient {
     fetch(url.toString(), requestInit)
       .then((response) => {
         if (response.status == 401 && rerun) {
-          this.handleUnauthorized(url, requestInit, currentCredentials, response, resolve, reject);
+          this.handleUnauthorized(url, requestInit, targetServer, sourceServer, response, resolve, reject);
         } else {
           resolve(response);
         }
@@ -130,21 +116,26 @@ export class ApiClient {
   private static async handleUnauthorized(
     url: URL,
     requestInit: RequestInit,
-    currentCredentials: BasicServerCredentials[],
+    targetServer: Server,
+    sourceServer: Server,
     originalResponse: Response,
     resolve: (value: Response | PromiseLike<Response>) => void,
     reject: (reason?: any) => void
   ) {
     const result = await originalResponse.clone().json();
     const server: "Target" | "Source" | undefined = result.server;
-    const serverToAuthorize = server == "Source" ? currentCredentials[1].server : currentCredentials[0].server;
+    const serverToAuthorize = server == "Source" ? sourceServer : targetServer;
+    if (serverToAuthorize == null) {
+      resolve(originalResponse);
+      return;
+    }
     const unsub = CredentialsService.onAuthorizationChangeEvent.subscribe(async (authorizationState) => {
       if (authorizationState.status == AuthorizationStatus.Cancel) {
         unsub();
         resolve(originalResponse);
       } else if (authorizationState.status == AuthorizationStatus.Authorized && authorizationState.server.id == serverToAuthorize.id) {
         unsub();
-        this.fetchWithRerun(url, requestInit, currentCredentials, true, resolve, reject);
+        this.fetchWithRerun(url, requestInit, targetServer, sourceServer, true, resolve, reject);
       }
     });
     CredentialsService.onAuthorizationChangeDispatch({ server: serverToAuthorize, status: AuthorizationStatus.Unauthorized });

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -171,3 +171,15 @@ export function truncateAbortHandler(e: Error): void {
   }
   throw e;
 }
+
+export function throwError(statusCode: number, message: string) {
+  switch (statusCode) {
+    case 401:
+    case 403:
+    case 404:
+    case 500:
+      throw new Error(message);
+    default:
+      throw new Error(`Something unexpected has happened.`);
+  }
+}

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -1,7 +1,7 @@
 import { Server } from "../models/server";
 import { getAccessToken, msalEnabled } from "../msal/MsalAuthProvider";
 
-import CredentialsService, { AuthorizationStatus } from "./credentialsService";
+import AuthorizationService, { AuthorizationStatus } from "./credentialsService";
 
 export class ApiClient {
   private static async getCommonHeaders(targetServer: Server = undefined, sourceServer: Server = undefined): Promise<HeadersInit> {
@@ -26,7 +26,7 @@ export class ApiClient {
     return null;
   }
 
-  public static async get(pathName: string, abortSignal: AbortSignal | null = null, server = CredentialsService.selectedServer): Promise<Response> {
+  public static async get(pathName: string, abortSignal: AbortSignal | null = null, server = AuthorizationService.selectedServer): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
       headers: await ApiClient.getCommonHeaders(server),
@@ -40,8 +40,8 @@ export class ApiClient {
     pathName: string,
     body: string,
     abortSignal: AbortSignal | null = null,
-    targetServer = CredentialsService.selectedServer,
-    sourceServer = CredentialsService.getSourceServer()
+    targetServer = AuthorizationService.selectedServer,
+    sourceServer = AuthorizationService.sourceServer
   ): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
@@ -129,7 +129,7 @@ export class ApiClient {
       resolve(originalResponse);
       return;
     }
-    const unsub = CredentialsService.onAuthorizationChangeEvent.subscribe(async (authorizationState) => {
+    const unsub = AuthorizationService.onAuthorizationChangeEvent.subscribe(async (authorizationState) => {
       if (authorizationState.status == AuthorizationStatus.Cancel) {
         unsub();
         resolve(originalResponse);
@@ -138,7 +138,7 @@ export class ApiClient {
         this.fetchWithRerun(url, requestInit, targetServer, sourceServer, true, resolve, reject);
       }
     });
-    CredentialsService.onAuthorizationChangeDispatch({ server: serverToAuthorize, status: AuthorizationStatus.Unauthorized });
+    AuthorizationService.onAuthorizationChangeDispatch({ server: serverToAuthorize, status: AuthorizationStatus.Unauthorized });
   }
 }
 

--- a/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
@@ -1,0 +1,37 @@
+import { ApiClient } from "./apiClient";
+
+import { BasicServerCredentials } from "./credentialsService";
+
+export class AuthorizationClient {
+  private static async getHeaders(credentials: BasicServerCredentials[], serverOnly: boolean): Promise<HeadersInit> {
+    const authorizationHeader = await ApiClient.getAuthorizationHeader();
+    return {
+      "Content-Type": "application/json",
+      ...(authorizationHeader ? { Authorization: authorizationHeader } : {}),
+      "WitsmlTargetServer": this.getServerHeader(credentials[0], serverOnly),
+      "WitsmlSourceServer": this.getServerHeader(credentials[1], serverOnly)
+    };
+  }
+
+  private static getServerHeader(credentials: BasicServerCredentials | undefined, serverOnly: boolean): string {
+    let result = "";
+    if (!credentials) {
+      return result;
+    }
+    if (!serverOnly) {
+      result = btoa(credentials.username + ":" + credentials.password) + "@";
+    }
+    result += credentials.server.url.toString();
+    return result;
+  }
+
+  public static async get(pathName: string, abortSignal: AbortSignal | null = null, targetCredentials: BasicServerCredentials): Promise<Response> {
+    const requestInit: RequestInit = {
+      signal: abortSignal,
+      headers: await AuthorizationClient.getHeaders([targetCredentials], false),
+      credentials: "include"
+    };
+
+    return ApiClient.runHttpRequest(pathName, requestInit, undefined, undefined, false);
+  }
+}

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -23,11 +23,11 @@ export interface AuthorizationState {
   status: AuthorizationStatus;
 }
 
-class CredentialsService {
-  private static _instance: CredentialsService;
+class AuthorizationService {
+  private static _instance: AuthorizationService;
   private _onAuthorizationChange = new SimpleEventDispatcher<AuthorizationState>();
   private server?: Server;
-  private sourceServer?: Server;
+  private _sourceServer?: Server;
   private serversAwaitingAuthorization: Server[] = [];
 
   public awaitServerAuthorization(server: Server) {
@@ -54,15 +54,15 @@ class CredentialsService {
   }
 
   public setSourceServer(server: Server) {
-    this.sourceServer = server;
+    this._sourceServer = server;
   }
 
-  public getSourceServer(): Server {
-    return { ...this.sourceServer };
+  public get sourceServer(): Server {
+    return { ...this._sourceServer };
   }
 
   public resetSourceServer() {
-    this.sourceServer = null;
+    this._sourceServer = null;
   }
 
   public onAuthorized(server: Server, username: string, dispatchNavigation: (action: UpdateServerAction) => void) {
@@ -96,7 +96,7 @@ class CredentialsService {
     const response = await AuthorizationClient.get(`/api/credentials/authorize?keep=` + keep, abortSignal, credentials);
     if (!response.ok) {
       const { message }: ErrorDetails = await response.json();
-      CredentialsService.throwError(response.status, message);
+      AuthorizationService.throwError(response.status, message);
     }
   }
 
@@ -104,7 +104,7 @@ class CredentialsService {
     const response = await ApiClient.get(`/api/credentials/deauthorize`, abortSignal);
     if (!response.ok) {
       const { message }: ErrorDetails = await response.json();
-      CredentialsService.throwError(response.status, message);
+      AuthorizationService.throwError(response.status, message);
     }
   }
 
@@ -132,4 +132,4 @@ class CredentialsService {
   }
 }
 
-export default CredentialsService.Instance;
+export default AuthorizationService.Instance;

--- a/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/credentialsService.ts
@@ -3,7 +3,7 @@ import { UpdateServerAction } from "../contexts/modificationActions";
 import ModificationType from "../contexts/modificationType";
 import { ErrorDetails } from "../models/errorDetails";
 import { Server } from "../models/server";
-import { ApiClient } from "./apiClient";
+import { ApiClient, throwError } from "./apiClient";
 import { AuthorizationClient } from "./authorizationClient";
 
 export interface BasicServerCredentials {
@@ -96,7 +96,7 @@ class AuthorizationService {
     const response = await AuthorizationClient.get(`/api/credentials/authorize?keep=` + keep, abortSignal, credentials);
     if (!response.ok) {
       const { message }: ErrorDetails = await response.json();
-      AuthorizationService.throwError(response.status, message);
+      throwError(response.status, message);
     }
   }
 
@@ -104,18 +104,7 @@ class AuthorizationService {
     const response = await ApiClient.get(`/api/credentials/deauthorize`, abortSignal);
     if (!response.ok) {
       const { message }: ErrorDetails = await response.json();
-      AuthorizationService.throwError(response.status, message);
-    }
-  }
-
-  private static throwError(statusCode: number, message: string) {
-    switch (statusCode) {
-      case 401:
-      case 404:
-      case 500:
-        throw new Error(message);
-      default:
-        throw new Error(`Something unexpected has happened.`);
+      throwError(response.status, message);
     }
   }
 

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -1,7 +1,7 @@
 import JobInfo from "../models/jobs/jobInfo";
 import { Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import CredentialsService from "./credentialsService";
+import AuthorizationService from "./credentialsService";
 import NotificationService from "./notificationService";
 
 export default class JobService {
@@ -15,8 +15,8 @@ export default class JobService {
     return this.onResponse(jobType, response, targetServer);
   }
 
-  private static async onResponse(jobType: JobType, response: Response, server = CredentialsService.selectedServer): Promise<any> {
-    CredentialsService.resetSourceServer();
+  private static async onResponse(jobType: JobType, response: Response, server = AuthorizationService.selectedServer): Promise<any> {
+    AuthorizationService.resetSourceServer();
     if (response.ok) {
       NotificationService.Instance.snackbarDispatcher.dispatch({
         serverUrl: new URL(server?.url),

--- a/Src/WitsmlExplorer.Frontend/services/logObjectService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/logObjectService.tsx
@@ -4,7 +4,7 @@ import { LogData } from "../models/logData";
 import LogObject, { emptyLogObject } from "../models/logObject";
 import { Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import CredentialsService from "./credentialsService";
+import AuthorizationService from "./credentialsService";
 import NotificationService from "./notificationService";
 
 export default class LogObjectService {
@@ -91,7 +91,7 @@ export default class LogObjectService {
           errorMessage = `Something unexpected has happened.`;
       }
       NotificationService.Instance.alertDispatcher.dispatch({
-        serverUrl: new URL(CredentialsService.selectedServer.url),
+        serverUrl: new URL(AuthorizationService.selectedServer.url),
         message: errorMessage,
         isSuccess: false
       });

--- a/Src/WitsmlExplorer.Frontend/services/logObjectService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/logObjectService.tsx
@@ -2,8 +2,9 @@ import { ErrorDetails } from "../models/errorDetails";
 import LogCurveInfo from "../models/logCurveInfo";
 import { LogData } from "../models/logData";
 import LogObject, { emptyLogObject } from "../models/logObject";
+import { Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import CredentialsService, { BasicServerCredentials } from "./credentialsService";
+import CredentialsService from "./credentialsService";
 import NotificationService from "./notificationService";
 
 export default class LogObjectService {
@@ -25,8 +26,8 @@ export default class LogObjectService {
     }
   }
 
-  public static async getLogFromServer(wellUid: string, wellboreUid: string, logUid: string, credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<LogObject> {
-    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}/logs/${logUid}`, abortSignal, [credentials]);
+  public static async getLogFromServer(wellUid: string, wellboreUid: string, logUid: string, server: Server, abortSignal?: AbortSignal): Promise<LogObject> {
+    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}/logs/${logUid}`, abortSignal, server);
     if (response.ok) {
       // the route returns null if the log was not found so we need to check for it
       const text = await response.text();
@@ -49,14 +50,8 @@ export default class LogObjectService {
     }
   }
 
-  public static async getLogCurveInfoFromServer(
-    wellUid: string,
-    wellboreUid: string,
-    logUid: string,
-    credentials: BasicServerCredentials,
-    abortSignal?: AbortSignal
-  ): Promise<LogCurveInfo[]> {
-    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}/logs/${logUid}/logcurveinfo`, abortSignal, [credentials]);
+  public static async getLogCurveInfoFromServer(wellUid: string, wellboreUid: string, logUid: string, server: Server, abortSignal?: AbortSignal): Promise<LogCurveInfo[]> {
+    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}/logs/${logUid}/logcurveinfo`, abortSignal, server);
     if (response.ok) {
       const text = await response.text();
       if (text.length) {
@@ -96,7 +91,7 @@ export default class LogObjectService {
           errorMessage = `Something unexpected has happened.`;
       }
       NotificationService.Instance.alertDispatcher.dispatch({
-        serverUrl: new URL(CredentialsService.getCredentials()[0].server.url),
+        serverUrl: new URL(CredentialsService.selectedServer.url),
         message: errorMessage,
         isSuccess: false
       });

--- a/Src/WitsmlExplorer.Frontend/services/messageObjectService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/messageObjectService.tsx
@@ -1,6 +1,6 @@
 import MessageObject, { emptyMessageObject } from "../models/messageObject";
+import { Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import { BasicServerCredentials } from "./credentialsService";
 
 export default class MessageObjectService {
   public static async getMessage(wellUid: string, wellboreUid: string, uid: string, abortSignal?: AbortSignal): Promise<MessageObject> {
@@ -21,14 +21,8 @@ export default class MessageObjectService {
     }
   }
 
-  public static async getMessageFromServer(
-    wellUid: string,
-    wellboreUid: string,
-    uid: string,
-    credentials: BasicServerCredentials,
-    abortSignal?: AbortSignal
-  ): Promise<MessageObject> {
-    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}/messages/${uid}`, abortSignal, [credentials]);
+  public static async getMessageFromServer(wellUid: string, wellboreUid: string, uid: string, server: Server, abortSignal?: AbortSignal): Promise<MessageObject> {
+    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}/messages/${uid}`, abortSignal, server);
     if (response.ok) {
       const text = await response.text();
       if (text.length) {

--- a/Src/WitsmlExplorer.Frontend/services/serverService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/serverService.tsx
@@ -1,7 +1,6 @@
 import { ErrorDetails } from "../models/errorDetails";
 import { emptyServer, Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import CredentialsService from "./credentialsService";
 
 export default class ServerService {
   public static async getServers(abortSignal?: AbortSignal): Promise<Server[]> {
@@ -16,9 +15,7 @@ export default class ServerService {
   public static async addServer(server: Server, abortSignal?: AbortSignal): Promise<Server> {
     const response = await ApiClient.post(`/api/witsml-servers`, JSON.stringify(server), abortSignal, undefined);
     if (response.ok) {
-      const result = await response.json();
-      CredentialsService.addServer(result);
-      return result;
+      return await response.json();
     } else {
       return emptyServer();
     }
@@ -27,9 +24,7 @@ export default class ServerService {
   public static async updateServer(server: Server, abortSignal?: AbortSignal): Promise<Server> {
     const response = await ApiClient.patch(`/api/witsml-servers/${server.id}`, JSON.stringify(server), abortSignal);
     if (response.ok) {
-      const result = await response.json();
-      CredentialsService.updateServer(result);
-      return result;
+      return await response.json();
     } else {
       return emptyServer();
     }
@@ -38,7 +33,6 @@ export default class ServerService {
   public static async removeServer(serverUid: string, abortSignal?: AbortSignal): Promise<boolean> {
     const response = await ApiClient.delete(`/api/witsml-servers/${serverUid}`, abortSignal);
     if (response.ok) {
-      CredentialsService.removeServer(serverUid);
       return true;
     } else {
       const { message }: ErrorDetails = await response.json();

--- a/Src/WitsmlExplorer.Frontend/services/serverService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/serverService.tsx
@@ -1,6 +1,6 @@
 import { ErrorDetails } from "../models/errorDetails";
-import { emptyServer, Server } from "../models/server";
-import { ApiClient } from "./apiClient";
+import { Server } from "../models/server";
+import { ApiClient, throwError } from "./apiClient";
 
 export default class ServerService {
   public static async getServers(abortSignal?: AbortSignal): Promise<Server[]> {
@@ -17,7 +17,7 @@ export default class ServerService {
     if (response.ok) {
       return await response.json();
     } else {
-      return emptyServer();
+      throwError(response.status, response.statusText);
     }
   }
 
@@ -26,7 +26,7 @@ export default class ServerService {
     if (response.ok) {
       return await response.json();
     } else {
-      return emptyServer();
+      throwError(response.status, response.statusText);
     }
   }
 
@@ -36,18 +36,7 @@ export default class ServerService {
       return true;
     } else {
       const { message }: ErrorDetails = await response.json();
-      this.throwError(response.status, message);
-    }
-  }
-
-  private static throwError(statusCode: number, message: string) {
-    switch (statusCode) {
-      case 401:
-      case 404:
-      case 500:
-        throw new Error(message);
-      default:
-        throw new Error(`Something unexpected has happened.`);
+      throwError(response.status, message);
     }
   }
 }

--- a/Src/WitsmlExplorer.Frontend/services/wellService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/wellService.tsx
@@ -1,6 +1,6 @@
 import { ErrorDetails } from "../models/errorDetails";
 import Well, { emptyWell } from "../models/well";
-import { ApiClient } from "./apiClient";
+import { ApiClient, throwError } from "./apiClient";
 
 export default class WellService {
   public static async getWells(abortSignal: AbortSignal = null): Promise<Well[]> {
@@ -10,14 +10,7 @@ export default class WellService {
       return response.json();
     } else {
       const { message }: ErrorDetails = await response.json();
-      switch (response.status) {
-        case 401:
-        case 404:
-        case 500:
-          throw new Error(message);
-        default:
-          throw new Error(`Something unexpected has happened.`);
-      }
+      throwError(response.status, message);
     }
   }
 

--- a/Src/WitsmlExplorer.Frontend/services/wellboreService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/wellboreService.tsx
@@ -1,7 +1,7 @@
+import { Server } from "../models/server";
 import Wellbore, { emptyWellbore } from "../models/wellbore";
 import { ApiClient } from "./apiClient";
 import BhaRunService from "./bhaRunService";
-import { BasicServerCredentials } from "./credentialsService";
 import LogObjectService from "./logObjectService";
 import RigService from "./rigService";
 import RiskObjectService from "./riskObjectService";
@@ -19,8 +19,8 @@ export default class WellboreService {
     }
   }
 
-  public static async getWellboreFromServer(wellUid: string, wellboreUid: string, credentials: BasicServerCredentials, abortSignal?: AbortSignal): Promise<Wellbore> {
-    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}`, abortSignal, [credentials]);
+  public static async getWellboreFromServer(wellUid: string, wellboreUid: string, server: Server, abortSignal?: AbortSignal): Promise<Wellbore> {
+    const response = await ApiClient.get(`/api/wells/${wellUid}/wellbores/${wellboreUid}`, abortSignal, server);
     if (response.ok) {
       const text = await response.text();
       if (text.length) {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-744

## Description
Refactor CredentialsService to AuthorizationService due to lack of need to manage credentials as they are saved in the backend now.
Replace most of BasicServerCredentials use with Server, as server information is sufficient.
Extract authorizationClient to signify the difference in fetching the authorize route.
Make selectedServer in AuthorizationService dependent on the NavigationContext to make sure the values match. Now the sole purpose of having selectedServer in AuthorizationService is to avoid property drilling.
Throw error and show notification on failed adding or updating a server.
Remove duplicated throwError code.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
