### PR TITLE
WE-797 refactor RefreshAction

### DIFF
--- a/Src/WitsmlExplorer.Api/Models/EntityType.cs
+++ b/Src/WitsmlExplorer.Api/Models/EntityType.cs
@@ -7,18 +7,14 @@ namespace WitsmlExplorer.Api.Models
     {
         Well,
         Wellbore,
-        BhaRuns,
+        BhaRun,
         LogObject,
-        LogObjects,
-        Messages,
-        MudLogs,
-        Rigs,
-        Risks,
+        Message,
+        MudLog,
+        Rig,
+        Risk,
         Tubular,
-        Tubulars,
-        Trajectories,
         Trajectory,
         WbGeometry,
-        WbGeometries,
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/EntityType.cs
+++ b/Src/WitsmlExplorer.Api/Models/EntityType.cs
@@ -10,15 +10,15 @@ namespace WitsmlExplorer.Api.Models
         BhaRuns,
         LogObject,
         LogObjects,
-        MessageObjects,
+        Messages,
         MudLogs,
         Rigs,
         Risks,
         Tubular,
+        Tubulars,
         Trajectories,
         Trajectory,
-        TrajectoryStation,
         WbGeometry,
-        WbGeometryObjects,
+        WbGeometries,
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/RefreshAction.cs
+++ b/Src/WitsmlExplorer.Api/Models/RefreshAction.cs
@@ -14,25 +14,25 @@ namespace WitsmlExplorer.Api.Models
 
     public abstract class RefreshAction
     {
-        protected RefreshAction(Uri serverUrl)
+        protected RefreshAction(Uri serverUrl, RefreshType refreshType)
         {
             ServerUrl = serverUrl;
+            RefreshType = refreshType;
         }
 
         public abstract EntityType EntityType { get; }
         public Uri ServerUrl { get; }
+        public RefreshType RefreshType { get; }
     }
 
     public class RefreshWell : RefreshAction
     {
         public override EntityType EntityType => EntityType.Well;
         public string WellUid { get; }
-        public RefreshType RefreshType { get; }
 
-        public RefreshWell(Uri serverUrl, string wellUid, RefreshType refreshType) : base(serverUrl)
+        public RefreshWell(Uri serverUrl, string wellUid, RefreshType refreshType) : base(serverUrl, refreshType)
         {
             WellUid = wellUid;
-            RefreshType = refreshType;
         }
     }
 
@@ -40,12 +40,10 @@ namespace WitsmlExplorer.Api.Models
     {
         public override EntityType EntityType => EntityType.Well;
         public string[] WellUids { get; }
-        public RefreshType RefreshType { get; }
 
-        public RefreshWells(Uri serverUrl, string[] wellUids, RefreshType refreshType) : base(serverUrl)
+        public RefreshWells(Uri serverUrl, string[] wellUids, RefreshType refreshType) : base(serverUrl, refreshType)
         {
             WellUids = wellUids;
-            RefreshType = refreshType;
         }
     }
 
@@ -54,205 +52,36 @@ namespace WitsmlExplorer.Api.Models
         public override EntityType EntityType => EntityType.Wellbore;
         public string WellUid { get; }
         public string WellboreUid { get; }
-        public RefreshType RefreshType { get; }
 
-        public RefreshWellbore(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
+        public RefreshWellbore(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl, refreshType)
         {
             WellUid = wellUid;
             WellboreUid = wellboreUid;
-            RefreshType = refreshType;
         }
     }
 
-    public class RefreshBhaRuns : RefreshAction
+    public class RefreshObjects : RefreshAction
     {
-        public override EntityType EntityType => EntityType.BhaRuns;
+        private readonly EntityType _entityType;
+        public override EntityType EntityType => _entityType;
         public string WellUid { get; }
         public string WellboreUid { get; }
+        public string ObjectUid { get; }
 
-        public RefreshType RefreshType { get; }
-
-        public RefreshBhaRuns(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
+        public RefreshObjects(Uri serverUrl, string wellUid, string wellboreUid, EntityType entityType) : base(serverUrl, RefreshType.Update)
         {
             WellUid = wellUid;
             WellboreUid = wellboreUid;
-            RefreshType = refreshType;
+            _entityType = entityType;
         }
-    }
 
-    public class RefreshLogObject : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.LogObject;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public string LogObjectUid { get; }
-
-        public RefreshType RefreshType { get; }
-
-        public RefreshLogObject(Uri serverUrl, string wellUid, string wellboreUid, string logObjectUid, RefreshType refreshType) : base(serverUrl)
+        public RefreshObjects(Uri serverUrl, string wellUid, string wellboreUid, string objectUid, EntityType entityType) : base(serverUrl, RefreshType.Update)
         {
             WellUid = wellUid;
             WellboreUid = wellboreUid;
-            LogObjectUid = logObjectUid;
-            RefreshType = refreshType;
+            _entityType = entityType;
+            ObjectUid = objectUid;
         }
     }
 
-    public class RefreshLogObjects : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.LogObjects;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public RefreshType RefreshType { get; }
-
-        public RefreshLogObjects(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshMessageObjects : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.MessageObjects;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-
-        public RefreshType RefreshType { get; }
-
-        public RefreshMessageObjects(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshMudLogs : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.MudLogs;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public RefreshType RefreshType { get; }
-
-        public RefreshMudLogs(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshRigs : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.Rigs;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-
-        public RefreshType RefreshType { get; }
-
-        public RefreshRigs(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-    public class RefreshRisks : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.Risks;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-
-        public RefreshType RefreshType { get; }
-
-        public RefreshRisks(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshTubulars : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.Tubular;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public RefreshType RefreshType { get; }
-
-        public RefreshTubulars(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshTrajectory : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.Trajectory;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public string TrajectoryUid { get; }
-        public RefreshType RefreshType { get; }
-
-        public RefreshTrajectory(Uri serverUrl, string wellUid, string wellboreUid, string trajectoryUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            TrajectoryUid = trajectoryUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshTrajectories : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.Trajectories;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public RefreshType RefreshType { get; }
-
-        public RefreshTrajectories(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshWbGeometry : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.WbGeometry;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-        public string WbGeometryUid { get; }
-
-        public RefreshType RefreshType { get; }
-
-        public RefreshWbGeometry(Uri serverUrl, string wellUid, string wellboreUid, string wbGeometryUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            WbGeometryUid = wbGeometryUid;
-            RefreshType = refreshType;
-        }
-    }
-
-    public class RefreshWbGeometryObjects : RefreshAction
-    {
-        public override EntityType EntityType => EntityType.WbGeometryObjects;
-        public string WellUid { get; }
-        public string WellboreUid { get; }
-
-        public RefreshType RefreshType { get; }
-
-        public RefreshWbGeometryObjects(Uri serverUrl, string wellUid, string wellboreUid, RefreshType refreshType) : base(serverUrl)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            RefreshType = refreshType;
-        }
-    }
 }

--- a/Src/WitsmlExplorer.Api/Models/RefreshAction.cs
+++ b/Src/WitsmlExplorer.Api/Models/RefreshAction.cs
@@ -68,14 +68,7 @@ namespace WitsmlExplorer.Api.Models
         public string WellboreUid { get; }
         public string ObjectUid { get; }
 
-        public RefreshObjects(Uri serverUrl, string wellUid, string wellboreUid, EntityType entityType) : base(serverUrl, RefreshType.Update)
-        {
-            WellUid = wellUid;
-            WellboreUid = wellboreUid;
-            _entityType = entityType;
-        }
-
-        public RefreshObjects(Uri serverUrl, string wellUid, string wellboreUid, string objectUid, EntityType entityType) : base(serverUrl, RefreshType.Update)
+        public RefreshObjects(Uri serverUrl, string wellUid, string wellboreUid, EntityType entityType, string objectUid = null) : base(serverUrl, RefreshType.Update)
         {
             WellUid = wellUid;
             WellboreUid = wellboreUid;

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyBhaRunWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyBhaRunWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlBhaRuns bhaRuns, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlBhaRun> queries = BhaRunQueries.CopyWitsmlBhaRuns(bhaRuns, targetWellbore);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.BhaRuns);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.BhaRun);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyBhaRunWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyBhaRunWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlBhaRuns bhaRuns, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlBhaRun> queries = BhaRunQueries.CopyWitsmlBhaRuns(bhaRuns, targetWellbore);
-            RefreshBhaRuns refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.BhaRuns);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -73,7 +73,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             int totalRowsCopied = copyResultForExistingMnemonics.NumberOfRowsCopied + copyResultForNewMnemonics.NumberOfRowsCopied;
             Logger.LogInformation("{JobType} - Job successful. {Count} rows copied. {Description}", GetType().Name, totalRowsCopied, job.Description());
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"{totalRowsCopied} rows copied");
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.LogObject);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.LogObject, job.Target.Uid);
             return (workerResult, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -73,7 +73,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             int totalRowsCopied = copyResultForExistingMnemonics.NumberOfRowsCopied + copyResultForNewMnemonics.NumberOfRowsCopied;
             Logger.LogInformation("{JobType} - Job successful. {Count} rows copied. {Description}", GetType().Name, totalRowsCopied, job.Description());
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"{totalRowsCopied} rows copied");
-            RefreshLogObject refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.LogObject);
             return (workerResult, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
@@ -72,7 +72,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.LogObjects);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.LogObject);
             string copiedLogsMessage = (sourceLogs.Length == 1 ? $"Copied log object {sourceLogs[0].Name}" : $"Copied {sourceLogs.Length} logs") + $" to: {targetWellbore.Name}";
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, copiedLogsMessage);
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogWorker.cs
@@ -72,7 +72,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshLogObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.LogObjects);
             string copiedLogsMessage = (sourceLogs.Length == 1 ? $"Copied log object {sourceLogs[0].Name}" : $"Copied {sourceLogs.Length} logs") + $" to: {targetWellbore.Name}";
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, copiedLogsMessage);
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyMudLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyMudLogWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlMudLogs mudlogs, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlMudLog> queries = MudLogQueries.CopyWitsmlMudLogs(mudlogs, targetWellbore);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.MudLogs);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.MudLog);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyMudLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyMudLogWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlMudLogs mudlogs, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlMudLog> queries = MudLogQueries.CopyWitsmlMudLogs(mudlogs, targetWellbore);
-            RefreshMudLogs refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.MudLogs);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyRigWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyRigWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlRigs rigs, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlRig> queries = RigQueries.CopyWitsmlRigs(rigs, targetWellbore);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Rigs);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Rig);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyRigWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyRigWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlRigs rigs, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlRig> queries = RigQueries.CopyWitsmlRigs(rigs, targetWellbore);
-            RefreshRigs refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Rigs);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyRiskWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlRisks risks, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlRisk> queries = RiskQueries.CopyWitsmlRisks(risks, targetWellbore);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Risks);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Risk);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyRiskWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlRisks risks, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlRisk> queries = RiskQueries.CopyWitsmlRisks(risks, targetWellbore);
-            RefreshRisks refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Risks);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
@@ -45,7 +45,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshTrajectory refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.Trajectory);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TrajectoryStations {trajectoryStationsString} copied to: {targetTrajectory.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryStationsWorker.cs
@@ -45,7 +45,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.Trajectory);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Trajectory, job.Target.Uid);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TrajectoryStations {trajectoryStationsString} copied to: {targetTrajectory.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryWorker.cs
@@ -31,7 +31,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlTrajectories trajectories, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlTrajectory> queries = TrajectoryQueries.CopyWitsmlTrajectories(trajectories, targetWellbore);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Trajectories);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Trajectory);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTrajectoryWorker.cs
@@ -31,7 +31,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlTrajectories trajectories, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlTrajectory> queries = TrajectoryQueries.CopyWitsmlTrajectories(trajectories, targetWellbore);
-            RefreshTrajectories refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Trajectories);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularComponentsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularComponentsWorker.cs
@@ -46,7 +46,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshTubulars refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.Tubular);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TubularComponents {tubularComponentsString} copied to: {targetTubular.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularComponentsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularComponentsWorker.cs
@@ -46,7 +46,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.Tubular);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Tubular, job.Target.Uid);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TubularComponents {tubularComponentsString} copied to: {targetTubular.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlTubulars tubulars, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlTubular> queries = TubularQueries.CopyWitsmlTubulars(tubulars, targetWellbore);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Tubulars);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Tubular);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyTubularWorker.cs
@@ -32,7 +32,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
         {
             (WitsmlTubulars tubulars, WitsmlWellbore targetWellbore) = await FetchData(job);
             IEnumerable<WitsmlTubular> queries = TubularQueries.CopyWitsmlTubulars(tubulars, targetWellbore);
-            RefreshTubulars refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.Tubulars);
             return await _copyUtils.CopyObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyWbGeometrySectionsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyWbGeometrySectionsWorker.cs
@@ -54,7 +54,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshWbGeometry refreshAction = new(witsmlClient.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, RefreshType.Update);
+            RefreshObjects refreshAction = new(witsmlClient.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.WbGeometry);
             WorkerResult workerResult = new(witsmlClient.GetServerHostname(), true, $"WbGeometrySections {wbGeometrySectionsString} copied to: {targetWbGeometry.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyWbGeometrySectionsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyWbGeometrySectionsWorker.cs
@@ -54,7 +54,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
 
             Logger.LogInformation("{JobType} - Job successful. {Description}", GetType().Name, job.Description());
-            RefreshObjects refreshAction = new(witsmlClient.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Target.Uid, EntityType.WbGeometry);
+            RefreshObjects refreshAction = new(witsmlClient.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, EntityType.WbGeometry, job.Target.Uid);
             WorkerResult workerResult = new(witsmlClient.GetServerHostname(), true, $"WbGeometrySections {wbGeometrySectionsString} copied to: {targetWbGeometry.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteBhaRunsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteBhaRunsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlBhaRun> queries = BhaRunQueries.DeleteBhaRunQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.BhaRuns);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.BhaRun);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteBhaRunsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteBhaRunsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlBhaRun> queries = BhaRunQueries.DeleteBhaRunQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshBhaRuns refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.BhaRuns);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteCurveValuesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteCurveValuesWorker.cs
@@ -60,7 +60,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                 }
             }
 
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, EntityType.LogObject);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.LogObject, logUid);
             string mnemonicsOnLog = string.Join(", ", logCurveInfos.Select(logCurveInfo => logCurveInfo.Mnemonic));
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted curve info values for mnemonics: {mnemonicsOnLog}, for log: {logUid}");
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteCurveValuesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteCurveValuesWorker.cs
@@ -60,7 +60,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                 }
             }
 
-            RefreshLogObject refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, EntityType.LogObject);
             string mnemonicsOnLog = string.Join(", ", logCurveInfos.Select(logCurveInfo => logCurveInfo.Mnemonic));
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted curve info values for mnemonics: {mnemonicsOnLog}, for log: {logUid}");
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteLogObjectsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteLogObjectsWorker.cs
@@ -39,7 +39,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                 UidWellbore = wellboreUid,
                 Uid = uid
             });
-            RefreshLogObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.LogObjects);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteLogObjectsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteLogObjectsWorker.cs
@@ -39,7 +39,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                 UidWellbore = wellboreUid,
                 Uid = uid
             });
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.LogObjects);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.LogObject);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMessagesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMessagesWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlMessage> queries = MessageQueries.DeleteMessageQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Messages);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Message);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMessagesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMessagesWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlMessage> queries = MessageQueries.DeleteMessageQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshMessageObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Messages);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMnemonicsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMnemonicsWorker.cs
@@ -43,7 +43,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                         wellboreUid,
                         logUid,
                         mnemonicsString);
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, EntityType.LogObject);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.LogObject, logUid);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted mnemonics: {mnemonicsString} for log: {logUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMnemonicsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMnemonicsWorker.cs
@@ -43,7 +43,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                         wellboreUid,
                         logUid,
                         mnemonicsString);
-                RefreshLogObject refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, EntityType.LogObject);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted mnemonics: {mnemonicsString} for log: {logUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMudLogsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMudLogsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlMudLog> queries = MudLogQueries.DeleteWitsmlMudLogs(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.MudLogs);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.MudLog);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMudLogsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteMudLogsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlMudLog> queries = MudLogQueries.DeleteWitsmlMudLogs(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshMudLogs refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.MudLogs);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRigsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRigsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlRig> queries = RigQueries.DeleteRigQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshRigs refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Rigs);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRigsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRigsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlRig> queries = RigQueries.DeleteRigQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Rigs);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Rig);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRisksWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRisksWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlRisk> queries = RiskQueries.DeleteRiskQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Risks);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Risk);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRisksWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteRisksWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlRisk> queries = RiskQueries.DeleteRiskQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshRisks refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Risks);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoriesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoriesWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlTrajectory> queries = TrajectoryQueries.DeleteTrajectories(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Trajectories);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Trajectory);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoriesWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoriesWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlTrajectory> queries = TrajectoryQueries.DeleteTrajectories(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshTrajectories refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Trajectories);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoryStationsWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                     wellboreUid,
                     trajectoryUid,
                     trajectoryStations);
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, trajectoryUid, EntityType.Trajectory);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.Trajectory, trajectoryUid);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted trajectoryStations: {trajectoryStationsString} for trajectory: {trajectoryUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoryStationsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTrajectoryStationsWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                     wellboreUid,
                     trajectoryUid,
                     trajectoryStations);
-                RefreshTrajectory refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, trajectoryUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, trajectoryUid, EntityType.Trajectory);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted trajectoryStations: {trajectoryStationsString} for trajectory: {trajectoryUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularComponentsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularComponentsWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                     wellboreUid,
                     tubularUid,
                     tubularcomponents);
-                RefreshTubulars refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, tubularUid, EntityType.Tubular);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted tubularcomponents: {tubularComponentsString} for tubular: {tubularUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularComponentsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularComponentsWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                     wellboreUid,
                     tubularUid,
                     tubularcomponents);
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, tubularUid, EntityType.Tubular);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.Tubular, tubularUid);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted tubularcomponents: {tubularComponentsString} for tubular: {tubularUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlTubular> queries = TubularQueries.DeleteWitsmlTubulars(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshTubulars refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Tubulars);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteTubularsWorker.cs
@@ -26,7 +26,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlTubular> queries = TubularQueries.DeleteWitsmlTubulars(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Tubulars);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.Tubular);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrySectionsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrySectionsWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                     wellboreUid,
                     wbGeometryUid,
                     wbGeometrySections);
-                RefreshWbGeometry refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, wbGeometryUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, wbGeometryUid, EntityType.WbGeometry);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted wbGeometrySections: {wbGeometrySectionsString} for wbGeometry: {wbGeometryUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrySectionsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrySectionsWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
                     wellboreUid,
                     wbGeometryUid,
                     wbGeometrySections);
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, wbGeometryUid, EntityType.WbGeometry);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.WbGeometry, wbGeometryUid);
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Deleted wbGeometrySections: {wbGeometrySectionsString} for wbGeometry: {wbGeometryUid}");
                 return (workerResult, refreshAction);
             }

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrysWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrysWorker.cs
@@ -28,7 +28,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlWbGeometry> queries = WbGeometryQueries.DeleteWbGeometryQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.WbGeometries);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.WbGeometry);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrysWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Delete/DeleteWbGeometrysWorker.cs
@@ -28,7 +28,7 @@ namespace WitsmlExplorer.Api.Workers.Delete
         {
             job.ToDelete.Verify();
             IEnumerable<WitsmlWbGeometry> queries = WbGeometryQueries.DeleteWbGeometryQuery(job.ToDelete.WellUid, job.ToDelete.WellboreUid, job.ToDelete.ObjectUids);
-            RefreshWbGeometryObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.ToDelete.WellUid, job.ToDelete.WellboreUid, EntityType.WbGeometries);
             return await _deleteUtils.DeleteObjectsOnWellbore(GetTargetWitsmlClientOrThrow(), queries, refreshAction);
         }
 

--- a/Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs
@@ -62,7 +62,7 @@ namespace WitsmlExplorer.Api.Workers
 
             Logger.LogInformation("{JobType} - Job successful", GetType().Name);
 
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, EntityType.LogObject);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.LogObject, logUid);
             string mnemonicsOnLog = string.Join(", ", logCurveInfos.Select(logCurveInfo => logCurveInfo.Mnemonic));
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Imported curve info values for mnemonics: {mnemonicsOnLog}, for log: {logUid}");
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/ImportLogDataWorker.cs
@@ -62,7 +62,7 @@ namespace WitsmlExplorer.Api.Workers
 
             Logger.LogInformation("{JobType} - Job successful", GetType().Name);
 
-            RefreshLogObject refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, logUid, EntityType.LogObject);
             string mnemonicsOnLog = string.Join(", ", logCurveInfos.Select(logCurveInfo => logCurveInfo.Mnemonic));
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Imported curve info values for mnemonics: {mnemonicsOnLog}, for log: {logUid}");
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyBhaRunWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyBhaRunWorker.cs
@@ -31,7 +31,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("BhaRun modified. {jobDescription}", job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.BhaRun.WellUid, job.BhaRun.WellboreUid, EntityType.BhaRuns);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.BhaRun.WellUid, job.BhaRun.WellboreUid, EntityType.BhaRun);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"BhaRun {job.BhaRun.Name} updated for {job.BhaRun.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyBhaRunWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyBhaRunWorker.cs
@@ -31,7 +31,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("BhaRun modified. {jobDescription}", job.Description());
-            RefreshBhaRuns refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.BhaRun.WellUid, job.BhaRun.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.BhaRun.WellUid, job.BhaRun.WellboreUid, EntityType.BhaRuns);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"BhaRun {job.BhaRun.Name} updated for {job.BhaRun.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyMessageWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyMessageWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("Message modified. {jobDescription}", job.Description());
-            RefreshMessageObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.MessageObject.WellUid, job.MessageObject.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.MessageObject.WellUid, job.MessageObject.WellboreUid, EntityType.Messages);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"MessageObject {job.MessageObject.Name} updated for {job.MessageObject.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyMessageWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyMessageWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("Message modified. {jobDescription}", job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.MessageObject.WellUid, job.MessageObject.WellboreUid, EntityType.Messages);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.MessageObject.WellUid, job.MessageObject.WellboreUid, EntityType.Message);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"MessageObject {job.MessageObject.Name} updated for {job.MessageObject.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRigWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRigWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("Rig modified. {jobDescription}", job.Description());
-            RefreshRigs refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Rig.WellUid, job.Rig.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Rig.WellUid, job.Rig.WellboreUid, EntityType.Rigs);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Rig {job.Rig.Name} updated for {job.Rig.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRigWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRigWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("Rig modified. {jobDescription}", job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Rig.WellUid, job.Rig.WellboreUid, EntityType.Rigs);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Rig.WellUid, job.Rig.WellboreUid, EntityType.Rig);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Rig {job.Rig.Name} updated for {job.Rig.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRiskWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("Risk modified. {jobDescription}", job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Risk.WellUid, job.Risk.WellboreUid, EntityType.Risks);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Risk.WellUid, job.Risk.WellboreUid, EntityType.Risk);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Risk {job.Risk.Name} updated for {job.Risk.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyRiskWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("Risk modified. {jobDescription}", job.Description());
-            RefreshRisks refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Risk.WellUid, job.Risk.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.Risk.WellUid, job.Risk.WellboreUid, EntityType.Risks);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Risk {job.Risk.Name} updated for {job.Risk.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTrajectoryStationWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTrajectoryStationWorker.cs
@@ -35,7 +35,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("TrajectoryStation modified. {jobDescription}", job.Description());
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, trajectoryUid, EntityType.Trajectory);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.Trajectory, trajectoryUid);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TrajectoryStation updated ({job.TrajectoryStation.Uid})"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTrajectoryStationWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTrajectoryStationWorker.cs
@@ -35,7 +35,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("TrajectoryStation modified. {jobDescription}", job.Description());
-                RefreshTrajectory refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, trajectoryUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, trajectoryUid, EntityType.Trajectory);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TrajectoryStation updated ({job.TrajectoryStation.Uid})"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularComponentWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularComponentWorker.cs
@@ -35,7 +35,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("TubularComponent modified. {jobDescription}", job.Description());
-                RefreshTubulars refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, tubularUid, EntityType.Tubular);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TubularComponent updated ({job.TubularComponent.Uid})"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularComponentWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularComponentWorker.cs
@@ -35,7 +35,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("TubularComponent modified. {jobDescription}", job.Description());
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, tubularUid, EntityType.Tubular);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.Tubular, tubularUid);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"TubularComponent updated ({job.TubularComponent.Uid})"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularWorker.cs
@@ -43,7 +43,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("Tubular modified. {jobDescription}", job.Description());
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, tubularUid, EntityType.Tubular);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.Tubular, tubularUid);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Tubular updated ({job.Tubular.Name} [{tubularUid}])"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyTubularWorker.cs
@@ -43,7 +43,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("Tubular modified. {jobDescription}", job.Description());
-                RefreshTubulars refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, tubularUid, EntityType.Tubular);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Tubular updated ({job.Tubular.Name} [{tubularUid}])"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometrySectionWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometrySectionWorker.cs
@@ -36,7 +36,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("WbGeometrySection modified. {jobDescription}", job.Description());
-                RefreshWbGeometry refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, wbGeometryUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, wbGeometryUid, EntityType.WbGeometry);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"WbGeometrySection updated ({job.WbGeometrySection.Uid})"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometrySectionWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometrySectionWorker.cs
@@ -36,7 +36,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("WbGeometrySection modified. {jobDescription}", job.Description());
-                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, wbGeometryUid, EntityType.WbGeometry);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.WbGeometry, wbGeometryUid);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"WbGeometrySection updated ({job.WbGeometrySection.Uid})"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometryWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("WbGeometry modified. {jobDescription}", job.Description());
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.WbGeometry.WellUid, job.WbGeometry.WellboreUid, EntityType.WbGeometries);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.WbGeometry.WellUid, job.WbGeometry.WellboreUid, EntityType.WbGeometry);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"WbGeometry {job.WbGeometry.Name} updated for {job.WbGeometry.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyWbGeometryWorker.cs
@@ -30,7 +30,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             }
 
             Logger.LogInformation("WbGeometry modified. {jobDescription}", job.Description());
-            RefreshWbGeometryObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.WbGeometry.WellUid, job.WbGeometry.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.WbGeometry.WellUid, job.WbGeometry.WellboreUid, EntityType.WbGeometries);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"WbGeometry {job.WbGeometry.Name} updated for {job.WbGeometry.WellboreName}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/RenameMnemonicWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/RenameMnemonicWorker.cs
@@ -61,7 +61,7 @@ namespace WitsmlExplorer.Api.Workers
             Logger.LogInformation("{JobType} - Job successful. Mnemonic renamed from {Mnemonic} to {NewMnemonic}", GetType().Name, job.Mnemonic, job.NewMnemonic);
             return (
                 new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Mnemonic renamed from {job.Mnemonic} to {job.NewMnemonic}"),
-                new RefreshLogObject(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogReference.WellUid, job.LogReference.WellboreUid, job.LogReference.Uid, RefreshType.Update));
+                new RefreshObjects(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogReference.WellUid, job.LogReference.WellboreUid, job.LogReference.Uid, EntityType.LogObject));
         }
 
         private static WitsmlLogs CreateNewLogWithRenamedMnemonic(RenameMnemonicJob job, WitsmlLog logHeader, IEnumerable<string> mnemonics, WitsmlLog logData)

--- a/Src/WitsmlExplorer.Api/Workers/RenameMnemonicWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/RenameMnemonicWorker.cs
@@ -61,7 +61,7 @@ namespace WitsmlExplorer.Api.Workers
             Logger.LogInformation("{JobType} - Job successful. Mnemonic renamed from {Mnemonic} to {NewMnemonic}", GetType().Name, job.Mnemonic, job.NewMnemonic);
             return (
                 new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Mnemonic renamed from {job.Mnemonic} to {job.NewMnemonic}"),
-                new RefreshObjects(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogReference.WellUid, job.LogReference.WellboreUid, job.LogReference.Uid, EntityType.LogObject));
+                new RefreshObjects(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogReference.WellUid, job.LogReference.WellboreUid, EntityType.LogObject, job.LogReference.Uid));
         }
 
         private static WitsmlLogs CreateNewLogWithRenamedMnemonic(RenameMnemonicJob job, WitsmlLog logHeader, IEnumerable<string> mnemonics, WitsmlLog logData)

--- a/Src/WitsmlExplorer.Api/Workers/TrimLogObjectWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/TrimLogObjectWorker.cs
@@ -79,7 +79,7 @@ namespace WitsmlExplorer.Api.Workers
                 }
             }
 
-            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogObject.WellUid, job.LogObject.WellboreUid, job.LogObject.Uid, EntityType.LogObject);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogObject.WellUid, job.LogObject.WellboreUid, EntityType.LogObject, job.LogObject.Uid);
 
             return trimmedStartOfLog && trimmedEndOfLog
                 ? ((WorkerResult, RefreshAction))(new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Updated start/end of log [{job.LogObject.Uid}]"), refreshAction)

--- a/Src/WitsmlExplorer.Api/Workers/TrimLogObjectWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/TrimLogObjectWorker.cs
@@ -79,7 +79,7 @@ namespace WitsmlExplorer.Api.Workers
                 }
             }
 
-            RefreshLogObject refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogObject.WellUid, job.LogObject.WellboreUid, job.LogObject.Uid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogObject.WellUid, job.LogObject.WellboreUid, job.LogObject.Uid, EntityType.LogObject);
 
             return trimmedStartOfLog && trimmedEndOfLog
                 ? ((WorkerResult, RefreshAction))(new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Updated start/end of log [{job.LogObject.Uid}]"), refreshAction)

--- a/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
@@ -35,44 +35,48 @@ const RefreshHandler = (): React.ReactElement => {
           case EntityType.Wellbore:
             await refreshWellbore(refreshAction, modificationType);
             break;
-          case EntityType.BhaRuns:
+          case EntityType.BhaRun:
             await refreshBhaRuns(refreshAction);
             break;
           case EntityType.LogObject:
-            await refreshLogObject(refreshAction);
+            if (refreshAction.objectUid == null) {
+              await refreshLogObjects(refreshAction);
+            } else {
+              await refreshLogObject(refreshAction);
+            }
             break;
-          case EntityType.LogObjects:
-            await refreshLogObjects(refreshAction);
-            break;
-          case EntityType.Messages:
+          case EntityType.Message:
             await refreshMessageObjects(refreshAction);
             break;
-          case EntityType.MudLogs:
+          case EntityType.MudLog:
             await refreshMudLogs(refreshAction);
             break;
           case EntityType.Trajectory:
-            await refreshTrajectory(refreshAction);
-            break;
-          case EntityType.Trajectories:
-            await refreshTrajectories(refreshAction);
+            if (refreshAction.objectUid == null) {
+              await refreshTrajectories(refreshAction);
+            } else {
+              await refreshTrajectory(refreshAction);
+            }
             break;
           case EntityType.Tubular:
-            await refreshTubular(refreshAction);
+            if (refreshAction.objectUid == null) {
+              await refreshTubulars(refreshAction);
+            } else {
+              await refreshTubular(refreshAction);
+            }
             break;
-          case EntityType.Tubulars:
-            await refreshTubulars(refreshAction);
-            break;
-          case EntityType.Risks:
+          case EntityType.Risk:
             await refreshRisks(refreshAction);
             break;
-          case EntityType.Rigs:
+          case EntityType.Rig:
             await refreshRigs(refreshAction);
             break;
           case EntityType.WbGeometry:
-            await refreshWbGeometry(refreshAction);
-            break;
-          case EntityType.WbGeometries:
-            await refreshWbGeometryObjects(refreshAction);
+            if (refreshAction.objectUid == null) {
+              await refreshWbGeometryObjects(refreshAction);
+            } else {
+              await refreshWbGeometry(refreshAction);
+            }
         }
       } catch (error) {
         // eslint-disable-next-line no-console

--- a/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
@@ -36,40 +36,43 @@ const RefreshHandler = (): React.ReactElement => {
             await refreshWellbore(refreshAction, modificationType);
             break;
           case EntityType.BhaRuns:
-            await refreshBhaRuns(refreshAction, modificationType);
+            await refreshBhaRuns(refreshAction);
             break;
           case EntityType.LogObject:
-            await refreshLogObject(refreshAction, modificationType);
+            await refreshLogObject(refreshAction);
             break;
           case EntityType.LogObjects:
-            await refreshLogObjects(refreshAction, ModificationType.UpdateLogObjects);
+            await refreshLogObjects(refreshAction);
+            break;
+          case EntityType.Messages:
+            await refreshMessageObjects(refreshAction);
             break;
           case EntityType.MudLogs:
-            await refreshMudLogs(refreshAction, ModificationType.UpdateMudLogs);
-            break;
-          case EntityType.MessageObjects:
-            await refreshMessageObjects(refreshAction, modificationType);
+            await refreshMudLogs(refreshAction);
             break;
           case EntityType.Trajectory:
-            await refreshTrajectory(refreshAction, ModificationType.UpdateTrajectoryOnWellbore);
+            await refreshTrajectory(refreshAction);
             break;
           case EntityType.Trajectories:
-            await refreshTrajectories(refreshAction, ModificationType.UpdateTrajectoriesOnWellbore);
+            await refreshTrajectories(refreshAction);
             break;
           case EntityType.Tubular:
-            await refreshTubulars(refreshAction, ModificationType.UpdateTubularsOnWellbore);
+            await refreshTubular(refreshAction);
+            break;
+          case EntityType.Tubulars:
+            await refreshTubulars(refreshAction);
             break;
           case EntityType.Risks:
-            await refreshRisks(refreshAction, ModificationType.UpdateRiskObjects);
+            await refreshRisks(refreshAction);
             break;
           case EntityType.Rigs:
-            await refreshRigs(refreshAction, ModificationType.UpdateRigsOnWellbore);
+            await refreshRigs(refreshAction);
             break;
           case EntityType.WbGeometry:
-            await refreshWbGeometry(refreshAction, ModificationType.UpdateWbGeometryOnWellbore);
+            await refreshWbGeometry(refreshAction);
             break;
-          case EntityType.WbGeometryObjects:
-            await refreshWbGeometryObjects(refreshAction, ModificationType.UpdateWbGeometryObjects);
+          case EntityType.WbGeometries:
+            await refreshWbGeometryObjects(refreshAction);
         }
       } catch (error) {
         // eslint-disable-next-line no-console
@@ -116,131 +119,114 @@ const RefreshHandler = (): React.ReactElement => {
     }
   }
 
-  async function refreshBhaRuns(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateBhaRuns) {
-      const bhaRuns = await BhaRunService.getBhaRuns(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (bhaRuns) {
-        dispatchNavigation({ type: modificationType, payload: { bhaRuns, wellUid, wellboreUid } });
-      }
+  async function refreshBhaRuns(refreshAction: RefreshAction) {
+    const bhaRuns = await BhaRunService.getBhaRuns(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (bhaRuns) {
+      dispatchNavigation({ type: ModificationType.UpdateBhaRuns, payload: { bhaRuns, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshLogObject(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateLogObject) {
-      const log = await LogObjectService.getLog(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.logObjectUid);
-      if (log) {
-        dispatchNavigation({ type: modificationType, payload: { log } });
-      }
+  async function refreshLogObject(refreshAction: RefreshAction) {
+    const log = await LogObjectService.getLog(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.objectUid);
+    if (log) {
+      dispatchNavigation({ type: ModificationType.UpdateLogObject, payload: { log } });
     }
   }
 
-  async function refreshLogObjects(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateLogObjects) {
-      const logs = await LogObjectService.getLogs(refreshAction.wellUid, refreshAction.wellboreUid);
-      if (logs) {
-        dispatchNavigation({ type: modificationType, payload: { logs, wellUid: refreshAction.wellUid, wellboreUid: refreshAction.wellboreUid } });
-      }
+  async function refreshLogObjects(refreshAction: RefreshAction) {
+    const logs = await LogObjectService.getLogs(refreshAction.wellUid, refreshAction.wellboreUid);
+    if (logs) {
+      dispatchNavigation({ type: ModificationType.UpdateLogObjects, payload: { logs, wellUid: refreshAction.wellUid, wellboreUid: refreshAction.wellboreUid } });
     }
   }
 
-  async function refreshMessageObjects(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateMessageObjects) {
-      const messages = await MessageObjectService.getMessages(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (messages) {
-        dispatchNavigation({ type: modificationType, payload: { messages, wellUid, wellboreUid } });
-      }
+  async function refreshMessageObjects(refreshAction: RefreshAction) {
+    const messages = await MessageObjectService.getMessages(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (messages) {
+      dispatchNavigation({ type: ModificationType.UpdateMessageObjects, payload: { messages, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshMudLogs(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateMudLogs) {
-      const mudLogs = await MudLogService.getMudLogs(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (mudLogs) {
-        dispatchNavigation({ type: modificationType, payload: { mudLogs, wellUid, wellboreUid } });
-      }
+  async function refreshMudLogs(refreshAction: RefreshAction) {
+    const mudLogs = await MudLogService.getMudLogs(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (mudLogs) {
+      dispatchNavigation({ type: ModificationType.UpdateMudLogs, payload: { mudLogs, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshRigs(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateRigsOnWellbore) {
-      const rigs = await RigService.getRigs(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (rigs) {
-        dispatchNavigation({ type: modificationType, payload: { rigs, wellUid, wellboreUid } });
-      }
+  async function refreshRigs(refreshAction: RefreshAction) {
+    const rigs = await RigService.getRigs(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (rigs) {
+      dispatchNavigation({ type: ModificationType.UpdateRigsOnWellbore, payload: { rigs, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshRisks(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateRiskObjects) {
-      const risks = await RiskObjectService.getRisks(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (risks) {
-        dispatchNavigation({ type: modificationType, payload: { risks, wellUid, wellboreUid } });
-      }
+  async function refreshRisks(refreshAction: RefreshAction) {
+    const risks = await RiskObjectService.getRisks(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (risks) {
+      dispatchNavigation({ type: ModificationType.UpdateRiskObjects, payload: { risks, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshTubulars(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateTubularsOnWellbore) {
-      const tubulars = await TubularService.getTubulars(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (tubulars) {
-        dispatchNavigation({ type: modificationType, payload: { tubulars, wellUid, wellboreUid } });
-      }
+  async function refreshTubular(refreshAction: RefreshAction) {
+    const tubular = await TubularService.getTubular(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.objectUid);
+    if (tubular) {
+      dispatchNavigation({ type: ModificationType.UpdateTubularOnWellbore, payload: { tubular, exists: true } });
     }
   }
 
-  async function refreshTrajectory(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateTrajectoryOnWellbore) {
-      const trajectory = await TrajectoryService.getTrajectory(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.trajectoryUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (trajectory) {
-        dispatchNavigation({ type: modificationType, payload: { trajectory, wellUid, wellboreUid } });
-      }
+  async function refreshTubulars(refreshAction: RefreshAction) {
+    const tubulars = await TubularService.getTubulars(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (tubulars) {
+      dispatchNavigation({ type: ModificationType.UpdateTubularsOnWellbore, payload: { tubulars, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshTrajectories(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateTrajectoriesOnWellbore) {
-      const trajectories = await TrajectoryService.getTrajectories(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (trajectories) {
-        dispatchNavigation({ type: modificationType, payload: { trajectories, wellUid, wellboreUid } });
-      }
+  async function refreshTrajectory(refreshAction: RefreshAction) {
+    const trajectory = await TrajectoryService.getTrajectory(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.objectUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (trajectory) {
+      dispatchNavigation({ type: ModificationType.UpdateTrajectoryOnWellbore, payload: { trajectory, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshWbGeometry(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateWbGeometryOnWellbore) {
-      const wbGeometry = await WbGeometryObjectService.getWbGeometry(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.wbGeometryUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (wbGeometry) {
-        dispatchNavigation({ type: modificationType, payload: { wbGeometry, wellUid, wellboreUid } });
-      }
+  async function refreshTrajectories(refreshAction: RefreshAction) {
+    const trajectories = await TrajectoryService.getTrajectories(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (trajectories) {
+      dispatchNavigation({ type: ModificationType.UpdateTrajectoriesOnWellbore, payload: { trajectories, wellUid, wellboreUid } });
     }
   }
 
-  async function refreshWbGeometryObjects(refreshAction: RefreshAction, modificationType: ModificationType) {
-    if (modificationType === ModificationType.UpdateWbGeometryObjects) {
-      const wbGeometrys = await WbGeometryObjectService.getWbGeometrys(refreshAction.wellUid, refreshAction.wellboreUid);
-      const wellUid = refreshAction.wellUid;
-      const wellboreUid = refreshAction.wellboreUid;
-      if (wbGeometrys) {
-        dispatchNavigation({ type: modificationType, payload: { wbGeometrys, wellUid, wellboreUid } });
-      }
+  async function refreshWbGeometry(refreshAction: RefreshAction) {
+    const wbGeometry = await WbGeometryObjectService.getWbGeometry(refreshAction.wellUid, refreshAction.wellboreUid, refreshAction.objectUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (wbGeometry) {
+      dispatchNavigation({ type: ModificationType.UpdateWbGeometryOnWellbore, payload: { wbGeometry, wellUid, wellboreUid } });
+    }
+  }
+
+  async function refreshWbGeometryObjects(refreshAction: RefreshAction) {
+    const wbGeometrys = await WbGeometryObjectService.getWbGeometrys(refreshAction.wellUid, refreshAction.wellboreUid);
+    const wellUid = refreshAction.wellUid;
+    const wellboreUid = refreshAction.wellboreUid;
+    if (wbGeometrys) {
+      dispatchNavigation({ type: ModificationType.UpdateWbGeometryObjects, payload: { wbGeometrys, wellUid, wellboreUid } });
     }
   }
 

--- a/Src/WitsmlExplorer.Frontend/models/entityType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/entityType.ts
@@ -4,16 +4,16 @@ enum EntityType {
   BhaRuns = "BhaRuns",
   LogObject = "LogObject",
   LogObjects = "LogObjects",
-  MessageObjects = "MessageObjects",
+  Messages = "Messages",
   MudLogs = "MudLogs",
   Risks = "Risks",
   Tubular = "Tubular",
+  Tubulars = "Tubulars",
   Rigs = "Rigs",
   Trajectory = "Trajectory",
   Trajectories = "Trajectories",
-  TrajectoryStation = "TrajectoryStation",
   WbGeometry = "WbGeometry",
-  WbGeometryObjects = "WbGeometryObjects"
+  WbGeometries = "WbGeometries"
 }
 
 export default EntityType;

--- a/Src/WitsmlExplorer.Frontend/models/entityType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/entityType.ts
@@ -1,19 +1,15 @@
 enum EntityType {
   Well = "Well",
   Wellbore = "Wellbore",
-  BhaRuns = "BhaRuns",
+  BhaRun = "BhaRun",
   LogObject = "LogObject",
-  LogObjects = "LogObjects",
-  Messages = "Messages",
-  MudLogs = "MudLogs",
-  Risks = "Risks",
+  Message = "Message",
+  MudLog = "MudLog",
+  Rig = "Rig",
+  Risk = "Risk",
   Tubular = "Tubular",
-  Tubulars = "Tubulars",
-  Rigs = "Rigs",
   Trajectory = "Trajectory",
-  Trajectories = "Trajectories",
-  WbGeometry = "WbGeometry",
-  WbGeometries = "WbGeometries"
+  WbGeometry = "WbGeometry"
 }
 
 export default EntityType;

--- a/Src/WitsmlExplorer.Frontend/services/notificationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/notificationService.ts
@@ -23,10 +23,7 @@ export interface RefreshAction {
   serverUrl: URL;
   wellUid: string;
   wellboreUid?: string;
-  logObjectUid?: string;
-  messageObjectUid?: string;
-  trajectoryUid?: string;
-  wbGeometryUid?: string;
+  objectUid?: string;
 }
 
 export enum RefreshType {

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteLogObjectsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteLogObjectsWorkerTests.cs
@@ -57,7 +57,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 }
             };
             (WorkerResult result, RefreshAction refreshAction) = await _worker.Execute(job);
-            Assert.True(result.IsSuccess && ((RefreshLogObjects)refreshAction).WellboreUid == WellboreUid);
+            Assert.True(result.IsSuccess && ((RefreshObjects)refreshAction).WellboreUid == WellboreUid);
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteMudLogsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteMudLogsWorkerTests.cs
@@ -57,7 +57,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 }
             };
             (WorkerResult result, RefreshAction refreshAction) = await _worker.Execute(job);
-            Assert.True(result.IsSuccess && ((RefreshMudLogs)refreshAction).WellboreUid == WellboreUid);
+            Assert.True(result.IsSuccess && ((RefreshObjects)refreshAction).WellboreUid == WellboreUid);
         }
     }
 }


### PR DESCRIPTION
## Fixes
This pull request fixes WE-797

## Description
Refactor RefreshAction.cs so that all objects use the RefreshObjects class whilst specifying the EntityType to refresh.
Refactor RefreshHandler.tsx so that ModificationType is baked in into refresh functions.
Remove plural EntityTypes so that the correct refresh function is picked based on whether we receive objectUid for the given entity.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests

## Further comments
ModifyLogObjectWorker uses RefreshWellbore, logs view is not updated on when using RefreshObjects with EntityType.LogObject.