### PR TITLE
WE-766 fail with reason on copy log data error during copy log job

### DIFF
--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -59,14 +59,14 @@ namespace WitsmlExplorer.Api.Workers.Copy
             CopyResult copyResultForExistingMnemonics = await CopyLogData(sourceLog, targetLog, job, existingMnemonicsInTarget);
             if (!copyResultForExistingMnemonics.Success)
             {
-                string message = $"Failed to copy curves for existing mnemonics to log. Copied a total of {copyResultForExistingMnemonics.NumberOfRowsCopied} rows";
+                string message = $"Failed to copy curves for existing mnemonics to log. {copyResultForExistingMnemonics.ErrorReason}. Copied a total of {copyResultForExistingMnemonics.NumberOfRowsCopied} rows.";
                 return LogAndReturnErrorResult(message, job);
             }
 
             CopyResult copyResultForNewMnemonics = await CopyLogData(sourceLog, targetLog, job, newMnemonicsInTarget);
             if (!copyResultForNewMnemonics.Success)
             {
-                string message = $"Failed to copy curves for new mnemonics to log. Copied a total of {copyResultForNewMnemonics.NumberOfRowsCopied} rows";
+                string message = $"Failed to copy curves for new mnemonics to log. {copyResultForNewMnemonics.ErrorReason}. Copied a total of {copyResultForNewMnemonics.NumberOfRowsCopied} rows";
                 return LogAndReturnErrorResult(message, job);
             }
 
@@ -110,7 +110,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
                 else
                 {
                     Logger.LogError("Failed to copy log data. - {Description} - Current index: {StartIndex}", job.Description(), startIndex.GetValueAsString());
-                    return new CopyResult { Success = false, NumberOfRowsCopied = numberOfDataRowsCopied };
+                    return new CopyResult { Success = false, NumberOfRowsCopied = numberOfDataRowsCopied, ErrorReason = result.Reason };
                 }
             }
 
@@ -223,6 +223,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             public bool Success { get; set; }
             public int NumberOfRowsCopied { get; set; }
+            public string ErrorReason { get; set; }
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -96,6 +96,22 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Assert.Null(logInQuery.EndDateTimeIndex);
         }
 
+        [Fact]
+        public async Task Execute_ErrorOnCopyLogData_ReasonInWorkingResult()
+        {
+            CopyLogJob copyLogJob = CreateJobTemplate();
+            SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD);
+            SetupGetWellbore();
+            string errorReason = "test";
+            IEnumerable<WitsmlLogs> copyLogQuery = SetupAddInStoreAsync();
+            _copyLogDataWorker.Setup(worker => worker.Execute(It.IsAny<CopyLogDataJob>()))
+                .ReturnsAsync((new WorkerResult(null, false, "", errorReason), null));
+
+            (WorkerResult Result, RefreshAction) copyTask = await _copyLogWorker.Execute(copyLogJob);
+
+            Assert.Contains(errorReason, copyTask.Result.Reason);
+        }
+
         private void SetupSourceLog(string indexType, WitsmlLogs sourceLogs = null)
         {
             switch (indexType)


### PR DESCRIPTION
## Fixes
This pull request fixes WE-766

## Description
Detect whether any of copy log data jobs fail during copy log jobs, and return the first error reason with the WorkerResult.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API
* Frontend (by turning a job completed message to an error message)

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests
