### PR TITLE
WE-796 finish routing on login cancellation

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -70,6 +70,7 @@ const Routing = (): React.ReactElement => {
   } = navigationState;
   const router = useRouter();
   const [isSyncingUrlAndState, setIsSyncingUrlAndState] = useState<boolean>(true);
+  const [hasSelectedServer, setHasSelectedServer] = useState<boolean>(false);
   const [urlParams, setUrlParams] = useState<QueryParams>(null);
   const [currentQueryParams, setCurrentQueryParams] = useState<QueryParams>(null);
 
@@ -120,8 +121,14 @@ const Routing = (): React.ReactElement => {
       const serverUrl = urlParams.serverUrl;
       const server = servers.find((server: Server) => server.url === serverUrl);
       if (server && !selectedServer) {
-        const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server } };
-        dispatchNavigation(action);
+        if (hasSelectedServer) {
+          // finish syncing if we already attempted to select a server (such as on login cancellation)
+          setIsSyncingUrlAndState(false);
+        } else {
+          setHasSelectedServer(true);
+          const action: SelectServerAction = { type: NavigationType.SelectServer, payload: { server } };
+          dispatchNavigation(action);
+        }
       }
     }
   }, [servers, urlParams]);


### PR DESCRIPTION
## Fixes
This pull request fixes WE-796

## Description
Finish routing on login cancellation to fix an issue where it was impossible to cancel logging in when pasting a link containing a server url.

## Type of change

* Bugfix

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
