### PR TITLE
WE-778 hide roles field in server modal on disabled msal

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -11,6 +11,7 @@ import OperationContext from "../../contexts/operationContext";
 import { DisplayModalAction, HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { Server } from "../../models/server";
+import { msalEnabled } from "../../msal/MsalAuthProvider";
 import NotificationService from "../../services/notificationService";
 import ServerService from "../../services/serverService";
 import { colors } from "../../styles/Colors";
@@ -152,15 +153,17 @@ const ServerModal = (props: ServerModalProps): React.ReactElement => {
             onChange={(e) => setServer({ ...server, description: e.target.value })}
             disabled={props.editDisabled}
           />
-          <TextField
-            id="role"
-            label="Roles (space delimited)"
-            defaultValue={server.roles?.join(" ")}
-            fullWidth
-            inputProps={{ maxLength: 64 }}
-            onChange={(e) => setServer({ ...server, roles: e.target.value.split(" ") })}
-            disabled={props.editDisabled}
-          />
+          {msalEnabled && (
+            <TextField
+              id="role"
+              label="Roles (space delimited)"
+              defaultValue={server.roles?.join(" ")}
+              fullWidth
+              inputProps={{ maxLength: 64 }}
+              onChange={(e) => setServer({ ...server, roles: e.target.value.split(" ") })}
+              disabled={props.editDisabled}
+            />
+          )}
         </>
       }
       onSubmit={onSubmit}


### PR DESCRIPTION
## Fixes
This pull request fixes WE-778

## Description
Hide the roles field in the server modal when MSAL is disabled, due to roles not being used in basic mode.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
