### PR TITLE
WE-789 Rework cache to store creds in a cacheId-server hierarchy

### DIFF
--- a/Src/WitsmlExplorer.Api/Extensions/HttpContextExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/HttpContextExtensions.cs
@@ -9,22 +9,17 @@ namespace WitsmlExplorer.Api.Extensions
 {
     public static class HttpContextExtensions
     {
-        public static string GetOrCreateWitsmlExplorerCookie(this HttpContext httpContext)
+        public static string CreateWitsmlExplorerCookie(this HttpContext httpContext)
         {
-            EssentialHeaders eh = new(httpContext.Request);
-            string cookieValue = eh.GetCookieValue();
-            if (string.IsNullOrEmpty(cookieValue))
+            CookieOptions cookieOptions = new()
             {
-                CookieOptions cookieOptions = new()
-                {
-                    SameSite = SameSiteMode.Strict,
-                    Secure = true,
-                    HttpOnly = true
-                };
-                // Using a more secure ID than Guid https://neilmadden.blog/2018/08/30/moving-away-from-uuids/
-                cookieValue = Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(20));
-                httpContext?.Response.Cookies.Append(EssentialHeaders.CookieName, cookieValue, cookieOptions);
-            }
+                SameSite = SameSiteMode.Strict,
+                Secure = true,
+                HttpOnly = true
+            };
+            // Using a more secure ID than Guid https://neilmadden.blog/2018/08/30/moving-away-from-uuids/
+            string cookieValue = Base64UrlEncoder.Encode(RandomNumberGenerator.GetBytes(20));
+            httpContext?.Response.Cookies.Append(EssentialHeaders.CookieName, cookieValue, cookieOptions);
             return cookieValue;
         }
     }

--- a/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsCache.cs
@@ -8,11 +8,12 @@ namespace WitsmlExplorer.Api.Services
 
     public interface ICredentialsCache
     {
-        void SetItem(string cacheId, string encryptedPassword, double ttl, string username);
-        public Dictionary<string, string> GetItem(string cacheId);
+        void SetItem(string cacheId, Uri serverUrl, string encryptedPassword, double ttl, string username);
+        public Dictionary<string, Dictionary<string, string>> GetItem(string cacheId);
+        public Dictionary<string, string> GetItem(string cacheId, Uri serverUrl);
         public long Count();
         public void Clear();
-        public void RemoveAllClientCredentials(string clientId);
+        public void RemoveAllClientCredentials(string cacheId);
     }
 
     public class CredentialsCache : ICredentialsCache
@@ -25,28 +26,32 @@ namespace WitsmlExplorer.Api.Services
             _logger = logger;
         }
 
-        public void SetItem(string cacheId, string encryptedPassword, double ttl, string username)
+        public void SetItem(string cacheId, Uri serverUrl, string encryptedPassword, double ttl, string username)
         {
             CacheItemPolicy cacheItemPolicy = new() { SlidingExpiration = TimeSpan.FromHours(ttl) };
-            Dictionary<string, string> item = GetItem(cacheId);
-            if (item == null)
+            Dictionary<string, Dictionary<string, string>> item = GetItem(cacheId);
+            item ??= new Dictionary<string, Dictionary<string, string>>();
+            if (!item.ContainsKey(serverUrl.Host))
             {
-                item = new Dictionary<string, string>
-                {
-                    { username, encryptedPassword }
-                };
+                item[serverUrl.Host] = new Dictionary<string, string>();
             }
-            else
-            {
-                item.Remove(username);
-                item.Add(username, encryptedPassword);
-            }
+            item[serverUrl.Host].Remove(username);
+            item[serverUrl.Host].Add(username, encryptedPassword);
             _cache.Set(cacheId, item, cacheItemPolicy);
         }
 
-        public Dictionary<string, string> GetItem(string cacheId)
+        public Dictionary<string, Dictionary<string, string>> GetItem(string cacheId)
         {
-            return _cache.Get(cacheId) as Dictionary<string, string>;
+            return _cache.Get(cacheId) as Dictionary<string, Dictionary<string, string>>;
+        }
+
+        public Dictionary<string, string> GetItem(string cacheId, Uri serverUrl)
+        {
+            if (_cache.Get(cacheId) is not Dictionary<string, Dictionary<string, string>> item)
+            {
+                return null;
+            }
+            return item.TryGetValue(serverUrl.Host, out Dictionary<string, string> value) ? value : null;
         }
 
         public long Count()
@@ -59,15 +64,9 @@ namespace WitsmlExplorer.Api.Services
             ((MemoryCache)_cache).Trim(100);
         }
 
-        public void RemoveAllClientCredentials(string clientId)
+        public void RemoveAllClientCredentials(string cacheId)
         {
-            foreach (KeyValuePair<string, object> item in _cache)
-            {
-                if (item.Key.StartsWith(clientId))
-                {
-                    _cache.Remove(item.Key);
-                }
-            }
+            _cache.Remove(cacheId);
         }
 
         public void LogCache()

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
 
+using Microsoft.AspNetCore.Http;
+
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.HttpHandlers;
 using WitsmlExplorer.Api.Middleware;
@@ -9,12 +11,12 @@ namespace WitsmlExplorer.Api.Services
 {
     public interface ICredentialsService
     {
-        public void RemoveCachedCredentials(string clientId);
+        public void RemoveCachedCredentials(string cacheId);
         public void VerifyUserIsLoggedIn(IEssentialHeaders eh, ServerType serverType);
         public Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri serverUrl);
         public string GetClaimFromToken(string token, string claim);
-        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, string clientId);
+        public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, HttpContext httpContext);
         public ServerCredentials GetCredentials(IEssentialHeaders eh, string server, string username);
-        public string GetClientId(IEssentialHeaders eh);
+        public string GetCacheId(IEssentialHeaders eh);
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
@@ -13,7 +13,6 @@ namespace WitsmlExplorer.Api.Tests.Services
     public class CredentialsCacheTests
     {
         private readonly CredentialsCache _credentialsCache;
-        private readonly Random _random = new();
 
         public CredentialsCacheTests()
         {
@@ -22,16 +21,15 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void RemoveAllClientCredentials_TwoOfThree_ReturnOne()
+        public void RemoveAllClientCredentials_OneOfTwo_ReturnOne()
         {
             string cacheId = Guid.NewGuid().ToString();
             string url = "https://somehost";
             string witsmlUsername = "user";
 
             _credentialsCache.Clear();
-            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem(Guid.NewGuid().ToString(), new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, new Uri($"{url}1.com"), "password1", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(Guid.NewGuid().ToString(), new Uri($"{url}2.com"), "password2", 1.0, witsmlUsername);
 
             long before = _credentialsCache.Count();
             _credentialsCache.RemoveAllClientCredentials(cacheId);
@@ -42,15 +40,14 @@ namespace WitsmlExplorer.Api.Tests.Services
         }
 
         [Fact]
-        public void Clear_SetThree_ReturnZero()
+        public void Clear_SetTwo_ReturnZero()
         {
             string cacheId = Guid.NewGuid().ToString();
             string url = "https://somehost";
             string witsmlUsername = "user";
 
-            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem(Guid.NewGuid().ToString(), new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, new Uri($"{url}1.com"), "password1", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(Guid.NewGuid().ToString(), new Uri($"{url}2.com"), "password2", 1.0, witsmlUsername);
 
             long before = _credentialsCache.Count();
             _credentialsCache.Clear();
@@ -65,8 +62,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             string cacheId = Guid.NewGuid().ToString();
             Uri url = new("https://somehost.com");
 
-            _credentialsCache.SetItem(cacheId, url, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, "user1");
-            _credentialsCache.SetItem(cacheId, url, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, "user2");
+            _credentialsCache.SetItem(cacheId, url, "password1", 1.0, "user1");
+            _credentialsCache.SetItem(cacheId, url, "password2", 1.0, "user2");
 
             Dictionary<string, Dictionary<string, string>> clientDictionary = _credentialsCache.GetItem(cacheId);
             Assert.Single(clientDictionary);
@@ -83,8 +80,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             Uri url2 = new("https://somehost2.com");
             string witsmlUsername = "user";
 
-            _credentialsCache.SetItem(cacheId, url, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem(cacheId, url2, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, url, "password1", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, url2, "password2", 1.0, witsmlUsername);
 
             Dictionary<string, Dictionary<string, string>> clientDictionary = _credentialsCache.GetItem(cacheId);
             Assert.Equal(2, clientDictionary.Count);

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using Microsoft.Extensions.Logging;
 
@@ -20,42 +21,97 @@ namespace WitsmlExplorer.Api.Tests.Services
             _credentialsCache = new CredentialsCache(logger.Object);
         }
 
-
         [Fact]
         public void RemoveAllClientCredentials_TwoOfThree_ReturnOne()
         {
-            string clientId = Guid.NewGuid().ToString();
+            string cacheId = Guid.NewGuid().ToString();
             string url = "https://somehost";
             string witsmlUsername = "user";
 
             _credentialsCache.Clear();
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(Guid.NewGuid().ToString(), new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
 
             long before = _credentialsCache.Count();
-            _credentialsCache.RemoveAllClientCredentials(clientId);
+            _credentialsCache.RemoveAllClientCredentials(cacheId);
             long after = _credentialsCache.Count();
-            Assert.Equal(3, before);
+            Assert.Equal(2, before);
             Assert.Equal(1, after);
             _credentialsCache.Clear();
         }
+
         [Fact]
         public void Clear_SetThree_ReturnZero()
         {
-            string clientId = Guid.NewGuid().ToString();
+            string cacheId = Guid.NewGuid().ToString();
             string url = "https://somehost";
             string witsmlUsername = "user";
 
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem($"{clientId}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
-            _credentialsCache.SetItem($"{Guid.NewGuid()}@{url}{_random.Next(1000)}.com", $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(Guid.NewGuid().ToString(), new Uri($"{url}{_random.Next(1000)}.com"), $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
 
             long before = _credentialsCache.Count();
             _credentialsCache.Clear();
             long after = _credentialsCache.Count();
-            Assert.Equal(3, before);
+            Assert.Equal(2, before);
             Assert.Equal(0, after);
+        }
+
+        [Fact]
+        public void SetItem_TwoForSameServer_OneDictionaryTwoValues()
+        {
+            string cacheId = Guid.NewGuid().ToString();
+            Uri url = new("https://somehost.com");
+
+            _credentialsCache.SetItem(cacheId, url, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, "user1");
+            _credentialsCache.SetItem(cacheId, url, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, "user2");
+
+            Dictionary<string, Dictionary<string, string>> clientDictionary = _credentialsCache.GetItem(cacheId);
+            Assert.Single(clientDictionary);
+            Dictionary<string, string> serverDictionary = _credentialsCache.GetItem(cacheId, url);
+            Assert.Equal(2, serverDictionary.Count);
+            _credentialsCache.Clear();
+        }
+
+        [Fact]
+        public void SetItem_TwoDifferentServers_TwoDictionaries()
+        {
+            string cacheId = Guid.NewGuid().ToString();
+            Uri url = new("https://somehost.com");
+            Uri url2 = new("https://somehost2.com");
+            string witsmlUsername = "user";
+
+            _credentialsCache.SetItem(cacheId, url, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, url2, $"DUMMY_VALUE{_random.Next(1000)}", 1.0, witsmlUsername);
+
+            Dictionary<string, Dictionary<string, string>> clientDictionary = _credentialsCache.GetItem(cacheId);
+            Assert.Equal(2, clientDictionary.Count);
+            Dictionary<string, string> server1Dictionary = _credentialsCache.GetItem(cacheId, url);
+            Assert.Single(server1Dictionary);
+            Dictionary<string, string> server2Dictionary = _credentialsCache.GetItem(cacheId, url2);
+            Assert.Single(server2Dictionary);
+            _credentialsCache.Clear();
+        }
+
+        [Fact]
+        public void SetItem_ReplaceExisting_OneDictionaryOneValue()
+        {
+            string cacheId = Guid.NewGuid().ToString();
+            Uri url = new("https://somehost.com");
+            string witsmlUsername = "user";
+            string replacement = "newpass";
+
+            _credentialsCache.SetItem(cacheId, url, "oldpass", 1.0, witsmlUsername);
+            _credentialsCache.SetItem(cacheId, url, replacement, 1.0, witsmlUsername);
+
+            Dictionary<string, Dictionary<string, string>> clientDictionary = _credentialsCache.GetItem(cacheId);
+            Assert.Single(clientDictionary);
+            Dictionary<string, string> serverDictionary = _credentialsCache.GetItem(cacheId, url);
+            Assert.Single(serverDictionary);
+            Assert.Equal(replacement, serverDictionary[witsmlUsername]);
+            _credentialsCache.Clear();
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -129,16 +129,16 @@ namespace WitsmlExplorer.Api.Tests.Services
         public void GetCredentials_CredentialsInCache_ReturnCorrectly()
         {
             string userId = "username";
-            string clientId = Guid.NewGuid().ToString();
+            string cacheId = Guid.NewGuid().ToString();
             ServerCredentials sc = new() { UserId = userId, Password = "dummypassword", Host = new Uri("https://somehost.url") };
             string b64Creds = Convert.ToBase64String(Encoding.ASCII.GetBytes(sc.UserId + ":" + sc.Password));
             string headerValue = b64Creds + "@" + sc.Host;
 
             Mock<IEssentialHeaders> headersMock = new();
-            headersMock.Setup(x => x.GetCookieValue()).Returns(clientId);
+            headersMock.Setup(x => x.GetCookieValue()).Returns(cacheId);
             headersMock.SetupGet(x => x.TargetServer).Returns(sc.Host.ToString());
 
-            _basicCredentialsService.CacheCredentials(clientId, sc, 1.0, n => n);
+            _basicCredentialsService.CacheCredentials(cacheId, sc, 1.0, n => n);
             ServerCredentials fromCache = _basicCredentialsService.GetCredentials(headersMock.Object, headersMock.Object.TargetServer, userId);
             Assert.Equal(sc, fromCache);
             _basicCredentialsService.RemoveAllCachedCredentials();


### PR DESCRIPTION
## Fixes
This pull request fixes WE-789

## Description
Store credentials in cache based on the following hierarchy:
cacheId -> Dictionary<serverUrl, Dictionary> -> Dictionary<WITSML username, WITSML password>.
Check whether a header cookie id already exists in cache before using it to store credentials.
Replace the name of clientId with cacheId for consistency.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests