### PR TITLE
WE-684 Generate a more secure cookie id

### DIFF
--- a/Src/WitsmlExplorer.Api/Extensions/HttpContextExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/HttpContextExtensions.cs
@@ -1,8 +1,10 @@
-using System;
+using System.Security.Cryptography;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Tokens;
 
 using WitsmlExplorer.Api.HttpHandlers;
+
 namespace WitsmlExplorer.Api.Extensions
 {
     public static class HttpContextExtensions
@@ -19,7 +21,8 @@ namespace WitsmlExplorer.Api.Extensions
                     Secure = true,
                     HttpOnly = true
                 };
-                cookieValue = Guid.NewGuid().ToString();
+                // Using a more secure ID than Guid https://neilmadden.blog/2018/08/30/moving-away-from-uuids/
+                cookieValue = Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(20));
                 httpContext?.Response.Cookies.Append(EssentialHeaders.CookieName, cookieValue, cookieOptions);
             }
             return cookieValue;


### PR DESCRIPTION
## Fixes
This pull request fixes WE-684

## Description
Generate a more secure cookie ID based on https://neilmadden.blog/2018/08/30/moving-away-from-uuids/. The new ID will not be used properly until #1741 is merged (although there should be no merge conflicts so this PR is not blocked).

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
