### PR TITLE
WE-845 bump Microsoft.Identity.Web

### DIFF
--- a/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
+++ b/Src/WitsmlExplorer.Api/WitsmlExplorer.Api.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.5" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.5.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="NetCore.AutoRegisterDi" Version="2.1.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />


### PR DESCRIPTION
## Fixes
This pull request fixes WE-845

## Description
Bump Microsoft.Identity.Web to 2.5.0 to fix error on the very first auth attempt after every restart of API.

## Type of change

* Bugfix

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
