### PR TITLE
WE-765 remove securityscheme from server model

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -167,9 +167,7 @@ To use Azure keyvault, create your keyvault (above named `witsmlexp-servers-kv`)
  
 ## Serverlist
 
-Credentials will be mapped on URL from secrets with the serverlist. `Server` entry in MongoDB or CosmosDB will have property `securityscheme` that can be `Basic` or `OAuth2`
-
-The app role assigned to a server will be compared to the role claims in the JWT provided in the Authorization header. If a user has been assigned the same application role, system credentials will be made available to the user. An API call will use the system credentials if the system username is set in the `WitsmlTargetUsername` or `WitsmlSourceUsername` header.
+Credentials will be mapped on URL from secrets with the serverlist. `Server` entry in MongoDB or CosmosDB will have the property `roles`. The app role assigned to a server will be compared to the role claims in the JWT provided in the Authorization header. If a user has been assigned the same application role, system credentials will be made available to the user. An API call will use the system credentials if the system username is set in the `WitsmlTargetUsername` or `WitsmlSourceUsername` header.
 
 For more info on app roles, see: [app roles](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps)
 
@@ -179,8 +177,7 @@ For more info on app roles, see: [app roles](https://learn.microsoft.com/en-us/a
     "name": "Equinor WITSML",
     "url": "https://witsml007.someserver/store/WITSML",
     "description": "Equinor testserver. Do not edit any datasets",
-    "securityScheme": "OAuth2",
-    "role": [ "user" ]
+    "roles": [ "user" ]
 }
 ```
 
@@ -208,15 +205,15 @@ NEXT_PUBLIC_AZURE_AD_SCOPE_API=
 ## Hybrid Flow
 It is possible to utilize both OAuth2 and Basic authentication security schemes at the same time. With this configuration the end user will have to authenticate against an authorization server that supports `OAuth2 Authorization Code Flow with PKCE`.
 
-As described in the [Serverlist](#serverlist), Witsml Explorer will make a system user available based on how you configure your list of servers. If the Server has securityscheme `OAuth2` and both the server and the Azure user have the same `app-roles`, the frontend will use the `Bearer` token received from the authorization server and relay this to the backend along with the url of the server. It will not ask the user for basic credentials (username:password) if the system username was specified in the `Witsml(Target/Source)Username` header.
+As described in the [Serverlist](#serverlist), Witsml Explorer will make a system user available based on how you configure your list of servers. If the Server has specified the `roles` and both the server and the Azure user have the same `app-roles`, the frontend will use the `Bearer` token received from the authorization server and relay this to the backend along with the url of the server. It will not ask the user for basic credentials (username:password) if the system username was specified in the `Witsml(Target/Source)Username` header.
 
 The backend in turn will do a lookup on the users application role, and if eligible, use the `system-user` fetched from `keyvault` for the connection to the WITSML server.
 
 ### Basic witsmlexplorer flow
-For an illustration of sequences initiated when the user queries a server with property securityscheme set to `Basic`, visit the figure in the beginning of this document under `WITSML server credentials flow`
+For an illustration of sequences initiated when the user queries a server without a `system-user`, visit the figure in the beginning of this document under `WITSML server credentials flow`
 
 ### OAuth2 witsmlexplorer flow with MSAL
-The following diagram illustrates the flow for a user contacting a `Server` that have been assigned securityscheme `OAuth2`. The setting `OAuth2Enabled=true` has been set in backend, and MSAL enabled in frontend:
+The following diagram illustrates the flow for a user contacting a `Server` with a `system-user`. The setting `OAuth2Enabled=true` has been set in backend, and MSAL enabled in frontend:
 
 
 ```mermaid
@@ -236,8 +233,8 @@ graph TD
 
 1. End user visits Witsml-Explorer.
 2. The end user will be redirected to login with the configured OAuth2 Authorization server (Azure AD).
-3. Witsml-Explorer will fetch the initial Serverlist from DB. When OAuth2 is enabled both in the frontend and backend, retrieving the serverlist will only be available for logged in users. Similarly Create, Update and Delete will be reserved for users with role `admin`. All servers in the list now include two properties: `securityscheme` and `role`. A list of available users will be returned for every server. These are previously logged in users and/or a system user.
-4. If the user through the frontend chooses to query a server with a `securityscheme` set to `OAuth2`, and picks an available system user, the backend will check the received `Bearer` JWT token for `app-roles`. This in turn will be checked against the configured `roles` for the server.
+3. Witsml-Explorer will fetch the initial Serverlist from DB. When OAuth2 is enabled both in the frontend and backend, retrieving the serverlist will only be available for logged in users. Similarly Create, Update and Delete of servers will be reserved for users with role `admin`. A list of available users will be returned for every server. These are previously logged in users and/or a system user.
+4. If the user through the frontend chooses to query a server with an available system user, the backend will check the received `Bearer` JWT token for `app-roles`. This in turn will be checked against the configured `roles` for the server.
 5. When one of the user roles and server roles overlap, the backend fetches system credentials from `Azure Keyvault` for this witsml server.
 6. The server will now forward the query to the witsml server using `Basic` authorization with system credentials fetched from step 5.
 
@@ -344,7 +341,7 @@ WitsmlTargetUsername: system-user123
 ```
 __3. Authorize WITSML credentials__ 
 
-If you do not have system credentials in keyvault, and need to use Basic credentials for a server in OAuth2 mode, you must `authorize` first like below before using endpoints with this server.
+If you do not have system credentials in keyvault and need to use Basic credentials, you must `authorize` first like below before using endpoints with the given server.
 
 ```http
 GET http://localhost:5000/api/credentials/authorize?keep=false HTTP/1.1

--- a/Src/WitsmlExplorer.Api/Models/Connection.cs
+++ b/Src/WitsmlExplorer.Api/Models/Connection.cs
@@ -10,7 +10,6 @@ namespace WitsmlExplorer.Api.Models
             Name = server.Name;
             Url = server.Url;
             Description = server.Description;
-            SecurityScheme = server.SecurityScheme;
             Roles = server.Roles;
             Id = server.Id;
         }

--- a/Src/WitsmlExplorer.Api/Models/Server.cs
+++ b/Src/WitsmlExplorer.Api/Models/Server.cs
@@ -23,8 +23,6 @@ namespace WitsmlExplorer.Api.Models
         {
             return JsonSerializer.Serialize(this);
         }
-        [JsonPropertyName("securityscheme")]
-        public string SecurityScheme { get; set; }
         [JsonPropertyName("roles")]
         public IList<string> Roles { get; set; }
 

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -1,4 +1,3 @@
-import { Autocomplete } from "@equinor/eds-core-react";
 import { Button, TextField } from "@material-ui/core";
 import MuiThumbUpOutlinedIcon from "@material-ui/icons/ThumbUpOutlined";
 import React, { ChangeEvent, useContext, useState } from "react";
@@ -36,7 +35,6 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const isAddingNewServer = props.server.id === undefined;
-  const schemeValues = ["Basic", "OAuth2"];
 
   const onSubmit = async () => {
     const abortController = new AbortController();
@@ -152,17 +150,6 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
             fullWidth
             inputProps={{ maxLength: 64 }}
             onChange={(e) => setServer({ ...server, description: e.target.value })}
-            disabled={props.editDisabled}
-          />
-          <Autocomplete
-            id="securityScheme"
-            label="Security Scheme Type"
-            options={schemeValues}
-            initialSelectedOptions={[server.securityscheme || schemeValues[0]]}
-            onOptionsChange={({ selectedItems }) => {
-              setServer({ ...server, securityscheme: selectedItems[0] || schemeValues[0] });
-            }}
-            hideClearButton={true}
             disabled={props.editDisabled}
           />
           <TextField

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
@@ -43,7 +43,7 @@ it("Should update list of servers, and current selected, if editing current sele
 });
 
 it("Should update list of servers when adding a server", () => {
-  const newServer: Server = { id: "1", name: "New server", url: "https://example.com", description: "A new server", securityscheme: "", roles: [] };
+  const newServer: Server = { id: "1", name: "New server", url: "https://example.com", description: "A new server", roles: [] };
   const selectServerAction = { type: ModificationType.AddServer, payload: { server: newServer } };
   const actual = reducer({ ...getInitialState() }, selectServerAction);
   expect(actual).toStrictEqual({

--- a/Src/WitsmlExplorer.Frontend/contexts/stateReducerTestUtils.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/stateReducerTestUtils.ts
@@ -7,8 +7,8 @@ import Wellbore from "../models/wellbore";
 import Filter, { EMPTY_FILTER } from "./filter";
 import { EMPTY_NAVIGATION_STATE, NavigationState } from "./navigationContext";
 
-export const SERVER_1: Server = { id: "1", name: "WITSML server", url: "http://example.com", description: "Witsml server", securityscheme: "", roles: [] };
-export const SERVER_2: Server = { id: "2", name: "WITSML server 2", url: "http://example2.com", description: "Witsml server 2", securityscheme: "", roles: [] };
+export const SERVER_1: Server = { id: "1", name: "WITSML server", url: "http://example.com", description: "Witsml server", roles: [] };
+export const SERVER_2: Server = { id: "2", name: "WITSML server 2", url: "http://example2.com", description: "Witsml server 2", roles: [] };
 export const WELLBORE_1: Wellbore = {
   uid: "wellbore1",
   wellUid: "well1",

--- a/Src/WitsmlExplorer.Frontend/models/server.ts
+++ b/Src/WitsmlExplorer.Frontend/models/server.ts
@@ -3,7 +3,6 @@ export interface Server {
   name: string;
   description: string;
   url: string;
-  securityscheme: string;
   roles: string[];
   currentUsername?: string;
   usernames?: string[];
@@ -15,7 +14,6 @@ export function emptyServer(): Server {
     name: "",
     description: "",
     url: "",
-    securityscheme: "Basic",
     roles: [],
     currentUsername: undefined,
     usernames: []

--- a/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/msal/MsalAuthProvider.tsx
@@ -7,11 +7,6 @@ export const authRequest: RedirectRequest = {
 
 export const msalEnabled = process.env.NEXT_PUBLIC_MSALENABLED;
 
-export enum SecurityScheme {
-  OAuth2 = "OAuth2",
-  Basic = "Basic"
-}
-
 export const adminRole = "admin";
 export const developerRole = "developer";
 

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -56,7 +56,6 @@ namespace WitsmlExplorer.Api.Tests.Services
                     Name = "Test Server",
                     Url = new Uri("http://some.url.com"),
                     Description = "Testserver for SystemCreds testing",
-                    SecurityScheme = "OAuth2",
                     Roles = new List<string>() {"validrole","developer"}
                 }
             });


### PR DESCRIPTION
## Fixes
This pull request fixes WE-765

## Description
Remove securityScheme from server model as it is unused. Adjusted documentation.
Before merging this PR, server lists in deployment need to have their securityScheme properties removed, otherwise GetWitsmlServer route will crash.

## Type of change

* Enhancement of existing functionality
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update

## Impacted Areas in Application

* Frontend, API, Database

## Checklist:

*Communication*
* [x] PR is related to an issue
* [x] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
