### PR TITLE
WE-647 move cookie creation to authorize route

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/WitsmlServerHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/WitsmlServerHandler.cs
@@ -5,10 +5,7 @@ using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 
-using WitsmlExplorer.Api.Configuration;
-using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Repositories;
 using WitsmlExplorer.Api.Services;
@@ -18,14 +15,9 @@ namespace WitsmlExplorer.Api.HttpHandlers
     public static class WitsmlServerHandler
     {
         [Produces(typeof(IEnumerable<Connection>))]
-        public static async Task<IResult> GetWitsmlServers([FromServices] IDocumentRepository<Server, Guid> witsmlServerRepository, IConfiguration configuration, HttpContext httpContext, ICredentialsService credentialsService)
+        public static async Task<IResult> GetWitsmlServers([FromServices] IDocumentRepository<Server, Guid> witsmlServerRepository, HttpContext httpContext, ICredentialsService credentialsService)
         {
             EssentialHeaders httpHeaders = new(httpContext?.Request);
-            bool useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
-            if (!useOAuth2)
-            {
-                httpContext.GetOrCreateWitsmlExplorerCookie();
-            }
             IEnumerable<Server> servers = await witsmlServerRepository.GetDocumentsAsync();
             IEnumerable<Connection> credentials = await Task.WhenAll(servers.Select(async (server) =>
                 new Connection(server)

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -55,7 +55,7 @@ namespace WitsmlExplorer.Api.Services
             _useOAuth2 = StringHelpers.ToBoolean(configuration[ConfigConstants.OAuth2Enabled]);
         }
 
-        public async Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep)
+        public async Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, string clientId)
         {
             ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(eh.TargetServer, Decrypt);
             if (creds.IsCredsNullOrEmpty())
@@ -66,8 +66,6 @@ namespace WitsmlExplorer.Api.Services
             WitsmlClient witsmlClient = new(creds.Host.ToString(), creds.UserId, creds.Password, _clientCapabilities);
             await witsmlClient.TestConnectionAsync();
 
-            string clientId = GetClientId(eh);
-            clientId ??= _useOAuth2 ? clientId : Guid.NewGuid().ToString();
             double ttl = keep ? 24.0 : 1.0; // hours
             CacheCredentials(clientId, creds, ttl);
             return true;

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -13,7 +13,7 @@ namespace WitsmlExplorer.Api.Services
         public void VerifyUserIsLoggedIn(IEssentialHeaders eh, ServerType serverType);
         public Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri serverUrl);
         public string GetClaimFromToken(string token, string claim);
-        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep);
+        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, string clientId);
         public ServerCredentials GetCredentials(IEssentialHeaders eh, string server, string username);
         public string GetClientId(IEssentialHeaders eh);
     }


### PR DESCRIPTION
## Fixes
This pull request fixes WE-647

## Description
Move cookie creation from GET witsml-servers to authorize route. This means that authentication with swagger in basic mode now works.

## Type of change

* Bugfix

## Impacted Areas in Application

* API, Swagger

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
It was attempted to include a cookie security scheme in SwaggerGen, but it was omitted from the PR given that no changes were observed when it was included.
