### PR TITLE
WE-756 Fix concurrent execution of cache tests

### DIFF
--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsCacheTests.cs
@@ -9,6 +9,7 @@ using WitsmlExplorer.Api.Services;
 using Xunit;
 namespace WitsmlExplorer.Api.Tests.Services
 {
+    [Collection("UsingCache")]
     public class CredentialsCacheTests
     {
         private readonly CredentialsCache _credentialsCache;

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -23,6 +23,7 @@ using WitsmlExplorer.Api.Services;
 using Xunit;
 namespace WitsmlExplorer.Api.Tests.Services
 {
+    [Collection("UsingCache")]
     public class CredentialsServiceTests
     {
         private readonly CredentialsService _basicCredentialsService;


### PR DESCRIPTION
## Fixes
This pull request fixes WE-756

## Description
Add [Collection("UsingCache")] to the two test classes that use the CredentialsCache in the hopes of avoiding concurrent test execution that causes cache tests to fail. Based on https://stackoverflow.com/questions/1408175/execute-unit-tests-serially-rather-than-in-parallel.

## Type of change

* Bugfix

## Impacted Areas in Application

* API Tests

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests