### PR TITLE
WE-852 fix null error on no more log data

### DIFF
--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -134,7 +134,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
                 WitsmlLogs query = LogQueries.GetLogContent(job.Source.Parent.WellUid, job.Source.Parent.WellboreUid,
                     job.Source.Parent.Uid, sourceLog.IndexType, mnemonics, startIndex, endIndex);
                 WitsmlLogs sourceData = await GetSourceWitsmlClientOrThrow().GetFromStoreAsync(query, new OptionsIn(ReturnElements.DataOnly));
-                if (!sourceData.Logs.Any())
+                if (!sourceData.Logs.Any() || sourceData.Logs.First().LogData == null)
                 {
                     break;
                 }


### PR DESCRIPTION
## Fixes
This pull request fixes WE-852

## Description
Fix error on null when the log data query returns a log with null logData. LogData is possibly null at that point due to no more data for the given mnemonics.

## Type of change

* Bugfix

## Impacted Areas in Application

* API

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
