### PR TITLE
WE-831 Generic copy objects worker

### DIFF
--- a/Src/Witsml/Data/IWitsmlObjectList.cs
+++ b/Src/Witsml/Data/IWitsmlObjectList.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Witsml.Data
+{
+    public interface IWitsmlObjectList : IWitsmlQueryType
+    {
+        [XmlIgnore]
+        IEnumerable<ObjectOnWellbore> Objects { get; set; }
+    }
+}

--- a/Src/Witsml/Data/MudLog/WitsmlMudLogs.cs
+++ b/Src/Witsml/Data/MudLog/WitsmlMudLogs.cs
@@ -1,16 +1,25 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data.MudLog
 {
     [XmlRoot("mudLogs", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlMudLogs : IWitsmlGrowingDataQueryType
+    public class WitsmlMudLogs : IWitsmlGrowingDataQueryType, IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
 
         [XmlElement("mudLog")]
         public List<WitsmlMudLog> MudLogs { get; set; } = new();
+
         public string TypeName => "mudLog";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => MudLogs;
+            set => MudLogs = value.Select(obj => (WitsmlMudLog)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/Rig/WitsmlRigs.cs
+++ b/Src/Witsml/Data/Rig/WitsmlRigs.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data.Rig
 {
     [XmlRoot("rigs", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlRigs : IWitsmlQueryType
+    public class WitsmlRigs : IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data.Rig
         public List<WitsmlRig> Rigs { get; set; } = new List<WitsmlRig>();
 
         public string TypeName => "rig";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => Rigs;
+            set => Rigs = value.Select(obj => (WitsmlRig)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/Tubular/WitsmlTubulars.cs
+++ b/Src/Witsml/Data/Tubular/WitsmlTubulars.cs
@@ -1,16 +1,25 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data.Tubular
 {
     [XmlRoot("tubulars", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlTubulars : IWitsmlQueryType
+    public class WitsmlTubulars : IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
 
         [XmlElement("tubular")]
         public List<WitsmlTubular> Tubulars { get; set; } = new List<WitsmlTubular>();
+
         public string TypeName => "tubular";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => Tubulars;
+            set => Tubulars = value.Select(obj => (WitsmlTubular)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlBhaRuns.cs
+++ b/Src/Witsml/Data/WitsmlBhaRuns.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("bhaRuns", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlBhaRuns : IWitsmlQueryType
+    public class WitsmlBhaRuns : IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data
         public List<WitsmlBhaRun> BhaRuns { get; set; } = new List<WitsmlBhaRun>();
 
         public string TypeName => "bhaRun";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => BhaRuns;
+            set => BhaRuns = value.Select(obj => (WitsmlBhaRun)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlFormationMarker.cs
+++ b/Src/Witsml/Data/WitsmlFormationMarker.cs
@@ -1,28 +1,19 @@
 using System.Xml.Serialization;
 
 using Witsml.Data.Measures;
+using Witsml.Extensions;
 
 namespace Witsml.Data
 {
-    public class WitsmlFormationMarker
+    public class WitsmlFormationMarker : ObjectOnWellbore
     {
-        [XmlAttribute("uidWell")]
-        public string UidWell { get; init; }
-
-        [XmlAttribute("uidWellbore")]
-        public string UidWellbore { get; init; }
-
-        [XmlAttribute("uid")]
-        public string Uid { get; init; }
-
-        [XmlElement("nameWell")]
-        public string NameWell { get; init; }
-
-        [XmlElement("nameWellbore")]
-        public string NameWellbore { get; init; }
-
-        [XmlElement("name")]
-        public string Name { get; init; }
+        public override WitsmlFormationMarkers AsSingletonWitsmlList()
+        {
+            return new WitsmlFormationMarkers()
+            {
+                FormationMarkers = this.AsSingletonList()
+            };
+        }
 
         [XmlElement("description")]
         public string Description { get; init; }

--- a/Src/Witsml/Data/WitsmlFormationMarkers.cs
+++ b/Src/Witsml/Data/WitsmlFormationMarkers.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("formationMarkers", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlFormationMarkers : IWitsmlQueryType
+    public class WitsmlFormationMarkers : IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data
         public List<WitsmlFormationMarker> FormationMarkers { get; set; } = new();
 
         public string TypeName => "formationMarker";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => FormationMarkers;
+            set => FormationMarkers = value.Select(obj => (WitsmlFormationMarker)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlLogs.cs
+++ b/Src/Witsml/Data/WitsmlLogs.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("logs", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlLogs : IWitsmlGrowingDataQueryType
+    public class WitsmlLogs : IWitsmlGrowingDataQueryType, IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data
         public List<WitsmlLog> Logs { get; set; } = new();
 
         public string TypeName => "log";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => Logs;
+            set => Logs = value.Select(obj => (WitsmlLog)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlMessages.cs
+++ b/Src/Witsml/Data/WitsmlMessages.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("messages", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlMessages : IWitsmlQueryType
+    public class WitsmlMessages : IWitsmlObjectList
     {
 
         [XmlAttribute("version")]
@@ -14,5 +15,12 @@ namespace Witsml.Data
         public List<WitsmlMessage> Messages { get; set; } = new List<WitsmlMessage>();
 
         public string TypeName => "message";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => Messages;
+            set => Messages = value.Select(obj => (WitsmlMessage)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlRisks.cs
+++ b/Src/Witsml/Data/WitsmlRisks.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("risks", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlRisks : IWitsmlQueryType
+    public class WitsmlRisks : IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data
         public List<WitsmlRisk> Risks { get; set; } = new List<WitsmlRisk>();
 
         public string TypeName => "risk";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => Risks;
+            set => Risks = value.Select(obj => (WitsmlRisk)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlTrajectories.cs
+++ b/Src/Witsml/Data/WitsmlTrajectories.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("trajectorys", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlTrajectories : IWitsmlGrowingDataQueryType
+    public class WitsmlTrajectories : IWitsmlGrowingDataQueryType, IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data
         public List<WitsmlTrajectory> Trajectories { get; set; } = new();
 
         public string TypeName => "trajectory";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => Trajectories;
+            set => Trajectories = value.Select(obj => (WitsmlTrajectory)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Data/WitsmlWbGeometrys.cs
+++ b/Src/Witsml/Data/WitsmlWbGeometrys.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace Witsml.Data
 {
     [XmlRoot("wbGeometrys", Namespace = "http://www.witsml.org/schemas/1series")]
-    public class WitsmlWbGeometrys : IWitsmlQueryType
+    public class WitsmlWbGeometrys : IWitsmlObjectList
     {
         [XmlAttribute("version")]
         public string Version = "1.4.1.1";
@@ -13,5 +14,12 @@ namespace Witsml.Data
         public List<WitsmlWbGeometry> WbGeometrys { get; set; } = new List<WitsmlWbGeometry>();
 
         public string TypeName => "wbGeometry";
+
+        [XmlIgnore]
+        public IEnumerable<ObjectOnWellbore> Objects
+        {
+            get => WbGeometrys;
+            set => WbGeometrys = value.Select(obj => (WitsmlWbGeometry)obj).ToList();
+        }
     }
 }

--- a/Src/Witsml/Xml/Serializer.cs
+++ b/Src/Witsml/Xml/Serializer.cs
@@ -24,12 +24,12 @@ namespace Witsml.Xml
             return textWriter.ToString();
         }
 
-        public static T Deserialize<T>(string xmlString)
+        public static T Deserialize<T>(string xmlString, T item)
         {
             var bytes = Encoding.UTF8.GetBytes(xmlString);
             using var stream = new MemoryStream(bytes);
 
-            var serializer = new XmlSerializer(typeof(T));
+            var serializer = new XmlSerializer(item.GetType());
             return (T)serializer.Deserialize(stream);
         }
     }

--- a/Src/WitsmlExplorer.Api/Jobs/CopyJobs.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CopyJobs.cs
@@ -6,6 +6,7 @@ namespace WitsmlExplorer.Api.Jobs
     public record CopyLogDataJob : ICopyJob<ComponentReferences, ObjectReference> { }
     public record CopyLogJob : ICopyJob<ObjectReferences, WellboreReference> { }
     public record CopyMudLogJob : ICopyJob<ObjectReferences, WellboreReference> { }
+    public record CopyObjectsJob : ICopyJob<ObjectReferences, WellboreReference> { }
     public record CopyRigJob : ICopyJob<ObjectReferences, WellboreReference> { }
     public record CopyRiskJob : ICopyJob<ObjectReferences, WellboreReference> { }
     public record CopyTrajectoryStationsJob : ICopyJob<ComponentReferences, ObjectReference> { }

--- a/Src/WitsmlExplorer.Api/Models/EntityType.cs
+++ b/Src/WitsmlExplorer.Api/Models/EntityType.cs
@@ -59,5 +59,24 @@ namespace WitsmlExplorer.Api.Models
                 _ => null,
             };
         }
+
+        public static IWitsmlObjectList EntityTypeToObjectList(EntityType type)
+        {
+            return type switch
+            {
+                EntityType.BhaRun => new WitsmlBhaRuns(),
+                EntityType.Log => new WitsmlLogs(),
+                EntityType.Message => new WitsmlMessages(),
+                EntityType.MudLog => new WitsmlMudLogs(),
+                EntityType.Rig => new WitsmlRigs(),
+                EntityType.Risk => new WitsmlRisks(),
+                EntityType.Tubular => new WitsmlTubulars(),
+                EntityType.Trajectory => new WitsmlTrajectories(),
+                EntityType.WbGeometry => new WitsmlWbGeometrys(),
+                EntityType.Well => null,
+                EntityType.Wellbore => null,
+                _ => null,
+            };
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/JobType.cs
+++ b/Src/WitsmlExplorer.Api/Models/JobType.cs
@@ -6,6 +6,7 @@ namespace WitsmlExplorer.Api.Models
         CopyLog,
         CopyLogData,
         CopyMudLog,
+        CopyObjects,
         CopyRig,
         CopyRisk,
         CopyTrajectory,

--- a/Src/WitsmlExplorer.Api/Query/ObjectQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/ObjectQueries.cs
@@ -40,7 +40,6 @@ namespace WitsmlExplorer.Api.Query
             });
         }
 
-
         public static IWitsmlObjectList GetWitsmlObjectsByIds(string wellUid, string wellboreUid, string[] objectUids, EntityType type)
         {
             IWitsmlObjectList list = EntityTypeHelper.EntityTypeToObjectList(type);

--- a/Src/WitsmlExplorer.Api/Query/ObjectQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/ObjectQueries.cs
@@ -12,12 +12,17 @@ namespace WitsmlExplorer.Api.Query
     {
         public static IEnumerable<Witsml.Data.ObjectOnWellbore> DeleteObjectsQuery(ObjectReferences toDelete)
         {
-            return toDelete.ObjectUids.Select((uid) =>
+            return IdsToObjects(toDelete.WellUid, toDelete.WellboreUid, toDelete.ObjectUids, toDelete.ObjectType);
+        }
+
+        public static IEnumerable<Witsml.Data.ObjectOnWellbore> IdsToObjects(string wellUid, string wellboreUid, string[] objectUids, EntityType type)
+        {
+            return objectUids.Select((uid) =>
             {
-                Witsml.Data.ObjectOnWellbore o = EntityTypeHelper.EntityTypeToObjectOnWellbore(toDelete.ObjectType);
+                Witsml.Data.ObjectOnWellbore o = EntityTypeHelper.EntityTypeToObjectOnWellbore(type);
                 o.Uid = uid;
-                o.UidWellbore = toDelete.WellboreUid;
-                o.UidWell = toDelete.WellUid;
+                o.UidWellbore = wellboreUid;
+                o.UidWell = wellUid;
                 return o;
             }
             );
@@ -33,6 +38,14 @@ namespace WitsmlExplorer.Api.Query
                 o.NameWellbore = targetWellbore.Name;
                 return o;
             });
+        }
+
+
+        public static IWitsmlObjectList GetWitsmlObjectsByIds(string wellUid, string wellboreUid, string[] objectUids, EntityType type)
+        {
+            IWitsmlObjectList list = EntityTypeHelper.EntityTypeToObjectList(type);
+            list.Objects = IdsToObjects(wellUid, wellboreUid, objectUids, type);
+            return list;
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyObjectsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyObjectsWorker.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Witsml.Data;
+using Witsml.ServiceReference;
+
+using WitsmlExplorer.Api.Jobs;
+using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Query;
+using WitsmlExplorer.Api.Services;
+
+namespace WitsmlExplorer.Api.Workers.Copy
+{
+    public class CopyObjectsWorker : BaseWorker<CopyObjectsJob>, IWorker
+    {
+        private readonly ICopyUtils _copyUtils;
+        public JobType JobType => JobType.CopyObjects;
+
+        public CopyObjectsWorker(ILogger<CopyObjectsJob> logger, IWitsmlClientProvider witsmlClientProvider, ICopyUtils copyUtils) : base(witsmlClientProvider, logger)
+        {
+            _copyUtils = copyUtils;
+        }
+
+        public override async Task<(WorkerResult, RefreshAction)> Execute(CopyObjectsJob job)
+        {
+            Witsml.IWitsmlClient client = GetTargetWitsmlClientOrThrow();
+            IWitsmlObjectList witsmlObject = ObjectQueries.GetWitsmlObjectsByIds(job.Source.WellUid, job.Source.WellboreUid, job.Source.ObjectUids, job.Source.ObjectType);
+            Task<IWitsmlObjectList> objectsQuery = GetTargetWitsmlClientOrThrow().GetFromStoreNullableAsync(witsmlObject, new OptionsIn(ReturnElements.All));
+            Task<WitsmlWellbore> wellboreQuery = WorkerTools.GetWellbore(GetTargetWitsmlClientOrThrow(), job.Target);
+            await Task.WhenAll(objectsQuery, wellboreQuery);
+            IWitsmlObjectList objectList = objectsQuery.Result;
+            WitsmlWellbore targetWellbore = wellboreQuery.Result;
+
+            if (objectList == null)
+            {
+                return (new WorkerResult(client.GetServerHostname(), false, "Failed to deserialize response from Witsml server when fetching objects to copy"), null);
+            }
+
+            IEnumerable<Witsml.Data.ObjectOnWellbore> queries = ObjectQueries.CopyObjectsQuery(objectList.Objects, targetWellbore);
+            RefreshObjects refreshAction = new(client.GetServerHostname(), job.Target.WellUid, job.Target.WellboreUid, job.Source.ObjectType);
+            return await _copyUtils.CopyObjectsOnWellbore(client, queries, refreshAction, job.Source.WellUid, job.Source.WellboreUid);
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -59,6 +59,7 @@ export enum JobType {
   CopyLog = "CopyLog",
   CopyLogData = "CopyLogData",
   CopyMudLog = "CopyMudLog",
+  CopyObjects = "CopyObjects",
   CopyRig = "CopyRig",
   CopyRisk = "CopyRisk",
   CopyTrajectory = "CopyTrajectory",

--- a/Tests/WitsmlExplorer.Api.Tests/Models/EntityTypeTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Models/EntityTypeTests.cs
@@ -41,5 +41,19 @@ namespace WitsmlExplorer.Api.Tests.Models
             Assert.IsType<WitsmlTubular>(EntityTypeHelper.EntityTypeToObjectOnWellbore(EntityType.Tubular));
             Assert.IsType<WitsmlWbGeometry>(EntityTypeHelper.EntityTypeToObjectOnWellbore(EntityType.WbGeometry));
         }
+
+        [Fact]
+        public void EntityTypeToObjectList_GetAllWellboreObjectLists_CorrectType()
+        {
+            Assert.IsType<WitsmlBhaRuns>(EntityTypeHelper.EntityTypeToObjectList(EntityType.BhaRun));
+            Assert.IsType<WitsmlLogs>(EntityTypeHelper.EntityTypeToObjectList(EntityType.Log));
+            Assert.IsType<WitsmlMessages>(EntityTypeHelper.EntityTypeToObjectList(EntityType.Message));
+            Assert.IsType<WitsmlMudLogs>(EntityTypeHelper.EntityTypeToObjectList(EntityType.MudLog));
+            Assert.IsType<WitsmlRigs>(EntityTypeHelper.EntityTypeToObjectList(EntityType.Rig));
+            Assert.IsType<WitsmlRisks>(EntityTypeHelper.EntityTypeToObjectList(EntityType.Risk));
+            Assert.IsType<WitsmlTrajectories>(EntityTypeHelper.EntityTypeToObjectList(EntityType.Trajectory));
+            Assert.IsType<WitsmlTubulars>(EntityTypeHelper.EntityTypeToObjectList(EntityType.Tubular));
+            Assert.IsType<WitsmlWbGeometrys>(EntityTypeHelper.EntityTypeToObjectList(EntityType.WbGeometry));
+        }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyObjectsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyObjectsWorkerTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Witsml;
+using Witsml.Data;
+using Witsml.Data.Tubular;
+using Witsml.ServiceReference;
+
+using WitsmlExplorer.Api.Jobs;
+using WitsmlExplorer.Api.Jobs.Common;
+using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Workers;
+using WitsmlExplorer.Api.Workers.Copy;
+
+using Xunit;
+
+namespace WitsmlExplorer.Api.Tests.Workers
+{
+    public class CopyObjectsWorkerTests
+    {
+        private readonly CopyObjectsWorker _copyObjectWorker;
+        private readonly Mock<IWitsmlClient> _witsmlClient;
+        private const string WellUid = "wellUid";
+        private const string SourceWellboreUid = "sourceWellboreUid";
+        private const string TargetWellboreUid = "targetWellboreUid";
+        private const string ObjectUid = "objectUid";
+
+        public CopyObjectsWorkerTests()
+        {
+            Mock<IWitsmlClientProvider> witsmlClientProvider = new();
+            _witsmlClient = new Mock<IWitsmlClient>();
+            witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlClient.Object);
+            Mock<ILogger<CopyObjectsJob>> logger = new();
+            CopyUtils copyUtils = new(new Mock<ILogger<CopyUtils>>().Object);
+            _copyObjectWorker = new CopyObjectsWorker(logger.Object, witsmlClientProvider.Object, copyUtils);
+        }
+
+        [Fact]
+        public async Task Execute_CopyOneTubular_IsSuccess()
+        {
+            CopyObjectsJob copyObjectJob = CreateJobTemplate();
+            _witsmlClient.Setup(client =>
+                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(witsmlObjects => witsmlObjects.Objects.First().Uid == ObjectUid), new OptionsIn(ReturnElements.All, null, null)))
+                .ReturnsAsync(GetSourceObjects());
+            SetupGetWellbore();
+            IEnumerable<IWitsmlObjectList> copyObjectQuery = CopyTestsUtils.SetupAddInStoreAsync<IWitsmlObjectList>(_witsmlClient);
+
+            (WorkerResult, RefreshAction) result = await _copyObjectWorker.Execute(copyObjectJob);
+            Assert.True(result.Item1.IsSuccess);
+        }
+
+        private void SetupGetWellbore()
+        {
+            _witsmlClient.Setup(client =>
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), new OptionsIn(ReturnElements.Requested, null, null)))
+                .ReturnsAsync(new WitsmlWellbores
+                {
+                    Wellbores = new List<WitsmlWellbore>
+                    {
+                        new WitsmlWellbore
+                        {
+                            UidWell = "Well1",
+                            Uid = "wellbore1",
+                            Name = "Wellbore 1",
+                            NameWell = "Well 1"
+                        }
+                    }
+                });
+        }
+
+        private static CopyObjectsJob CreateJobTemplate(string targetWellboreUid = TargetWellboreUid)
+        {
+            return new CopyObjectsJob
+            {
+                Source = new ObjectReferences
+                {
+                    WellUid = WellUid,
+                    WellboreUid = SourceWellboreUid,
+                    ObjectUids = new string[] { ObjectUid },
+                    ObjectType = EntityType.Tubular
+                },
+                Target = new WellboreReference
+                {
+                    WellUid = WellUid,
+                    WellboreUid = targetWellboreUid
+                }
+            };
+        }
+
+        private static IWitsmlObjectList GetSourceObjects()
+        {
+            WitsmlTubular witsmlObject = new()
+            {
+                UidWell = WellUid,
+                UidWellbore = SourceWellboreUid,
+                Uid = ObjectUid,
+            };
+            return new WitsmlTubulars
+            {
+                Objects = new List<WitsmlTubular> { witsmlObject }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Fixes
This pull request fixes WE-381

## Description
Implement a generic copy objects worker that will replace existing copy workers handling ObjectOnWellbore types.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* WITSML, API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [x] New code is covered by passing tests
