### PR TITLE
WE-743 add refresh button to jobs view

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -1,5 +1,6 @@
-import { Switch } from "@equinor/eds-core-react";
+import { Button, Icon, Switch, Typography } from "@equinor/eds-core-react";
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import styled from "styled-components";
 import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
@@ -22,6 +23,7 @@ export const JobsView = (): React.ReactElement => {
   } = useContext(OperationContext);
   const { servers, selectedServer } = navigationState;
   const [jobInfos, setJobInfos] = useState<JobInfo[]>([]);
+  const [lastFetched, setLastFetched] = useState<string>(new Date().toLocaleTimeString());
   const [shouldRefresh, setShouldRefresh] = useState<boolean>(true);
   const [showAll, setShowAll] = useState(false);
 
@@ -30,6 +32,7 @@ export const JobsView = (): React.ReactElement => {
     const getJobInfos = async () => {
       const jobInfos = showAll ? JobService.getAllJobInfos(abortController.signal) : JobService.getUserJobInfos(abortController.signal);
       setJobInfos(await jobInfos);
+      setLastFetched(new Date().toLocaleTimeString());
     };
 
     getJobInfos();
@@ -107,14 +110,27 @@ export const JobsView = (): React.ReactElement => {
 
   return (
     <>
-      {msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) && (
-        <Switch
-          label="Show all users' jobs"
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            setShowAll(e.target.checked);
-          }}
-        />
-      )}
+      <Panel>
+        {msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) && (
+          <Switch
+            label="Show all users' jobs"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setShowAll(e.target.checked);
+            }}
+          />
+        )}
+        <Button
+          variant="outlined"
+          aria-disabled={shouldRefresh ? true : false}
+          aria-label={shouldRefresh ? "loading data" : null}
+          onClick={shouldRefresh ? undefined : () => setShouldRefresh(true)}
+          disabled={shouldRefresh}
+        >
+          <Icon name="refresh" />
+          Refresh
+        </Button>
+        <Typography>Last fetched: {lastFetched}</Typography>
+      </Panel>
       <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} />
     </>
   );
@@ -127,5 +143,11 @@ const serverUrlToName = (servers: Server[], url: string): string => {
   const server = servers.find((server) => server.url == url);
   return server ? server.name : url;
 };
+
+const Panel = styled.div`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+`;
 
 export default JobsView;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -111,14 +111,6 @@ export const JobsView = (): React.ReactElement => {
   return (
     <>
       <Panel>
-        {msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) && (
-          <Switch
-            label="Show all users' jobs"
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              setShowAll(e.target.checked);
-            }}
-          />
-        )}
         <Button
           variant="outlined"
           aria-disabled={shouldRefresh ? true : false}
@@ -129,6 +121,14 @@ export const JobsView = (): React.ReactElement => {
           <Icon name="refresh" />
           Refresh
         </Button>
+        {msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) && (
+          <Switch
+            label="Show all users' jobs"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setShowAll(e.target.checked);
+            }}
+          />
+        )}
         <Typography>Last fetched: {lastFetched}</Typography>
       </Panel>
       <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} />


### PR DESCRIPTION
## Fixes
This pull request fixes WE-743

## Description
Add refresh button and show the last timestamp jobs were fetched in JobsView
![image](https://user-images.githubusercontent.com/66632214/218783862-72165161-9968-4c17-8ff8-9d8863a1e5db.png)


## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
