### PR TITLE
WE-794 Update mudLog and geologyInterval columns

### DIFF
--- a/Src/Witsml/Data/MudLog/WitsmlMudLog.cs
+++ b/Src/Witsml/Data/MudLog/WitsmlMudLog.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
+using Witsml.Data.Measures;
 using Witsml.Extensions;
 
 namespace Witsml.Data.MudLog
@@ -28,10 +29,10 @@ namespace Witsml.Data.MudLog
         public string MudLogEngineers { get; set; }
 
         [XmlElement("startMd")]
-        public WitsmlIndex StartMd { get; set; }
+        public WitsmlMeasureWithDatum StartMd { get; set; }
 
         [XmlElement("endMd")]
-        public WitsmlIndex EndMd { get; set; }
+        public WitsmlMeasureWithDatum EndMd { get; set; }
 
         [XmlElement("relatedLog")]
         public List<string> RelatedLog { get; set; }

--- a/Src/Witsml/Data/MudLog/WitsmlMudLogGeologyInterval.cs
+++ b/Src/Witsml/Data/MudLog/WitsmlMudLogGeologyInterval.cs
@@ -14,10 +14,10 @@ namespace Witsml.Data.MudLog
         public string TypeLithology { get; set; }
 
         [XmlElement("mdTop")]
-        public WitsmlIndex MdTop { get; set; }
+        public WitsmlMeasureWithDatum MdTop { get; set; }
 
         [XmlElement("mdBottom")]
-        public WitsmlIndex MdBottom { get; set; }
+        public WitsmlMeasureWithDatum MdBottom { get; set; }
 
         [XmlElement("dTim")]
         public string DTim { get; set; }

--- a/Src/WitsmlExplorer.Api/Models/CommonTime.cs
+++ b/Src/WitsmlExplorer.Api/Models/CommonTime.cs
@@ -1,13 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace WitsmlExplorer.Api.Models
 {
     public class CommonTime
     {
-        public DateTime? DTimCreation { get; set; }
-        public DateTime? DTimLastChange { get; set; }
+        public string DTimCreation { get; set; }
+        public string DTimLastChange { get; set; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/MudLog.cs
+++ b/Src/WitsmlExplorer.Api/Models/MudLog.cs
@@ -1,5 +1,6 @@
-using System;
 using System.Collections.Generic;
+
+using WitsmlExplorer.Api.Models.Measure;
 
 namespace WitsmlExplorer.Api.Models
 {
@@ -8,12 +9,9 @@ namespace WitsmlExplorer.Api.Models
         public bool ObjectGrowing { get; set; }
         public string MudLogCompany { get; set; }
         public string MudLogEngineers { get; set; }
-        public string StartMd { get; set; }
-        public string EndMd { get; set; }
-        public DateTime? DateTimeCreation { get; set; }
-        public DateTime? DateTimeLastChange { get; set; }
+        public MeasureWithDatum StartMd { get; set; }
+        public MeasureWithDatum EndMd { get; set; }
         public List<MudLogGeologyInterval> GeologyInterval { get; set; }
-        public string ItemState { get; internal set; }
         public CommonData CommonData { get; set; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/MudLogGeologyInterval.cs
+++ b/Src/WitsmlExplorer.Api/Models/MudLogGeologyInterval.cs
@@ -1,14 +1,27 @@
 using System.Collections.Generic;
 
+using WitsmlExplorer.Api.Models.Measure;
+
 namespace WitsmlExplorer.Api.Models
 {
     public class MudLogGeologyInterval
     {
         public string Uid { get; set; }
         public string TypeLithology { get; set; }
-        public string MdTop { get; set; }
-        public string MdBottom { get; set; }
+        public MeasureWithDatum MdTop { get; set; }
+        public MeasureWithDatum MdBottom { get; set; }
+        public MeasureWithDatum TvdTop { get; set; }
+        public MeasureWithDatum TvdBase { get; set; }
+        public LengthMeasure RopAv { get; set; }
+        public LengthMeasure WobAv { get; set; }
+        public LengthMeasure TqAv { get; set; }
+        public LengthMeasure CurrentAv { get; set; }
+        public LengthMeasure RpmAv { get; set; }
+        public LengthMeasure WtMudAv { get; set; }
+        public LengthMeasure EcdTdAv { get; set; }
+        public string DxcAv { get; set; }
         public List<MudLogLithology> Lithologies { get; set; }
+        public string Description { get; set; }
         public CommonTime CommonTime { get; set; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Query/MudLogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/MudLogQueries.cs
@@ -2,10 +2,12 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Witsml.Data;
+using Witsml.Data.Measures;
 using Witsml.Data.MudLog;
 using Witsml.Extensions;
 
 using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Models.Measure;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Query
@@ -22,8 +24,8 @@ namespace WitsmlExplorer.Api.Query
                     UidWell = wellUid,
                     UidWellbore = wellboreUid,
                     Name = "",
-                    StartMd = new WitsmlIndex(),
-                    EndMd = new WitsmlIndex(),
+                    StartMd = MeasureWithDatum.ToEmptyWitsml<WitsmlMeasureWithDatum>(),
+                    EndMd = MeasureWithDatum.ToEmptyWitsml<WitsmlMeasureWithDatum>(),
                     CommonData = new WitsmlCommonData()
                 }.AsSingletonList()
             };
@@ -48,8 +50,8 @@ namespace WitsmlExplorer.Api.Query
             {
                 Uid = geologyInterval.Uid,
                 TypeLithology = geologyInterval.TypeLithology,
-                MdTop = new WitsmlIndex { Uom = "m", Value = geologyInterval.MdTop },
-                MdBottom = new WitsmlIndex { Uom = "m", Value = geologyInterval.MdBottom },
+                MdTop = geologyInterval.MdTop.ToWitsml<WitsmlMeasureWithDatum>(),
+                MdBottom = geologyInterval.MdBottom.ToWitsml<WitsmlMeasureWithDatum>(),
                 Lithologies = geologyInterval.Lithologies?.Select(l => new WitsmlMudLogLithology()
                 {
                     Uid = l.Uid,
@@ -59,8 +61,8 @@ namespace WitsmlExplorer.Api.Query
                 }).ToList(),
                 CommonTime = new WitsmlCommonTime
                 {
-                    DTimCreation = geologyInterval.CommonTime.DTimCreation?.ToString("yyyy-MM-ddTHH:mm:ssK.fffZ"),
-                    DTimLastChange = geologyInterval.CommonTime.DTimLastChange?.ToString("yyyy-MM-ddTHH:mm:ssK.fffZ")
+                    DTimCreation = geologyInterval.CommonTime.DTimCreation,
+                    DTimLastChange = geologyInterval.CommonTime.DTimLastChange
                 },
             }).ToList();
 
@@ -77,8 +79,8 @@ namespace WitsmlExplorer.Api.Query
                     ObjectGrowing = StringHelpers.OptionalBooleanToString(mudLog.ObjectGrowing),
                     MudLogCompany = mudLog.MudLogCompany,
                     MudLogEngineers = mudLog.MudLogEngineers,
-                    StartMd = new WitsmlIndex { Uom = "m", Value = mudLog.StartMd },
-                    EndMd = new WitsmlIndex { Uom = "m", Value = mudLog.EndMd },
+                    StartMd = mudLog.StartMd.ToWitsml<WitsmlMeasureWithDatum>(),
+                    EndMd = mudLog.EndMd.ToWitsml<WitsmlMeasureWithDatum>(),
                     GeologyInterval = geologyIntervals,
                     CommonData = new WitsmlCommonData
                     {

--- a/Src/WitsmlExplorer.Api/Services/MudLogService.cs
+++ b/Src/WitsmlExplorer.Api/Services/MudLogService.cs
@@ -6,6 +6,7 @@ using Witsml.Data.MudLog;
 using Witsml.ServiceReference;
 
 using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Models.Measure;
 using WitsmlExplorer.Api.Query;
 
 namespace WitsmlExplorer.Api.Services
@@ -25,20 +26,7 @@ namespace WitsmlExplorer.Api.Services
             WitsmlMudLogs query = MudLogQueries.QueryByWellbore(wellUid, wellboreUid);
             WitsmlMudLogs result = await _witsmlClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.HeaderOnly));
 
-            return result.MudLogs.Select(mudLog =>
-                new MudLog
-                {
-                    Uid = mudLog.Uid,
-                    Name = mudLog.Name,
-                    WellUid = mudLog.UidWell,
-                    WellName = mudLog.NameWell,
-                    WellboreUid = mudLog.UidWellbore,
-                    WellboreName = mudLog.NameWellbore,
-                    StartMd = mudLog.StartMd?.Value,
-                    EndMd = mudLog.EndMd?.Value,
-                    ItemState = mudLog.CommonData.ItemState,
-                    DateTimeCreation = StringHelpers.ToDateTime(mudLog.CommonData.DTimCreation),
-                }).OrderBy(mudLog => mudLog.Name);
+            return result.MudLogs.Select(FromWitsml).OrderBy(mudLog => mudLog.Name);
         }
 
         public async Task<MudLog> GetMudLog(string wellUid, string wellboreUid, string mudlogUid)
@@ -52,20 +40,8 @@ namespace WitsmlExplorer.Api.Services
                 return null;
             }
 
-            MudLog mudlog = new()
-            {
-                Uid = witsmlMudLog.Uid,
-                Name = witsmlMudLog.Name,
-                WellUid = witsmlMudLog.UidWell,
-                WellName = witsmlMudLog.NameWell,
-                WellboreUid = witsmlMudLog.UidWellbore,
-                WellboreName = witsmlMudLog.NameWellbore,
-                StartMd = witsmlMudLog.StartMd?.Value,
-                EndMd = witsmlMudLog.EndMd?.Value,
-                GeologyInterval = GetGeologyIntervals(witsmlMudLog.GeologyInterval),
-                ItemState = witsmlMudLog.CommonData.ItemState,
-                DateTimeCreation = StringHelpers.ToDateTime(witsmlMudLog.CommonData.DTimCreation),
-            };
+            MudLog mudlog = FromWitsml(witsmlMudLog);
+            mudlog.GeologyInterval = GetGeologyIntervals(witsmlMudLog.GeologyInterval);
             return mudlog;
         }
 
@@ -76,8 +52,18 @@ namespace WitsmlExplorer.Api.Services
                 {
                     Uid = geologyInterval.Uid,
                     TypeLithology = geologyInterval.TypeLithology,
-                    MdTop = geologyInterval.MdTop?.Value,
-                    MdBottom = geologyInterval.MdBottom?.Value,
+                    MdTop = MeasureWithDatum.FromWitsml(geologyInterval.MdTop),
+                    MdBottom = MeasureWithDatum.FromWitsml(geologyInterval.MdBottom),
+                    TvdTop = MeasureWithDatum.FromWitsml(geologyInterval.TvdTop),
+                    TvdBase = MeasureWithDatum.FromWitsml(geologyInterval.TvdBase),
+                    RopAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    WobAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    TqAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    CurrentAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    RpmAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    WtMudAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    EcdTdAv = LengthMeasure.FromWitsml(geologyInterval.RopAv),
+                    DxcAv = geologyInterval.DxcAv,
                     Lithologies = geologyInterval.Lithologies?.Select(l => new MudLogLithology()
                     {
                         Uid = l.Uid,
@@ -85,12 +71,37 @@ namespace WitsmlExplorer.Api.Services
                         LithPc = l.LithPc?.Value,
                         Type = l.Type
                     }).ToList(),
+                    Description = geologyInterval.Description,
                     CommonTime = new CommonTime
                     {
-                        DTimCreation = StringHelpers.ToDateTime(geologyInterval.CommonTime.DTimCreation),
-                        DTimLastChange = StringHelpers.ToDateTime(geologyInterval.CommonTime.DTimLastChange)
+                        DTimCreation = geologyInterval.CommonTime.DTimCreation,
+                        DTimLastChange = geologyInterval.CommonTime.DTimLastChange
                     }
                 }).ToList();
+        }
+
+        private static MudLog FromWitsml(WitsmlMudLog witsmlMudLog)
+        {
+            return new()
+            {
+                Uid = witsmlMudLog.Uid,
+                Name = witsmlMudLog.Name,
+                WellUid = witsmlMudLog.UidWell,
+                WellName = witsmlMudLog.NameWell,
+                WellboreUid = witsmlMudLog.UidWellbore,
+                WellboreName = witsmlMudLog.NameWellbore,
+                MudLogCompany = witsmlMudLog.MudLogCompany,
+                MudLogEngineers = witsmlMudLog.MudLogEngineers,
+                StartMd = MeasureWithDatum.FromWitsml(witsmlMudLog.StartMd),
+                EndMd = MeasureWithDatum.FromWitsml(witsmlMudLog.EndMd),
+                GeologyInterval = GetGeologyIntervals(witsmlMudLog.GeologyInterval),
+                CommonData = new CommonData()
+                {
+                    DTimCreation = witsmlMudLog.CommonData.DTimCreation,
+                    DTimLastChange = witsmlMudLog.CommonData.DTimLastChange,
+                    ItemState = witsmlMudLog.CommonData.ItemState,
+                }
+            };
         }
     }
 }

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
@@ -1,10 +1,25 @@
 import React, { useContext, useEffect, useState } from "react";
 import NavigationContext from "../../contexts/navigationContext";
 import GeologyInterval from "../../models/geologyInterval";
+import { measureToString } from "../../models/measure";
 import MudLogService from "../../services/mudLogService";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 
 export interface GeologyIntervalRow extends ContentTableRow {
+  typeLithology: string;
+  description: string;
+  mdTop: string;
+  mdBottom: string;
+  tvdTop: string;
+  tvdBase: string;
+  ropAv: string;
+  wobAv: string;
+  tqAv: string;
+  currentAv: string;
+  rpmAv: string;
+  wtMudAv: string;
+  ecdTdAv: string;
+  dxcAv: string;
   uid: string;
 }
 
@@ -32,11 +47,41 @@ export const MudLogView = (): React.ReactElement => {
     }
   }, [selectedMudLog]);
 
-  const columns: ContentTableColumn[] = [{ property: "uid", label: "uid", type: ContentType.String }];
+  const columns: ContentTableColumn[] = [
+    { property: "typeLithology", label: "typeLithology", type: ContentType.String },
+    { property: "description", label: "description", type: ContentType.String },
+    { property: "mdTop", label: "mdTop", type: ContentType.String },
+    { property: "mdBottom", label: "mdBottom", type: ContentType.String },
+    { property: "tvdTop", label: "tvdTop", type: ContentType.String },
+    { property: "tvdBase", label: "tvdBase", type: ContentType.String },
+    { property: "ropAv", label: "ropAv", type: ContentType.String },
+    { property: "wobAv", label: "wobAv", type: ContentType.String },
+    { property: "tqAv", label: "tqAv", type: ContentType.String },
+    { property: "currentAv", label: "currentAv", type: ContentType.String },
+    { property: "rpmAv", label: "rpmAv", type: ContentType.String },
+    { property: "wtMudAv", label: "wtMudAv", type: ContentType.String },
+    { property: "ecdTdAv", label: "ecdTdAv", type: ContentType.String },
+    { property: "dxcAv", label: "dxcAv", type: ContentType.String },
+    { property: "uid", label: "uid", type: ContentType.String }
+  ];
 
-  const geologyIntervalRows = geologyIntervals.map((geologyInterval) => {
+  const geologyIntervalRows: GeologyIntervalRow[] = geologyIntervals.map((geologyInterval, index) => {
     return {
-      id: geologyInterval.uid,
+      id: index,
+      typeLithology: geologyInterval.typeLithology,
+      description: geologyInterval.description,
+      mdTop: measureToString(geologyInterval.mdTop),
+      mdBottom: measureToString(geologyInterval.mdBottom),
+      tvdTop: measureToString(geologyInterval.tvdTop),
+      tvdBase: measureToString(geologyInterval.tvdBase),
+      ropAv: measureToString(geologyInterval.ropAv),
+      wobAv: measureToString(geologyInterval.wobAv),
+      tqAv: measureToString(geologyInterval.tqAv),
+      currentAv: measureToString(geologyInterval.currentAv),
+      rpmAv: measureToString(geologyInterval.rpmAv),
+      wtMudAv: measureToString(geologyInterval.wtMudAv),
+      ecdTdAv: measureToString(geologyInterval.ecdTdAv),
+      dxcAv: geologyInterval.dxcAv,
       uid: geologyInterval.uid
     };
   });

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
@@ -1,17 +1,29 @@
 import React, { useContext, useEffect, useState } from "react";
 import NavigationContext from "../../contexts/navigationContext";
 import NavigationType from "../../contexts/navigationType";
+import OperationContext from "../../contexts/operationContext";
+import { measureToString } from "../../models/measure";
 import MudLog from "../../models/mudLog";
+import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 
 export interface MudLogRow extends ContentTableRow {
   mudLog: MudLog;
   name: string;
+  mudLogCompany: string;
+  mudLogEngineers: string;
+  startMd: string;
+  endMd: string;
+  dTimCreation: string;
+  dTimLastChange: string;
   uid: string;
 }
 
 export const MudLogsListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
 
   const { selectedWell, selectedWellbore, selectedMudLogGroup } = navigationState;
   const [mudLogs, setMudLogs] = useState<MudLog[]>([]);
@@ -34,6 +46,12 @@ export const MudLogsListView = (): React.ReactElement => {
       return {
         id: index,
         name: mudLog.name,
+        mudLogCompany: mudLog.mudLogCompany,
+        mudLogEngineers: mudLog.mudLogEngineers,
+        startMd: measureToString(mudLog.startMd),
+        endMd: measureToString(mudLog.endMd),
+        dTimCreation: formatDateString(mudLog.commonData.dTimCreation, timeZone),
+        dTimLastChange: formatDateString(mudLog.commonData.dTimLastChange, timeZone),
         uid: mudLog.uid,
         mudLog
       };
@@ -42,6 +60,12 @@ export const MudLogsListView = (): React.ReactElement => {
 
   const columns: ContentTableColumn[] = [
     { property: "name", label: "name", type: ContentType.String },
+    { property: "mudLogCompany", label: "mudLogCompany", type: ContentType.String },
+    { property: "mudLogEngineers", label: "mudLogEngineers", type: ContentType.String },
+    { property: "startMd", label: "startMd", type: ContentType.String },
+    { property: "endMd", label: "endMd", type: ContentType.String },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime },
     { property: "uid", label: "uid", type: ContentType.String }
   ];
 

--- a/Src/WitsmlExplorer.Frontend/models/geologyInterval.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/geologyInterval.tsx
@@ -1,3 +1,20 @@
+import Measure from "./measure";
+import MeasureWithDatum from "./measureWithDatum";
+
 export default interface GeologyInterval {
   uid: string;
+  typeLithology: string;
+  mdTop: MeasureWithDatum;
+  mdBottom: MeasureWithDatum;
+  tvdTop: MeasureWithDatum;
+  tvdBase: MeasureWithDatum;
+  ropAv: Measure;
+  wobAv: Measure;
+  tqAv: Measure;
+  currentAv: Measure;
+  rpmAv: Measure;
+  wtMudAv: Measure;
+  ecdTdAv: Measure;
+  dxcAv: string;
+  description: string;
 }

--- a/Src/WitsmlExplorer.Frontend/models/mudLog.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/mudLog.tsx
@@ -1,11 +1,22 @@
+import CommonData, { emptyCommonData } from "./commonData";
+import MeasureWithDatum from "./measureWithDatum";
 import ObjectOnWellbore, { emptyObjectOnWellbore } from "./objectOnWellbore";
 
-// This is disabled because more attributes will be included later
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export default interface MudLog extends ObjectOnWellbore {}
+export default interface MudLog extends ObjectOnWellbore {
+  mudLogCompany: string;
+  mudLogEngineers: string;
+  startMd: MeasureWithDatum;
+  endMd: MeasureWithDatum;
+  commonData: CommonData;
+}
 
 export function emptyMudLog(): MudLog {
   return {
-    ...emptyObjectOnWellbore()
+    ...emptyObjectOnWellbore(),
+    mudLogCompany: "",
+    mudLogEngineers: "",
+    startMd: null,
+    endMd: null,
+    commonData: emptyCommonData()
   };
 }


### PR DESCRIPTION
## Fixes
This pull request fixes WE-794

## Description
 Update mudLog and geologyInterval columns.
 Update mudLog and geologyInterval models:
- Replace types of StartMd and EndMd to (Witsml)MeasureWithDatum as previous types were insufficient.
- Remove DateTimeCreation, DateTimeLastChange, and ItemState from MudLog as they already exist in CommonData
- Replace DateTime in CommonTime with string to avoid inaccurent dateTime conversions
- Replace types of MdTop and MdBottomto (Witsml)MeasureWithDatum as previous types were insufficient.
Refactor duplicated MudLog FromWitsml(WitsmlMudLog witsmlMudLog) functionality.

## Type of change

* New feature (non-breaking change which adds functionality)
* Enhancement of existing functionality

## Impacted Areas in Application

* WITSML, API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
