### PR TITLE
WE-813 fix well name filter not set on routing

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/SearchFilter.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/SearchFilter.tsx
@@ -14,7 +14,7 @@ const SearchFilter = (): React.ReactElement => {
   const { selectedFilter } = navigationState;
   const [filter, setFilter] = useState<Filter>(EMPTY_FILTER);
   const [expanded, setExpanded] = useState<boolean>(false);
-  const [wellNameFilter, setWellNameFilter] = useState<string>(filter.wellName);
+  const [wellNameFilter, setWellNameFilter] = useState<string>(selectedFilter.wellName);
   const FilterPopup: CSSProp = { zIndex: 10, position: "absolute", width: "inherit", top: "6rem", minWidth: "174px", paddingRight: "0.1em" };
   useEffect(() => {
     setFilter(selectedFilter);
@@ -26,6 +26,12 @@ const SearchFilter = (): React.ReactElement => {
     }, 400);
     return () => clearTimeout(dispatch);
   }, [wellNameFilter]);
+
+  useEffect(() => {
+    if (wellNameFilter === "") {
+      setWellNameFilter(selectedFilter.wellName);
+    }
+  }, [selectedFilter.wellName]);
 
   return (
     <>


### PR DESCRIPTION
## Fixes
This pull request fixes WE-813

## Description
Fix well name filter not being set in the search bar when pasting a link that navigates to a well.

## Type of change

* Bugfix
* 
## Impacted Areas in Application

* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
