### PR TITLE
WE-780 Fix namespace collision

### DIFF
--- a/Src/WitsmlExplorer.Frontend/next.config.js
+++ b/Src/WitsmlExplorer.Frontend/next.config.js
@@ -8,7 +8,7 @@ module.exports = {
   basePath: wePath,
   webpack: (config) => {
     const env = Object.keys(process.env).reduce((acc, curr) => {
-      acc[`process.env.${curr}`] = JSON.stringify(process.env[curr]);
+      acc[`process.env.NODE_ENV${curr}`] = JSON.stringify(process.env[curr]);
       return acc;
     }, {});
 


### PR DESCRIPTION
This is a small change removing warnings at startup and build of the frontend.

```sh
DefinePlugin
Conflicting values for 'process.env.NEXT_RUNTIME'

DefinePlugin
Conflicting values for 'process.env.NEXT_RUNTIME'
```