### PR TITLE
WE-842 fix missing indexType in CopyLogDataWorker

### DIFF
--- a/Src/WitsmlExplorer.Api/Query/LogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/LogQueries.cs
@@ -55,12 +55,11 @@ namespace WitsmlExplorer.Api.Query
             Index startIndex,
             Index endIndex)
         {
-            var queryLog = new WitsmlLog
+            WitsmlLog queryLog = new()
             {
                 Uid = logUid,
                 UidWell = wellUid,
                 UidWellbore = wellboreUid,
-                IndexType = "",
                 LogCurveInfo = new List<WitsmlLogCurveInfo>(),
                 LogData = new WitsmlLogData
                 {
@@ -77,6 +76,8 @@ namespace WitsmlExplorer.Api.Query
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     queryLog.StartDateTimeIndex = startIndex.GetValueAsString();
                     queryLog.EndDateTimeIndex = endIndex.GetValueAsString();
+                    break;
+                default:
                     break;
             }
 
@@ -95,7 +96,7 @@ namespace WitsmlExplorer.Api.Query
             Index startIndex,
             Index endIndex)
         {
-            var queryLog = new WitsmlLog
+            WitsmlLog queryLog = new()
             {
                 Uid = logUid,
                 UidWell = wellUid,
@@ -116,6 +117,8 @@ namespace WitsmlExplorer.Api.Query
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     queryLog.StartDateTimeIndex = startIndex.GetValueAsString();
                     queryLog.EndDateTimeIndex = endIndex.GetValueAsString();
+                    break;
+                default:
                     break;
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -105,6 +105,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
                 if (result.IsSuccessful)
                 {
                     numberOfDataRowsCopied += copyNewCurvesQuery.Logs.First().LogData.Data.Count;
+                    sourceLogWithData.IndexType = sourceLog.IndexType;
                     startIndex = Index.End(sourceLogWithData).AddEpsilon();
                 }
                 else

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -399,7 +399,6 @@ namespace WitsmlExplorer.Api.Tests.Workers
                     {
                         StartDateTimeIndex = startIndex.GetValueAsString(),
                         EndDateTimeIndex = endIndex.GetValueAsString(),
-                        IndexType = WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME,
                         LogData = new WitsmlLogData
                         {
                             MnemonicList = string.Join(",", SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME]),
@@ -437,7 +436,6 @@ namespace WitsmlExplorer.Api.Tests.Workers
                     {
                         StartIndex = new WitsmlIndex(new DepthIndex(startIndex.Value)),
                         EndIndex = new WitsmlIndex(new DepthIndex(endIndex.Value)),
-                        IndexType = WitsmlLog.WITSML_INDEX_TYPE_MD,
                         LogData = new WitsmlLogData
                         {
                             MnemonicList = string.Join(",", mnemonics ?? SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD]),


### PR DESCRIPTION
## Fixes
This pull request fixes WE-842

## Description
Fix missing indexType in CopyLogDataWorker. I don't think CopyLogDataWorker has ever copied more than 10000 rows at a time with this bug being present.

## Type of change

* Bugfix

## Impacted Areas in Application
* API

## Checklist:
_Please tick all the boxes or remove the ones that aren't needed and explain why_

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
