### PR TITLE
WE-693 use useOAuth2 from configuration in API CredentialsService

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -11,11 +11,10 @@ namespace WitsmlExplorer.Api.HttpHandlers
 {
     public static class AuthorizeHandler
     {
-        public static async Task<IResult> Authorize([FromQuery(Name = "keep")] bool keep, [FromServices] ICredentialsService credentialsService, IConfiguration configuration, HttpContext httpContext)
+        public static async Task<IResult> Authorize([FromQuery(Name = "keep")] bool keep, [FromServices] ICredentialsService credentialsService, HttpContext httpContext)
         {
-            bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
             EssentialHeaders eh = new(httpContext?.Request);
-            bool success = await credentialsService.VerifyAndCacheCredentials(eh, useOAuth2, keep);
+            bool success = await credentialsService.VerifyAndCacheCredentials(eh, keep);
             if (success)
             {
                 return TypedResults.Ok();
@@ -27,11 +26,11 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
             bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
             EssentialHeaders eh = new(httpContext?.Request);
-            string cacheClientId = useOAuth2 ? credentialsService.GetClaimFromToken(eh.GetBearerToken(), "sub") : eh.GetCookieValue();
             if (!useOAuth2)
             {
                 httpContext.Response.Cookies.Delete(EssentialHeaders.CookieName);
             }
+            string cacheClientId = credentialsService.GetClientId(eh);
             credentialsService.RemoveCachedCredentials(cacheClientId);
 
             return TypedResults.Ok();

--- a/Src/WitsmlExplorer.Api/HttpHandlers/WitsmlServerHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WitsmlServerHandler.cs
@@ -21,8 +21,8 @@ namespace WitsmlExplorer.Api.HttpHandlers
         public static async Task<IResult> GetWitsmlServers([FromServices] IDocumentRepository<Server, Guid> witsmlServerRepository, IConfiguration configuration, HttpContext httpContext, ICredentialsService credentialsService)
         {
             EssentialHeaders httpHeaders = new(httpContext?.Request);
-            bool useOAuth = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
-            if (!useOAuth)
+            bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
+            if (!useOAuth2)
             {
                 httpContext.GetOrCreateWitsmlExplorerCookie();
             }
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
             IEnumerable<Connection> credentials = await Task.WhenAll(servers.Select(async (server) =>
                 new Connection(server)
                 {
-                    Usernames = await credentialsService.GetLoggedInUsernames(useOAuth, httpHeaders, server.Url)
+                    Usernames = await credentialsService.GetLoggedInUsernames(httpHeaders, server.Url)
                 }));
             return TypedResults.Ok(credentials);
         }

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -11,9 +11,10 @@ namespace WitsmlExplorer.Api.Services
     {
         public void RemoveCachedCredentials(string clientId);
         public void VerifyUserIsLoggedIn(IEssentialHeaders eh, ServerType serverType);
-        public Task<string[]> GetLoggedInUsernames(bool useOauth, IEssentialHeaders eh, Uri serverUrl);
+        public Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri serverUrl);
         public string GetClaimFromToken(string token, string claim);
-        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool useOauth, bool keep);
-        public ServerCredentials GetCredentials(bool useOauth, IEssentialHeaders eh, string server, string username);
+        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep);
+        public ServerCredentials GetCredentials(IEssentialHeaders eh, string server, string username);
+        public string GetClientId(IEssentialHeaders eh);
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -31,7 +31,6 @@ namespace WitsmlExplorer.Api.Services
         private readonly ICredentialsService _credentialsService;
         private readonly ILogger<WitsmlClientProvider> _logger;
         private readonly bool _logQueries;
-        private readonly bool _useOAuth;
 
         public WitsmlClientProvider(ILogger<WitsmlClientProvider> logger, IConfiguration configuration, IHttpContextAccessor httpContextAccessor, ICredentialsService credentialsService, IOptions<WitsmlClientCapabilities> witsmlClientCapabilities)
         {
@@ -45,7 +44,6 @@ namespace WitsmlExplorer.Api.Services
             _logger = logger ?? throw new ArgumentException("Logger missing");
             _logQueries = StringHelpers.ToBoolean(configuration[ConfigConstants.LogQueries]);
             _logger.LogDebug("WitsmlClientProvider initialised");
-            _useOAuth = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
         }
 
         internal WitsmlClientProvider(IConfiguration configuration)
@@ -67,7 +65,7 @@ namespace WitsmlExplorer.Api.Services
         {
             if (_witsmlClient == null)
             {
-                _targetCreds = _credentialsService.GetCredentials(_useOAuth, _httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
+                _targetCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
                 _witsmlClient = (_targetCreds != null && !_targetCreds.IsCredsNullOrEmpty())
                     ? new WitsmlClient(_targetCreds.Host.ToString(), _targetCreds.UserId, _targetCreds.Password, _clientCapabilities, null, _logQueries)
                     : null;
@@ -80,7 +78,7 @@ namespace WitsmlExplorer.Api.Services
         {
             if (_witsmlSourceClient == null)
             {
-                _sourceCreds = _credentialsService.GetCredentials(_useOAuth, _httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
+                _sourceCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
                 _witsmlSourceClient = (_sourceCreds != null && !_sourceCreds.IsCredsNullOrEmpty())
                     ? new WitsmlClient(_sourceCreds.Host.ToString(), _sourceCreds.UserId, _sourceCreds.Password, _clientCapabilities, null, _logQueries)
                     : null;

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -24,7 +25,8 @@ namespace WitsmlExplorer.Api.Tests.Services
 {
     public class CredentialsServiceTests
     {
-        private readonly CredentialsService _credentialsService;
+        private readonly CredentialsService _basicCredentialsService;
+        private readonly CredentialsService _oauthCredentialsService;
 
         public CredentialsServiceTests()
         {
@@ -35,6 +37,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             Mock<IWitsmlSystemCredentials> witsmlServerCredentials = new();
             Mock<IDocumentRepository<Server, Guid>> witsmlServerRepository = new();
             CredentialsCache credentialsCache = new(new Mock<ILogger<CredentialsCache>>().Object);
+            Mock<IConfiguration> basicConfiguration = new();
+            Mock<IConfiguration> oauthConfiguration = new();
 
             dataProtector.Setup(p => p.Protect(It.IsAny<byte[]>())).Returns((byte[] a) => a);
             dataProtector.Setup(p => p.Unprotect(It.IsAny<byte[]>())).Returns((byte[] a) => a);
@@ -60,13 +64,26 @@ namespace WitsmlExplorer.Api.Tests.Services
                 }
             });
 
-            _credentialsService = new(
+            basicConfiguration.SetupGet(p => p[ConfigConstants.OAuth2Enabled]).Returns("False");
+            _basicCredentialsService = new(
                 dataProtectorProvider.Object,
                 clientCapabilities.Object,
                 witsmlServerCredentials.Object,
                 witsmlServerRepository.Object,
                 credentialsCache,
-                logger.Object
+                logger.Object,
+                basicConfiguration.Object
+            );
+
+            oauthConfiguration.SetupGet(p => p[ConfigConstants.OAuth2Enabled]).Returns("True");
+            _oauthCredentialsService = new(
+                dataProtectorProvider.Object,
+                clientCapabilities.Object,
+                witsmlServerCredentials.Object,
+                witsmlServerRepository.Object,
+                credentialsCache,
+                logger.Object,
+                oauthConfiguration.Object
             );
         }
 
@@ -81,9 +98,9 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://some.url.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _credentialsService.GetCredentials(true, eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
             Assert.True(creds.UserId == "systemuser" && creds.Password == "systempassword");
-            Cleanup();
+            _oauthCredentialsService.RemoveAllCachedCredentials();
         }
 
         [Fact]
@@ -92,9 +109,9 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://some.invalidurl.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _credentialsService.GetCredentials(true, eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
             Assert.Null(creds);
-            Cleanup();
+            _oauthCredentialsService.RemoveAllCachedCredentials();
         }
 
         [Fact]
@@ -103,9 +120,9 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://some.url.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "invalidrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _credentialsService.GetCredentials(true, eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
             Assert.Null(creds);
-            Cleanup();
+            _oauthCredentialsService.RemoveAllCachedCredentials();
         }
 
         [Fact]
@@ -121,16 +138,10 @@ namespace WitsmlExplorer.Api.Tests.Services
             headersMock.Setup(x => x.GetCookieValue()).Returns(clientId);
             headersMock.SetupGet(x => x.TargetServer).Returns(sc.Host.ToString());
 
-            _credentialsService.CacheCredentials(clientId, sc, 1.0, n => n);
-            ServerCredentials fromCache = _credentialsService.GetCredentials(false, headersMock.Object, headersMock.Object.TargetServer, userId);
+            _basicCredentialsService.CacheCredentials(clientId, sc, 1.0, n => n);
+            ServerCredentials fromCache = _basicCredentialsService.GetCredentials(headersMock.Object, headersMock.Object.TargetServer, userId);
             Assert.Equal(sc, fromCache);
-            _credentialsService.RemoveAllCachedCredentials();
-            Cleanup();
-        }
-
-        private void Cleanup()
-        {
-            _credentialsService.RemoveAllCachedCredentials();
+            _basicCredentialsService.RemoveAllCachedCredentials();
         }
 
         private static EssentialHeaders CreateEhWithAuthorization(string[] appRoles, bool signed, string upn)


### PR DESCRIPTION
## Fixes
This pull request fixes WE-693

## Description
Use useOAuth2 from configuration instead of passing it to methods in API CredentialsService, or basing it on existing cookie. This fixes error on existing cookie when accessing WEx with OAuth2 enabled.
Standardize variable naming of useOAuth2.

## Type of change

* Bugfix
* Enhancement of existing functionality

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests