### PR TITLE
WE-748 fit whole datetime in CurveValuesView

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
@@ -285,6 +285,7 @@ const configureTemplateColumns = memoizeOne((checkableRows: boolean, isHeader: b
     }
     const columnWidth = "200px";
     const columnWidths = new Array(columns.length).fill(columnWidth);
+    columnWidths[0] = "235px"; //make the first data column wider to fit datetime index
     templateColumns = templateColumns.concat(columnWidths);
   } else {
     templateColumns = columnRefs.map((ref: any) => {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-748

## Description
Enlarge the first column of VirtualizedContentTable to fit datetimes in a single line.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests