### PR TITLE
WE-757 Implement user switching

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -18,7 +18,8 @@ This is a description of the flow:
 ### 1. When the user connects to a server for the first time
   - frontend contacts `authorize` endpoint with entered credentials along with server url
   - if this is a new client without any cookie and id, generate an id for this client
-  - backend verifies credentials with the WITSML server, if OK, encrypts credentials, adds them to the cache and generates an unique cacheId based on client-id and server host
+  - backend verifies credentials with the WITSML server
+  - verified credentials are added to a <username, encrypted password> dictionary cached under a unique cacheId based on client-id and server host
   - `TTL` before credentials are invalidated will be given by the query param `keep`
     - keep=true => 24 hours
     - keep=false or missing  => 1 hour
@@ -26,11 +27,15 @@ This is a description of the flow:
   - **session cookie used**
 
 ### 2. Successive connections to API
-  - frontend calls API with `WitsmlTargetServer` and (in copy-jobs) `WitsmlSourceServer` information
+  - frontend calls API with `WitsmlTargetServer` and `WitsmlTargetUsername` headers
+  - API routes that handle two servers include `WitsmlSourceServer` and `WitsmlSourceUsername` headers as well
   - `[secure ,samesite=strict, httponly]` cookie is passed along with the request with id as value
   - backend uses uuid from cookie to lookup encrypted credentials in `CredentialsCache`
-    - if no credentials exists, send response `401` . User will have to login to get a cookie with valid cache entry
+    - if no credentials exists, send response `401`. User will have to login to get a cookie with valid cache entry
+  - given that multiple sets of credentials can be saved in the backend for a given server, it is sufficient to change the `WitsmlTargetUsername` (or Source) header to use a different set of credentials
+    - in the frontend this can be achieved by clicking on the WITSML username in the top right corner menu, or in the server connections tab
   - **session cookie used**
+
 
 ```mermaid
 sequenceDiagram
@@ -46,7 +51,7 @@ sequenceDiagram
     activate Api
     Api->>Api: If valid, encrypt password <br> and store it in memory <br> using DataProtection library
     Api->>Frontend: Return 200 OK + cookie
-    Frontend->>-Api: Fetch wells using cookie <br>fetching encrypted password from cache
+    Frontend->>-Api: Fetch wells using cookie<br>and WITSML username<br>fetching encrypted password from cache
     Api->>-Api: Decrypt password using <br> Data Protection Libary
     activate Api
     Api->>-Frontend: If not able to decrypt, or expired <br> send back unauthorized 401
@@ -68,7 +73,9 @@ User will log in by Equinor tenant.
 
 #### OAuth mode with system credentials access based on app role assignment
   - backend uses claim sub in Bearer token for user-to-app identification
-  - backend fetches credentials from keyvault, encrypts and stores the credentials in the backend cache identified by information in id_token (sub)
+  - when fetching the server list, system credentials usernames are returned if they are available for the given Azure user and WITSML server
+  - system credentials username will appear in a dropdown when attempting to log in to an applicable WITSML server
+  - if the user chooses to use system credentials, the backend fetches the credentials from keyvault, encrypts and stores the credentials in the backend cache identified by information in id_token (sub)
   - **TTL** before credentials are invalidated will be given by the query param `keep`
     - keep=true => 24 hours
     - keep=false or missing  => 1 hour
@@ -79,8 +86,9 @@ User will log in by Equinor tenant.
   - backend uses Bearer token sub for user identification
   - **no cookies involved**
 ### 2. Successive connections to API
-  - frontend calls API with WitsmlTargetServer and (in copy-jobs) WitsmlSourceServer information
-  - backend uses sub from Bearer token to lookup encrypted credentials in CredentialsCache
+  - frontend calls API with `WitsmlTargetServer` and `WitsmlTargetUsername` headers
+  - API routes that handle two servers include `WitsmlSourceServer` and `WitsmlSourceUsername` headers as well
+  - backend uses sub from the Bearer token and the username from the header to look up the encrypted password in CredentialsCache
     - if no credentials exists, send response 401 and display the credentials modal
   - **no cookies involved**
 
@@ -92,7 +100,7 @@ The `WitsmlServerHandler` at `/api/witsml-servers` endpoint can be used to get a
 
 Steps to use endpoints with `Basic` authentication
 1. Authenticate against the WITSML server through the `AuthorizationHandler` endpoint `/api/credentials/authorize`. Url and base64 encoded credentials needs to be provided with the request in the header `WitsmlTargetServer`. 
-2. Now visit any endpoint, e.g. `/api/wells` and provide the same Url in the header `AuthorizationHandler` (now without credentials)
+2. Now visit any endpoint, e.g. `/api/wells` and provide the same Url in the header `WitsmlTargetServer` (now without credentials), as well as the username in the `WitsmlTargetUsername` header
 
 Further information about the header format is given on the swagger page/endpoint. 
 ### OAuth2 authentication
@@ -161,7 +169,7 @@ To use Azure keyvault, create your keyvault (above named `witsmlexp-servers-kv`)
 
 Credentials will be mapped on URL from secrets with the serverlist. `Server` entry in MongoDB or CosmosDB will have property `securityscheme` that can be `Basic` or `OAuth2`
 
-The app role assigned to a server will be compared to the role claims in the JWT provided in the Authorization header. If a user has been assigned the same application role, system credentials will be applied to the connection.
+The app role assigned to a server will be compared to the role claims in the JWT provided in the Authorization header. If a user has been assigned the same application role, system credentials will be made available to the user. An API call will use the system credentials if the system username is set in the `WitsmlTargetUsername` or `WitsmlSourceUsername` header.
 
 For more info on app roles, see: [app roles](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps)
 
@@ -198,11 +206,11 @@ NEXT_PUBLIC_AZURE_AD_SCOPE_API=
 ```
 
 ## Hybrid Flow
-It is now possible to utilize both OAuth2 and Basic authentication security schemes at the same time. With this configuration the end user will have to authenticate against an authorization server that supports `OAuth2 Authorization Code Flow with PKCE`.
+It is possible to utilize both OAuth2 and Basic authentication security schemes at the same time. With this configuration the end user will have to authenticate against an authorization server that supports `OAuth2 Authorization Code Flow with PKCE`.
 
-As described in the serverlist, Witsml-Explorer will choose the correct method to contact the backend, based on how you configure your list of servers. If the Server has securityscheme `OAuth2` and both the server and user have the same `app-roles`, the frontend will use the `Bearer` token received from the authorization server and relay this to the backend along with the url of the server. It will not ask the user for basic credentials (username:password).
+As described in the [Serverlist](#serverlist), Witsml Explorer will make a system user available based on how you configure your list of servers. If the Server has securityscheme `OAuth2` and both the server and the Azure user have the same `app-roles`, the frontend will use the `Bearer` token received from the authorization server and relay this to the backend along with the url of the server. It will not ask the user for basic credentials (username:password) if the system username was specified in the `Witsml(Target/Source)Username` header.
 
-The backend in turn will do a lookup on the users application role, and if eligible, use the `system-user` fetched from `keyvault` for further connections to the WITSML server.
+The backend in turn will do a lookup on the users application role, and if eligible, use the `system-user` fetched from `keyvault` for the connection to the WITSML server.
 
 ### Basic witsmlexplorer flow
 For an illustration of sequences initiated when the user queries a server with property securityscheme set to `Basic`, visit the figure in the beginning of this document under `WITSML server credentials flow`
@@ -218,7 +226,7 @@ graph TD
     B[2. Auth Server] --> |token| A[WitsmlExplorer Frontend]
     A[1. WitsmlExplorer Frontend] --->|w/token:getservers| G[3. ServerlistDB]
     G[3. ServerlistDB] --->|servers| A[itsml-Explorer]
-    A[1. WitsmlExplorer Frontend] ----> |w/token:getwells| H[3. WitsmlExplorer API]
+    A[1. WitsmlExplorer Frontend] ----> |w/token&username:getwells| H[3. WitsmlExplorer API]
     H[3. WitsmlExplorer API] ----> |wells| A[1. WitsmlExplorer Frontend]  
     H[3. WitsmlExplorer API] --> |getsyscreds| K[5. Azure Keyvault]
     K[5. Azure Keyvault] --> |syscreds| H[3. WitsmlExplorer API]
@@ -228,8 +236,8 @@ graph TD
 
 1. End user visits Witsml-Explorer.
 2. The end user will be redirected to login with the configured OAuth2 Authorization server (Azure AD).
-3. Witsml-Explorer will fetch the initial Serverlist from DB. When OAuth2 is enabled both in the frontend and backend, retrieving the serverlist will only be available for logged in users. Similarly Create, Update and Delete will be reserved for users with role `admin`. All servers in the list now include two properties: `securityscheme` and `role`.
-4. If the user through the frontend chooses to query a server with a `securityscheme` set to `OAuth2`, the backend will check the received `Bearer` JWT token for `app-roles`. This in turn will be checked against the configured `roles` for the server.
+3. Witsml-Explorer will fetch the initial Serverlist from DB. When OAuth2 is enabled both in the frontend and backend, retrieving the serverlist will only be available for logged in users. Similarly Create, Update and Delete will be reserved for users with role `admin`. All servers in the list now include two properties: `securityscheme` and `role`. A list of available users will be returned for every server. These are previously logged in users and/or a system user.
+4. If the user through the frontend chooses to query a server with a `securityscheme` set to `OAuth2`, and picks an available system user, the backend will check the received `Bearer` JWT token for `app-roles`. This in turn will be checked against the configured `roles` for the server.
 5. When one of the user roles and server roles overlap, the backend fetches system credentials from `Azure Keyvault` for this witsml server.
 6. The server will now forward the query to the witsml server using `Basic` authorization with system credentials fetched from step 5.
 
@@ -256,7 +264,7 @@ HTTP/1.1 200 OK
 Set-Cookie: witsmlexplorer=9a8c9c5d-1d0c-4ebf-867d-6641962da380; path=/; secure; samesite=strict; httponly
 ```
 
-__2. Authorize WITSML credentials__ for the WITSML server you will query, this to ensure that backend encrypts the password and caches it against your session. 
+__2. Authorize WITSML credentials__ for the WITSML server you will query, this to ensure that backend encrypts the password and caches it against your session. The WitsmlTargetServer consists of base 64 encoded `username:password` (in the following example it is `user123:pass456`), and, after the 'at' sign `@`, the WITSML server URL.
 
 ```http
 GET http://localhost:5000/api/credentials/authorize?keep=false HTTP/1.1
@@ -277,7 +285,7 @@ Access-Control-Allow-Origin: http://localhost:3000
 ```
 
 __3. Use endpoints__  
-Include cookie. If credentials has expired or missing you will get a `401` response and will need to authorize (step 2) again first
+Include cookie. If credentials has expired or missing you will get a `401` response and will need to authorize (step 2) again first. `WitsmlTargetServer` and `WitsmlTargetUsername` have to match the information entered in step 2. to correctly use the cached credentials.
 
 ```http
 GET http://localhost:5000/api/wells HTTP/1.1
@@ -286,6 +294,7 @@ Content-Type: application/json
 Origin: http://localhost:3000
 Cookie: witsmlexplorer=9a8c9c5d-1d0c-4ebf-867d-6641962da380
 WitsmlTargetServer: https://witsmlserver.using.basic.creds/Store/WITSML
+WitsmlTargetUsername: user123
 ```
 ```http
 HTTP/1.1 200 OK
@@ -310,30 +319,33 @@ Transfer-Encoding: chunked
 
 `witsml-explorer` is in `OAuth2` mode. (Started with `OAuth2Enabled=true` in appsettings).
 
+__1. witsml-server configuration list__ (and other endpoints)
+
 No cookie involved. But you will still need to authorize for servers configured as `Basic`.
 
 **Prerequisite**: a valid `Bearer` token with app-roles and server configuration in place.
 
-__1. witsml-server configuration list__ (and other endpoints)
 ```http
 GET https://localhost:5001/api/witsml-servers HTTP/1.1
 Content-Type: application/json
 Authorization: Bearer eyJ...<token here>
 ```
 
+__2. Use endpoints__ 
+
 If a server has system credentials in keyvault and the bearer of the token has the correct `role` for this server, you can use endpoints directly. Example below for rigs
 
-__2. Use endpoints__ 
 ```http
 GET http://localhost:5000/api/wells/<wellId>/wellbores/<wellboreId>/rigs HTTP/1.1
 Authorization: Bearer eyJ...<token here>
 Content-Type: application/json
 WitsmlTargetServer: https://witsmlserver.using.system.creds/store/WITSML
+WitsmlTargetUsername: system-user123
 ```
+__3. Authorize WITSML credentials__ 
 
 If you do not have system credentials in keyvault, and need to use Basic credentials for a server in OAuth2 mode, you must `authorize` first like below before using endpoints with this server.
 
-__3. Authorize WITSML credentials__ 
 ```http
 GET http://localhost:5000/api/credentials/authorize?keep=false HTTP/1.1
 Authorization: Bearer eyJ...<token here>

--- a/Src/WitsmlExplorer.Api/HttpHandlers/EssentialHeaders.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/EssentialHeaders.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Http;
+
 namespace WitsmlExplorer.Api.HttpHandlers
 {
     public interface IEssentialHeaders
@@ -7,6 +8,8 @@ namespace WitsmlExplorer.Api.HttpHandlers
         public string Authorization { get; }
         public string TargetServer { get; }
         public string SourceServer { get; }
+        public string TargetUsername { get; }
+        public string SourceUsername { get; }
         public string GetCookieValue();
         public string GetBearerToken();
 
@@ -17,6 +20,8 @@ namespace WitsmlExplorer.Api.HttpHandlers
         public static readonly string CookieName = "witsmlexplorer";
         public static readonly string WitsmlTargetServer = "WitsmlTargetServer";
         public static readonly string WitsmlSourceServer = "WitsmlSourceServer";
+        public static readonly string WitsmlTargetUsername = "WitsmlTargetUsername";
+        public static readonly string WitsmlSourceUsername = "WitsmlSourceUsername";
 
         public EssentialHeaders() { }
         public EssentialHeaders(HttpRequest httpRequest)
@@ -25,11 +30,15 @@ namespace WitsmlExplorer.Api.HttpHandlers
             Authorization = httpRequest?.Headers["Authorization"];
             TargetServer = httpRequest?.Headers[WitsmlTargetServer];
             SourceServer = httpRequest?.Headers[WitsmlSourceServer];
+            TargetUsername = httpRequest?.Headers[WitsmlTargetUsername];
+            SourceUsername = httpRequest?.Headers[WitsmlSourceUsername];
             WitsmlExplorerCookie = httpRequest?.Cookies[CookieName];
         }
         public string Authorization { get; init; }
         public string TargetServer { get; init; }
         public string SourceServer { get; init; }
+        public string TargetUsername { get; init; }
+        public string SourceUsername { get; init; }
         private string WitsmlExplorerCookie { get; init; }
 
 

--- a/Src/WitsmlExplorer.Api/Models/Connection.cs
+++ b/Src/WitsmlExplorer.Api/Models/Connection.cs
@@ -15,8 +15,8 @@ namespace WitsmlExplorer.Api.Models
             Id = server.Id;
         }
 
-        [JsonPropertyName("username")]
-        public string Username { get; set; }
+        [JsonPropertyName("usernames")]
+        public string[] Usernames { get; set; }
 
         public override string ToString()
         {

--- a/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
@@ -8,8 +8,8 @@ namespace WitsmlExplorer.Api.Services
 
     public interface ICredentialsCache
     {
-        void SetItem(string cacheId, string encryptedCredentials, double ttl);
-        public string GetItem(string cacheId);
+        void SetItem(string cacheId, string encryptedPassword, double ttl, string username);
+        public Dictionary<string, string> GetItem(string cacheId);
         public long Count();
         public void Clear();
         public void RemoveAllClientCredentials(string clientId);
@@ -25,15 +25,28 @@ namespace WitsmlExplorer.Api.Services
             _logger = logger;
         }
 
-        public void SetItem(string cacheId, string encryptedCredentials, double ttl)
+        public void SetItem(string cacheId, string encryptedPassword, double ttl, string username)
         {
             CacheItemPolicy cacheItemPolicy = new() { SlidingExpiration = TimeSpan.FromHours(ttl) };
-            _cache.Set(cacheId, encryptedCredentials, cacheItemPolicy);
+            Dictionary<string, string> item = GetItem(cacheId);
+            if (item == null)
+            {
+                item = new Dictionary<string, string>
+                {
+                    { username, encryptedPassword }
+                };
+            }
+            else
+            {
+                item.Remove(username);
+                item.Add(username, encryptedPassword);
+            }
+            _cache.Set(cacheId, item, cacheItemPolicy);
         }
 
-        public string GetItem(string cacheId)
+        public Dictionary<string, string> GetItem(string cacheId)
         {
-            return _cache.Get(cacheId) as string;
+            return _cache.Get(cacheId) as Dictionary<string, string>;
         }
 
         public long Count()

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -76,9 +76,10 @@ namespace WitsmlExplorer.Api.Services
 
             bool systemCredsExists = _witsmlServerCredentials.WitsmlCreds.Any(n => n.Host == host);
             IEnumerable<Server> hostServer = allServers.Where(n => n.Url.ToString() == host.ToString());
-            bool validRole = hostServer.Any(n => n.Roles.Intersect(roles).Any());
+            bool validRole = hostServer.Any(n =>
+             n.Roles != null && n.Roles.Intersect(roles).Any()
+             );
             result &= systemCredsExists & validRole;
-
             return result;
         }
 

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -3,19 +3,17 @@ using System.Threading.Tasks;
 
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.HttpHandlers;
+using WitsmlExplorer.Api.Middleware;
 
 namespace WitsmlExplorer.Api.Services
 {
     public interface ICredentialsService
     {
-        public Task VerifyCredentials(ServerCredentials serverCreds);
-        public string GetClaimFromToken(IEssentialHeaders headers, string claim);
-        public ServerCredentials GetCredentialsFromCache(bool useOauth, IEssentialHeaders headers, string serverUrl, Func<string, string> delDecrypt = null);
-        public void CacheCredentials(string clientId, ServerCredentials credentials, double ttl, Func<string, string> delEncrypt = null);
         public void RemoveCachedCredentials(string clientId);
-        public void RemoveAllCachedCredentials();
-        public Task<ServerCredentials> GetSystemCredentialsByToken(string token, Uri server);
-        public Task<ServerCredentials> GetCredentialsFromHeaderValue(string headerValue, string token = null);
-        public (ServerCredentials targetServer, ServerCredentials sourceServer) GetWitsmlUsernamesFromCache(IEssentialHeaders headers);
+        public void VerifyUserIsLoggedIn(IEssentialHeaders eh, ServerType serverType);
+        public Task<string[]> GetLoggedInUsernames(bool useOauth, IEssentialHeaders eh, Uri serverUrl);
+        public string GetClaimFromToken(string token, string claim);
+        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool useOauth, bool keep);
+        public ServerCredentials GetCredentials(bool useOauth, IEssentialHeaders eh, string server, string username);
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -67,8 +67,7 @@ namespace WitsmlExplorer.Api.Services
         {
             if (_witsmlClient == null)
             {
-                _targetCreds = _credentialsService.GetCredentialsFromCache(_useOAuth, _httpHeaders, _httpHeaders.TargetServer);
-                _targetCreds ??= _useOAuth ? _credentialsService.GetSystemCredentialsByToken(_httpHeaders.GetBearerToken(), new Uri(_httpHeaders.TargetServer)).Result : null;
+                _targetCreds = _credentialsService.GetCredentials(_useOAuth, _httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
                 _witsmlClient = (_targetCreds != null && !_targetCreds.IsCredsNullOrEmpty())
                     ? new WitsmlClient(_targetCreds.Host.ToString(), _targetCreds.UserId, _targetCreds.Password, _clientCapabilities, null, _logQueries)
                     : null;
@@ -81,8 +80,7 @@ namespace WitsmlExplorer.Api.Services
         {
             if (_witsmlSourceClient == null)
             {
-                _sourceCreds = _credentialsService.GetCredentialsFromCache(_useOAuth, _httpHeaders, _httpHeaders.SourceServer);
-                _sourceCreds ??= _useOAuth ? _credentialsService.GetSystemCredentialsByToken(_httpHeaders.GetBearerToken(), new Uri(_httpHeaders.SourceServer)).Result : null;
+                _sourceCreds = _credentialsService.GetCredentials(_useOAuth, _httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
                 _witsmlSourceClient = (_sourceCreds != null && !_sourceCreds.IsCredsNullOrEmpty())
                     ? new WitsmlClient(_sourceCreds.Host.ToString(), _sourceCreds.UserId, _sourceCreds.Password, _clientCapabilities, null, _logQueries)
                     : null;

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -15,7 +15,7 @@ namespace WitsmlExplorer.Api.Swagger
     {
         private static readonly string AUTHORIZE_DESCRIPTION = """
             Include b64 encoded credentials.
-            Example: 'dXNlcm5hbWU6cHNzd29yZA==@https://witsml-explorer.serverhost.com/Store/WITSML'
+            Example: 'dXNlcm5hbWU6cGFzc3dvcmQ=@https://witsml-explorer.serverhost.com/Store/WITSML'
         """;
 
         private static readonly string SERVER_DESCRIPTION = """

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -14,11 +14,13 @@ namespace WitsmlExplorer.Api.Swagger
     public class WitsmlHeaderFilter : IOperationFilter
     {
         private static readonly string AUTHORIZE_DESCRIPTION = """
-            Include b64 encoded credentials.Example: 'dXNlcm5hbWU6cHNzd29yZA==@https://witsml-explorer.serverhost.com/Store/WITSML'
+            Include b64 encoded credentials.
+            Example: 'dXNlcm5hbWU6cHNzd29yZA==@https://witsml-explorer.serverhost.com/Store/WITSML'
         """;
 
         private static readonly string SERVER_DESCRIPTION = """
-            Only use host url.Example: 'https://witsml-explorer.serverhost.com/Store/WITSML'
+            Only use host url.
+            Example: 'https://witsml-explorer.serverhost.com/Store/WITSML'
         """;
 
         private static readonly string USERNAME_DESCRIPTION = """

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -20,7 +20,7 @@ export const JobsView = (): React.ReactElement => {
     dispatchOperation,
     operationState: { timeZone }
   } = useContext(OperationContext);
-  const { servers } = navigationState;
+  const { servers, selectedServer } = navigationState;
   const [jobInfos, setJobInfos] = useState<JobInfo[]>([]);
   const [shouldRefresh, setShouldRefresh] = useState<boolean>(true);
   const [showAll, setShowAll] = useState(false);
@@ -57,7 +57,7 @@ export const JobsView = (): React.ReactElement => {
 
   useEffect(() => {
     return setShouldRefresh(true);
-  }, [showAll]);
+  }, [showAll, selectedServer]);
 
   useEffect(() => {
     if (shouldRefresh) {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
@@ -11,13 +11,14 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { emptyServer, Server } from "../../models/server";
 import { adminRole, getUserAppRoles, msalEnabled } from "../../msal/MsalAuthProvider";
-import AuthorizationService, { AuthorizationState, AuthorizationStatus } from "../../services/credentialsService";
+import AuthorizationService, { AuthorizationState, AuthorizationStatus } from "../../services/authorizationService";
 import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
 import WellService from "../../services/wellService";
 import { colors } from "../../styles/Colors";
 import Icon from "../../styles/Icons";
 import ServerModal, { showDeleteServerModal } from "../Modals/ServerModal";
+import UserCredentialsModal, { UserCredentialsModalProps } from "../Modals/UserCredentialsModal";
 
 const NEW_SERVER_ID = "1";
 
@@ -81,9 +82,21 @@ const ServerManager = (): React.ReactElement => {
   }, [isAuthenticated, hasFetchedServers]);
 
   const onSelectItem = async (server: Server) => {
-    const currentServer = server.id === selectedServer?.id ? null : server;
-    const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server: currentServer } };
-    dispatchNavigation(action);
+    if (server.id === selectedServer?.id) {
+      const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server: null } };
+      dispatchNavigation(action);
+    } else {
+      const userCredentialsModalProps: UserCredentialsModalProps = {
+        server,
+        onConnectionVerified: (username) => {
+          dispatchOperation({ type: OperationType.HideModal });
+          AuthorizationService.onAuthorized(server, username, dispatchNavigation);
+          const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server } };
+          dispatchNavigation(action);
+        }
+      };
+      dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });
+    }
   };
 
   const onEditItem = (server: Server) => {
@@ -125,7 +138,7 @@ const ServerManager = (): React.ReactElement => {
               <Table.Row id={server.id} key={server.id}>
                 <Table.Cell style={CellHeaderStyle}>{server.name}</Table.Cell>
                 <Table.Cell style={CellHeaderStyle}>{server.url}</Table.Cell>
-                <Table.Cell style={CellHeaderStyle}>{server.username}</Table.Cell>
+                <Table.Cell style={CellHeaderStyle}>{server.currentUsername == null ? "" : server.currentUsername}</Table.Cell>
                 <Table.Cell style={{ textAlign: "center" }}>
                   <Icon color={selectedServer?.id == server.id && wells.length ? colors.interactive.successResting : colors.text.staticIconsTertiary} name="cloudDownload" />
                 </Table.Cell>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuUtils.tsx
@@ -9,7 +9,7 @@ import ObjectOnWellbore, { toObjectReferences } from "../../models/objectOnWellb
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
-import AuthorizationService from "../../services/credentialsService";
+import AuthorizationService from "../../services/authorizationService";
 import JobService, { JobType } from "../../services/jobService";
 import Icon from "../../styles/Icons";
 import ConfirmModal from "../Modals/ConfirmModal";

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyCurveToServer.tsx
@@ -10,7 +10,7 @@ import LogObject from "../../models/logObject";
 import { toObjectReference } from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
-import AuthorizationService from "../../services/credentialsService";
+import AuthorizationService from "../../services/authorizationService";
 import JobService, { JobType } from "../../services/jobService";
 import LogObjectService from "../../services/logObjectService";
 import { LogCurveInfoRow } from "../ContentViews/LogCurveInfoListView";

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyLogToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyLogToServer.tsx
@@ -9,7 +9,7 @@ import { toObjectReferences } from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
-import AuthorizationService from "../../services/credentialsService";
+import AuthorizationService from "../../services/authorizationService";
 import JobService, { JobType } from "../../services/jobService";
 import LogObjectService from "../../services/logObjectService";
 import WellboreService from "../../services/wellboreService";

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyUtils.tsx
@@ -9,7 +9,7 @@ import ObjectOnWellbore, { toObjectReference, toObjectReferences } from "../../m
 import { ObjectType } from "../../models/objectType";
 import { Server } from "../../models/server";
 import Wellbore from "../../models/wellbore";
-import AuthorizationService from "../../services/credentialsService";
+import AuthorizationService from "../../services/authorizationService";
 import JobService, { JobType } from "../../services/jobService";
 import { DispatchOperation } from "./ContextMenuUtils";
 

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
@@ -93,7 +93,7 @@ const LogComparisonModal = (props: LogComparisonModalProps): React.ReactElement 
 
   const toFixed = (value: string | number): string => {
     const number = Number(value);
-    if (isNaN(number)) {
+    if (Number.isNaN(number)) {
       return missingIndex;
     }
     return number.toFixed(4);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -12,12 +12,11 @@ import OperationContext from "../../contexts/operationContext";
 import { DisplayModalAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
-import { BasicServerCredentials } from "../../services/credentialsService";
 import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
 import { colors } from "../../styles/Colors";
 import ModalDialog from "./ModalDialog";
-import UserCredentialsModal, { CredentialsMode, UserCredentialsModalProps } from "./UserCredentialsModal";
+import UserCredentialsModal, { UserCredentialsModalProps } from "./UserCredentialsModal";
 
 export interface ServerModalProps {
   server: Server;
@@ -69,12 +68,9 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
       dispatchOperation({ type: OperationType.HideModal });
     };
 
-    const serverCredentials: BasicServerCredentials = { username: "", password: "", server };
     const userCredentialsModalProps: UserCredentialsModalProps = {
       server,
-      serverCredentials,
-      mode: CredentialsMode.TEST,
-      errorMessage: "",
+      confirmText: "Test",
       onConnectionVerified: onVerifyConnection
     };
     dispatchOperation({ type: OperationType.DisplayModal, payload: <UserCredentialsModal {...userCredentialsModalProps} /> });

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -15,7 +15,7 @@ import {
   calculateWellboreNodeId,
   getWellboreProperties
 } from "../models/wellbore";
-import AuthorizationService from "../services/credentialsService";
+import AuthorizationService from "../services/authorizationService";
 import { filterWells } from "./filter";
 import { performModificationAction } from "./modificationStateReducer";
 import ModificationType from "./modificationType";

--- a/Src/WitsmlExplorer.Frontend/models/server.ts
+++ b/Src/WitsmlExplorer.Frontend/models/server.ts
@@ -5,7 +5,8 @@ export interface Server {
   url: string;
   securityscheme: string;
   roles: string[];
-  username?: string;
+  currentUsername?: string;
+  usernames?: string[];
 }
 
 export function emptyServer(): Server {
@@ -16,6 +17,7 @@ export function emptyServer(): Server {
     url: "",
     securityscheme: "Basic",
     roles: [],
-    username: undefined
+    currentUsername: undefined,
+    usernames: []
   };
 }

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -5,14 +5,14 @@ import AuthorizationService, { AuthorizationStatus } from "./authorizationServic
 
 export class ApiClient {
   private static async getCommonHeaders(targetServer: Server = undefined, sourceServer: Server = undefined): Promise<HeadersInit> {
-    const authorizationHeader = await this.getAuthorizationHeader();
+    const authorizationHeader = await ApiClient.getAuthorizationHeader();
     return {
       "Content-Type": "application/json",
       ...(authorizationHeader ? { Authorization: authorizationHeader } : {}),
-      "WitsmlTargetServer": this.getServerHeader(targetServer),
-      "WitsmlSourceServer": this.getServerHeader(sourceServer),
-      "WitsmlTargetUsername": this.getUsernameHeader(targetServer),
-      "WitsmlSourceUsername": this.getUsernameHeader(sourceServer)
+      "WitsmlTargetServer": ApiClient.getServerHeader(targetServer),
+      "WitsmlSourceServer": ApiClient.getServerHeader(sourceServer),
+      "WitsmlTargetUsername": ApiClient.getUsernameHeader(targetServer),
+      "WitsmlSourceUsername": ApiClient.getUsernameHeader(sourceServer)
     };
   }
 

--- a/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
@@ -17,7 +17,7 @@ export class AuthorizationClient {
     if (!credentials) {
       return "";
     }
-    return btoa(credentials.username + ":" + credentials.password) + "@" + credentials.server.url.toString();
+    return Buffer.from(credentials.username + ":" + credentials.password).toString("base64") + "@" + credentials.server.url.toString();
   }
 
   public static async get(pathName: string, abortSignal: AbortSignal | null = null, targetCredentials: BasicServerCredentials): Promise<Response> {

--- a/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
@@ -1,34 +1,29 @@
 import { ApiClient } from "./apiClient";
 
-import { BasicServerCredentials } from "./credentialsService";
+import { BasicServerCredentials } from "./authorizationService";
 
 export class AuthorizationClient {
-  private static async getHeaders(credentials: BasicServerCredentials[], serverOnly: boolean): Promise<HeadersInit> {
+  private static async getHeaders(credentials: BasicServerCredentials[]): Promise<HeadersInit> {
     const authorizationHeader = await ApiClient.getAuthorizationHeader();
     return {
       "Content-Type": "application/json",
       ...(authorizationHeader ? { Authorization: authorizationHeader } : {}),
-      "WitsmlTargetServer": this.getServerHeader(credentials[0], serverOnly),
-      "WitsmlSourceServer": this.getServerHeader(credentials[1], serverOnly)
+      "WitsmlTargetServer": this.getServerHeader(credentials[0]),
+      "WitsmlSourceServer": this.getServerHeader(credentials[1])
     };
   }
 
-  private static getServerHeader(credentials: BasicServerCredentials | undefined, serverOnly: boolean): string {
-    let result = "";
+  private static getServerHeader(credentials: BasicServerCredentials | undefined): string {
     if (!credentials) {
-      return result;
+      return "";
     }
-    if (!serverOnly) {
-      result = btoa(credentials.username + ":" + credentials.password) + "@";
-    }
-    result += credentials.server.url.toString();
-    return result;
+    return btoa(credentials.username + ":" + credentials.password) + "@" + credentials.server.url.toString();
   }
 
   public static async get(pathName: string, abortSignal: AbortSignal | null = null, targetCredentials: BasicServerCredentials): Promise<Response> {
     const requestInit: RequestInit = {
       signal: abortSignal,
-      headers: await AuthorizationClient.getHeaders([targetCredentials], false),
+      headers: await AuthorizationClient.getHeaders([targetCredentials]),
       credentials: "include"
     };
 

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -65,9 +65,17 @@ class AuthorizationService {
     this._sourceServer = null;
   }
 
+  public onServerStateChange(server: Server) {
+    if (this.selectedServer?.id == server.id) {
+      this.setSelectedServer(server);
+    }
+    if (this.sourceServer?.id == server.id) {
+      this.setSourceServer(server);
+    }
+  }
+
   public onAuthorized(server: Server, username: string, dispatchNavigation: (action: UpdateServerAction) => void) {
-    // TODO: username on first login with system user is not set yet, will be fixed as part of WE-749
-    server.username = username;
+    server.currentUsername = username;
     dispatchNavigation({ type: ModificationType.UpdateServer, payload: { server } });
     this._onAuthorizationChange.dispatch({ server, status: AuthorizationStatus.Authorized });
   }

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -76,6 +76,12 @@ class AuthorizationService {
 
   public onAuthorized(server: Server, username: string, dispatchNavigation: (action: UpdateServerAction) => void) {
     server.currentUsername = username;
+    if (server.usernames == null) {
+      server.usernames = [];
+    }
+    if (!server.usernames.includes(username)) {
+      server.usernames.push(username);
+    }
     dispatchNavigation({ type: ModificationType.UpdateServer, payload: { server } });
     this._onAuthorizationChange.dispatch({ server, status: AuthorizationStatus.Authorized });
   }

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -1,7 +1,7 @@
 import JobInfo from "../models/jobs/jobInfo";
 import { Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import AuthorizationService from "./credentialsService";
+import AuthorizationService from "./authorizationService";
 import NotificationService from "./notificationService";
 
 export default class JobService {

--- a/Src/WitsmlExplorer.Frontend/services/logObjectService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/logObjectService.tsx
@@ -4,7 +4,7 @@ import { LogData } from "../models/logData";
 import LogObject, { emptyLogObject } from "../models/logObject";
 import { Server } from "../models/server";
 import { ApiClient } from "./apiClient";
-import AuthorizationService from "./credentialsService";
+import AuthorizationService from "./authorizationService";
 import NotificationService from "./notificationService";
 
 export default class LogObjectService {

--- a/Tests/WitsmlExplorer.Api.Tests/Extensions/HttpRequestExtensionsTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Extensions/HttpRequestExtensionsTests.cs
@@ -76,5 +76,39 @@ namespace WitsmlExplorer.Api.Tests.Extensions
             Assert.True(testResult.IsCredsNullOrEmpty() && testResult.Host == null);
         }
 
+        [Fact]
+        public void ParseServerHttpHeader_BasicCreds_ReturnBasicCreds()
+        {
+            string basicHeader = CreateBasicHeaderValue("basicuser", "basicpassword", "http://some.url.com");
+
+            ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(basicHeader, n => n);
+            Assert.True(creds.UserId == "basicuser" && creds.Password == "basicpassword");
+        }
+
+        [Fact]
+        public void ParseServerHttpHeader_BasicNoCreds_ReturnEmpty()
+        {
+            string basicHeader = "http://some.url.com";
+
+            ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(basicHeader, n => n);
+            Assert.True(creds.IsCredsNullOrEmpty());
+        }
+
+        [Fact]
+        public void ParseServerHttpHeader_BasicNoHeader_ReturnEmpty()
+        {
+            string basicHeader = null;
+
+            ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(basicHeader, n => n);
+            Assert.True(creds.IsCredsNullOrEmpty());
+        }
+
+        private static string CreateBasicHeaderValue(string username, string dummypassword, string host)
+        {
+            ServerCredentials sc = new() { UserId = username, Password = dummypassword, Host = new Uri(host) };
+            string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(sc.UserId + ":" + sc.Password));
+            return b64Creds + "@" + sc.Host.ToString();
+        }
+
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
@@ -26,11 +26,12 @@ namespace WitsmlExplorer.Api.Tests.Services
         {
             string clientId = Guid.NewGuid().ToString();
             string url = "https://somehost";
+            string witsmlUsername = "user";
 
             _credentialsCache.Clear();
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
-            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
+            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
 
             long before = _credentialsCache.Count();
             _credentialsCache.RemoveAllClientCredentials(clientId);
@@ -44,10 +45,11 @@ namespace WitsmlExplorer.Api.Tests.Services
         {
             string clientId = Guid.NewGuid().ToString();
             string url = "https://somehost";
+            string witsmlUsername = "user";
 
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
-            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0);
+            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
 
             long before = _credentialsCache.Count();
             _credentialsCache.Clear();

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -72,96 +72,49 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCredentialsFromHeaderValue_BasicCreds_ReturnBasicCreds()
+        public void GetCredentials_ValidTokenValidRolesValidURLValidUsername_ReturnSystemCreds()
         {
-            string token = null;
-            string basicHeader = CreateBasicHeaderValue("basicuser", "basicpassword", "http://some.url.com");
-
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
-            Assert.True(creds.UserId == "basicuser" && creds.Password == "basicpassword");
-            Cleanup();
-        }
-
-        [Fact]
-        public void GetCredentialsFromHeaderValue_BasicNoCreds_ReturnEmpty()
-        {
-            string token = null;
-            string basicHeader = "http://some.url.com";
-
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
-            Assert.True(creds.IsCredsNullOrEmpty());
-            Cleanup();
-        }
-
-        [Fact]
-        public void GetCredentialsFromHeaderValue_BasicNoHeader_ReturnEmpty()
-        {
-            string token = null;
-            string basicHeader = null;
-
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
-            Assert.True(creds.IsCredsNullOrEmpty());
-            Cleanup();
-        }
-        [Fact]
-        public void GetCredentialsFromHeaderValue_BasicAndTokenValidRolesHeaderValidURL_ReturnBasicCreds()
-        {
-            // WHEN
-            //  Valid Basic credentials and Valid Bearer token are present along with Valid URL
-            // THEN 
-            //  Basic auth should always be preferred
-            string basicHeader = CreateBasicHeaderValue("basicuser", "basicpassword", "http://some.url.com");
-            string token = CreateJwtToken(new string[] { "validrole" }, false, "tokenuser@arpa.net");
-
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
-            Assert.True(creds.UserId == "basicuser" && creds.Password == "basicpassword");
-            Cleanup();
-        }
-
-        [Fact]
-        public void GetCredentialsFromHeaderValue_ValidTokenValidRolesValidURLBasicHeader_ReturnSystemCreds()
-        {
-            // 1. CONFIG:   There is a server config in DB with URL: "http://some.url.com" and role: ["user"]
+            // 1. CONFIG:   There is a server config in DB with URL: "http://some.url.com" and role: ["validrole"]
             // 2. CONFIG:   There exist system credentials in keyvault for server with URL: "http://some.url.com"
             // 3. REQUEST:  User provide token and valid roles in token
             // 4. REQUEST:  Header WitsmlTargetServer Header with URL: "http://some.url.com"
             // 5. RESPONSE: System creds should be returned because server-roles and user-roles overlap
-            string basicHeader = "http://some.url.com";
-            string token = CreateJwtToken(new string[] { "validrole" }, false, "tokenuser@arpa.net");
+            string server = "http://some.url.com";
+            EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
+            ServerCredentials creds = _credentialsService.GetCredentials(true, eh, server, "systemuser");
             Assert.True(creds.UserId == "systemuser" && creds.Password == "systempassword");
             Cleanup();
         }
 
         [Fact]
-        public void GetCredentialsFromHeaderValue_ValidTokenValidRolesInvalidURLBasicHeader_ReturnEmpty()
+        public void GetCredentials_ValidTokenValidRolesInvalidURL_ReturnNull()
         {
-            string basicHeader = "http://some.invalidurl.com";
-            string token = CreateJwtToken(new string[] { "validrole" }, false, "tokenuser@arpa.net");
+            string server = "http://some.invalidurl.com";
+            EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
-            Assert.True(creds.IsCredsNullOrEmpty());
+            ServerCredentials creds = _credentialsService.GetCredentials(true, eh, server, "systemuser");
+            Assert.Null(creds);
             Cleanup();
         }
 
         [Fact]
-        public void GetCredentialsFromHeaderValue_InvalidTokenRolesURLOnlyBasicHeader_ReturnEmpty()
+        public void GetCredentials_InvalidTokenRolesURLOnlyBasicHeader_ReturnNull()
         {
-            string basicHeader = "http://some.url.com";
-            string token = CreateJwtToken(new string[] { "invalidrole" }, false, "tokenuser@arpa.net");
+            string server = "http://some.url.com";
+            EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "invalidrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _credentialsService.GetCredentialsFromHeaderValue(basicHeader, token).Result;
-            Assert.True(creds.IsCredsNullOrEmpty());
+            ServerCredentials creds = _credentialsService.GetCredentials(true, eh, server, "systemuser");
+            Assert.Null(creds);
             Cleanup();
         }
 
         [Fact]
-        public void CacheCredentials_InsertOne_GetCredentialsFromCache()
+        public void GetCredentials_CredentialsInCache_ReturnerCorrectly()
         {
-
+            string userId = "username";
             string clientId = Guid.NewGuid().ToString();
-            ServerCredentials sc = new() { UserId = "username", Password = "dummypassword", Host = new Uri("https://somehost.url") };
+            ServerCredentials sc = new() { UserId = userId, Password = "dummypassword", Host = new Uri("https://somehost.url") };
             string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(sc.UserId + ":" + sc.Password));
             string headerValue = b64Creds + "@" + sc.Host;
 
@@ -170,23 +123,18 @@ namespace WitsmlExplorer.Api.Tests.Services
             headersMock.SetupGet(x => x.TargetServer).Returns(sc.Host.ToString());
 
             _credentialsService.CacheCredentials(clientId, sc, 1.0, n => n);
-            ServerCredentials fromCache = _credentialsService.GetCredentialsFromCache(false, headersMock.Object, headersMock.Object.TargetServer);
+            ServerCredentials fromCache = _credentialsService.GetCredentials(false, headersMock.Object, headersMock.Object.TargetServer, userId);
             Assert.Equal(sc, fromCache);
             _credentialsService.RemoveAllCachedCredentials();
             Cleanup();
         }
+
         private void Cleanup()
         {
             _credentialsService.RemoveAllCachedCredentials();
         }
-        private static string CreateBasicHeaderValue(string username, string dummypassword, string host)
-        {
-            ServerCredentials sc = new() { UserId = username, Password = dummypassword, Host = new Uri(host) };
-            string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(sc.UserId + ":" + sc.Password));
-            return b64Creds + "@" + sc.Host.ToString();
-        }
 
-        private static string CreateJwtToken(string[] appRoles, bool signed, string upn)
+        private static EssentialHeaders CreateEhWithAuthorization(string[] appRoles, bool signed, string upn)
         {
             SecurityTokenDescriptor tokenDescriptor = new()
             {
@@ -207,7 +155,10 @@ namespace WitsmlExplorer.Api.Tests.Services
                     SecurityAlgorithms.Sha512Digest
                 );
             }
-            return new JwtSecurityTokenHandler().WriteToken(new JwtSecurityTokenHandler().CreateJwtSecurityToken(tokenDescriptor));
+            return new()
+            {
+                Authorization = "Bearer " + new JwtSecurityTokenHandler().WriteToken(new JwtSecurityTokenHandler().CreateJwtSecurityToken(tokenDescriptor))
+            };
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -110,7 +110,7 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void GetCredentials_CredentialsInCache_ReturnerCorrectly()
+        public void GetCredentials_CredentialsInCache_ReturnCorrectly()
         {
             string userId = "username";
             string clientId = Guid.NewGuid().ToString();


### PR DESCRIPTION
## Fixes
This pull request fixes WE-757

## Description
Add target and source usernames to headers. Now every WITSML-related API call will need to include a username header to fetch correct credentials cached through the authorize route (or system credentials that are cached on the fly).

API:
* Refactor CredentialsService in API.
* Cache a <username, encryptedPassword> dictionary instead of a single set of credentials per cacheId to allow for easy switching between users.
* Implement a single GetCredentials that, given a username, always checks the cache first, and on miss checks for system credentials.
* Return all logged in usernames in get servers route.
* Fix crash on Server.Roles being null.
* Adjust swagger headers. Ref WE-664.

Frontend:
* Allow opening user credentials modal from top right corner menu to switch user.
* Always show credentials modal when selecting a server instead of automatically logging in.
* Rename credentialsService to authorizationService which was omitted in the previous PR.
* Add dropdown to user credentials modal to easily switch to a previously logged in user or a system user.
* Remove CredentialsMode from user credentials modal due to Test being the only one used.
* Remove a username that is no longer logged in on 401 in AuthorizationManager.
* Server now holds the currentUsername used to decide which credentials should be used in the backend, and a list of logged in usernames for easy switching.
* Remove serverOnly flag from AuthorizationClient due to always being false.

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality
* This change requires a documentation update

## Impacted Areas in Application

* Frontend, API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [x] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
