### PR TITLE
WE-857 use WitsmlAuth header for authorization route

### DIFF
--- a/Docs/APICLIENT.md
+++ b/Docs/APICLIENT.md
@@ -23,7 +23,7 @@ var credentials = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{w
 
 using var httpClient = new HttpClient();
 var request = new HttpRequestMessage(HttpMethod.Get, url);
-request.Headers.Add("WitsmlTargetServer", $"{credentials}@{witsmlServer}");
+request.Headers.Add("WitsmlAuth", $"{credentials}@{witsmlServer}");
 
 var response = httpClient.Send(request); 
 var setCookie = response.Headers.FirstOrDefault(n=> n.Key == "Set-Cookie").Value.ToList()[0];
@@ -61,7 +61,7 @@ credentials = base64.b64encode(f"{witsmluser}:{witsmlpass}".encode()).decode()
 url = "https://localhost:5001/api/credentials/authorize"
 witsmlserver= "https://witsml-server.com"
 params = {  "keep": "false" }
-headers = { "WitsmlTargetServer": f"{credentials}@{witsmlserver}" }
+headers = { "WitsmlAuth": f"{credentials}@{witsmlserver}" }
 cookies = {'witsmlexplorer': ''}
 ca_certs = "localhost.pem" # For local dev-certs, in case of https
 

--- a/Docs/BASIC_AUTH.md
+++ b/Docs/BASIC_AUTH.md
@@ -55,7 +55,7 @@ When developing, visit `https://localhost:5001/swagger/index.html` to examine en
 The `WitsmlServerHandler` at `/api/witsml-servers` endpoint can be used to get a list of WITSML servers in json format without any credentials.
 
 Steps to use endpoints with `Basic` authentication
-1. Authenticate against the WITSML server through the `AuthorizationHandler` endpoint `/api/credentials/authorize`. Url and base64 encoded credentials needs to be provided with the request in the header `WitsmlTargetServer`. 
+1. Authenticate against the WITSML server through the `AuthorizationHandler` endpoint `/api/credentials/authorize`. Url and base64 encoded credentials needs to be provided with the request in the header `WitsmlAuth`. 
 2. Now visit any endpoint, e.g. `/api/wells` and provide the same Url in the header `WitsmlTargetServer` (now without credentials), as well as the username in the `WitsmlTargetUsername` header
 
 Further information about the header format is given on the swagger page/endpoint. 
@@ -77,7 +77,7 @@ HTTP/1.1 200 OK
 Set-Cookie: witsmlexplorer=9a8c9c5d-1d0c-4ebf-867d-6641962da380; path=/; secure; samesite=strict; httponly
 ```
 
-__2. Authorize WITSML credentials__ for the WITSML server you will query, this to ensure that backend encrypts the password and caches it against your session. The WitsmlTargetServer consists of base 64 encoded `username:password` (in the following example it is `user123:pass456`), and, after the 'at' sign `@`, the WITSML server URL.
+__2. Authorize WITSML credentials__ for the WITSML server you will query, this to ensure that backend encrypts the password and caches it against your session. The WitsmlAuth consists of base 64 encoded `username:password` (in the following example it is `user123:pass456`), and, after the 'at' sign `@`, the WITSML server URL.
 
 ```http
 GET http://localhost:5000/api/credentials/authorize?keep=false HTTP/1.1
@@ -85,7 +85,7 @@ Host: localhost:5000
 Content-Type: application/json
 Origin: http://localhost:3000
 Cookie: witsmlexplorer=9a8c9c5d-1d0c-4ebf-867d-6641962da380
-WitsmlTargetServer: dXNlcjEyMzpwYXNzNDU2@https://witsmlserver.using.basic.creds/Store/WITSML
+WitsmlAuth: dXNlcjEyMzpwYXNzNDU2@https://witsmlserver.using.basic.creds/Store/WITSML
 ```
 ```http
 HTTP/1.1 200 OK

--- a/Docs/OAUTH.md
+++ b/Docs/OAUTH.md
@@ -167,7 +167,7 @@ The `WitsmlServerHandler` at `/api/witsml-servers` endpoint can be used to get a
 
 Steps to use endpoints:
 1. Authorize with the tenant.
-2. Authenticate against the WITSML server through the `AuthorizationHandler` endpoint `/api/credentials/authorize`. Url and base64 encoded credentials needs to be provided with the request in the header `WitsmlTargetServer`. 
+2. Authenticate against the WITSML server through the `AuthorizationHandler` endpoint `/api/credentials/authorize`. Url and base64 encoded credentials needs to be provided with the request in the header `WitsmlAuth`. 
 3. Now visit any endpoint, e.g. `/api/wells` and provide the same Url in the header `WitsmlTargetServer` (now without credentials), as well as the username in the `WitsmlTargetUsername` header.
 
 When using a system user, the second step can be omitted.
@@ -211,6 +211,6 @@ Authorization: Bearer eyJ...<token here>
 Host: localhost:5000
 Content-Type: application/json
 Origin: http://localhost:3000
-WitsmlTargetServer: dXNlcjEyMzpwYXNzNDU2@https://witsmlserver.using.basic.creds/Store/WITSML
+WitsmlAuth: dXNlcjEyMzpwYXNzNDU2@https://witsmlserver.using.basic.creds/Store/WITSML
 ```
 (note the base64 encoded `username:password` @ witsmlserver)

--- a/Src/WitsmlExplorer.Api/HttpHandlers/EssentialHeaders.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/EssentialHeaders.cs
@@ -6,6 +6,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
     {
 
         public string Authorization { get; }
+        public string WitsmlAuth { get; }
         public string TargetServer { get; }
         public string SourceServer { get; }
         public string TargetUsername { get; }
@@ -18,6 +19,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
     public class EssentialHeaders : IEssentialHeaders
     {
         public static readonly string CookieName = "witsmlexplorer";
+        public static readonly string WitsmlAuthHeader = "WitsmlAuth";
         public static readonly string WitsmlTargetServer = "WitsmlTargetServer";
         public static readonly string WitsmlSourceServer = "WitsmlSourceServer";
         public static readonly string WitsmlTargetUsername = "WitsmlTargetUsername";
@@ -28,6 +30,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
         {
 
             Authorization = httpRequest?.Headers["Authorization"];
+            WitsmlAuth = httpRequest?.Headers[WitsmlAuthHeader];
             TargetServer = httpRequest?.Headers[WitsmlTargetServer];
             SourceServer = httpRequest?.Headers[WitsmlSourceServer];
             TargetUsername = httpRequest?.Headers[WitsmlTargetUsername];
@@ -35,6 +38,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
             WitsmlExplorerCookie = httpRequest?.Cookies[CookieName];
         }
         public string Authorization { get; init; }
+        public string WitsmlAuth { get; init; }
         public string TargetServer { get; init; }
         public string SourceServer { get; init; }
         public string TargetUsername { get; init; }

--- a/Src/WitsmlExplorer.Api/Middleware/ExceptionMiddleware.cs
+++ b/Src/WitsmlExplorer.Api/Middleware/ExceptionMiddleware.cs
@@ -45,7 +45,7 @@ namespace WitsmlExplorer.Api.Middleware
             catch (EndpointNotFoundException ex)
             {
                 Log.Debug($"Not able to connect server endpoint. : {ex}");
-                ServerCredentials witsmlTarget = httpContext.Request.GetWitsmlServerHttpHeader(EssentialHeaders.WitsmlTargetServer, n => "");
+                ServerCredentials witsmlTarget = httpContext.Request.GetWitsmlServerHttpHeader(EssentialHeaders.WitsmlAuthHeader, n => "");
                 ErrorDetails errorDetails = new()
                 {
                     StatusCode = (int)HttpStatusCode.NotFound,

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -58,7 +58,7 @@ namespace WitsmlExplorer.Api.Services
 
         public async Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, HttpContext httpContext)
         {
-            ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(eh.TargetServer, Decrypt);
+            ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(eh.WitsmlAuth, Decrypt);
             if (creds.IsCredsNullOrEmpty())
             {
                 return false;

--- a/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
+++ b/Src/WitsmlExplorer.Api/Swagger/WitsmlHeaderFilter.cs
@@ -9,7 +9,7 @@ using WitsmlExplorer.Api.HttpHandlers;
 namespace WitsmlExplorer.Api.Swagger
 {
     /// <summary>
-    /// This class will add a Required HTTP Header `WitsmlTargetServer` and `WitsmlSourceServer`to SwaggerUI for all required endpoints,
+    /// This class will add a Required HTTP Headers to SwaggerUI for all required endpoints,
     /// </summary>
     public class WitsmlHeaderFilter : IOperationFilter
     {
@@ -24,7 +24,7 @@ namespace WitsmlExplorer.Api.Swagger
         """;
 
         private static readonly string USERNAME_DESCRIPTION = """
-            Use the same username as the one passed in the WitsmlTargetServer header to the api/credentials/authorize route.
+            Use the same username as the one passed in the WitsmlAuth header to the api/credentials/authorize route.
         """;
 
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
@@ -39,11 +39,25 @@ namespace WitsmlExplorer.Api.Swagger
 
             if (authorizeHeaders)
             {
-                AddTargetServerHeader(operation, AUTHORIZE_DESCRIPTION);
+                operation.Parameters.Add(new OpenApiParameter
+                {
+                    Name = EssentialHeaders.WitsmlAuthHeader,
+                    In = ParameterLocation.Header,
+                    Schema = new OpenApiSchema { Type = "string" },
+                    Required = true,
+                    Description = AUTHORIZE_DESCRIPTION
+                });
             }
             else if (!noHeader)
             {
-                AddTargetServerHeader(operation, SERVER_DESCRIPTION);
+                operation.Parameters.Add(new OpenApiParameter
+                {
+                    Name = EssentialHeaders.WitsmlTargetServer,
+                    In = ParameterLocation.Header,
+                    Schema = new OpenApiSchema { Type = "string" },
+                    Required = true,
+                    Description = SERVER_DESCRIPTION
+                });
                 if (targetUsernameHeader)
                 {
                     AddTargetUsernameHeader(operation);
@@ -83,18 +97,5 @@ namespace WitsmlExplorer.Api.Swagger
                 Description = USERNAME_DESCRIPTION
             });
         }
-
-        private static void AddTargetServerHeader(OpenApiOperation operation, string description)
-        {
-            operation.Parameters.Add(new OpenApiParameter
-            {
-                Name = EssentialHeaders.WitsmlTargetServer,
-                In = ParameterLocation.Header,
-                Schema = new OpenApiSchema { Type = "string" },
-                Required = true,
-                Description = description
-            });
-        }
-
     }
 }

--- a/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationClient.tsx
@@ -8,8 +8,7 @@ export class AuthorizationClient {
     return {
       "Content-Type": "application/json",
       ...(authorizationHeader ? { Authorization: authorizationHeader } : {}),
-      "WitsmlTargetServer": this.getServerHeader(credentials[0]),
-      "WitsmlSourceServer": this.getServerHeader(credentials[1])
+      "WitsmlAuth": this.getServerHeader(credentials[0])
     };
   }
 

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -96,7 +96,7 @@ class AuthorizationService {
   }
 
   // Verify basic credentials for the first time
-  // Basic credentials for this call will be set in header: WitsmlTargetServer
+  // Basic credentials for this call will be set in header: WitsmlAuth
   public async verifyCredentials(credentials: BasicServerCredentials, keep: boolean, abortSignal?: AbortSignal): Promise<any> {
     try {
       if (keep) {


### PR DESCRIPTION
## Fixes
This pull request fixes WE-857

## Description
Use new WitsmlAuth header instead of WitsmlTargetServer for authorization rotue.

## Type of change

* Enhancement of existing functionality

## Impacted Areas in Application

* API, Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [x] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests
