### PR TITLE
WE-865 case insensitive server match in routing

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -64,10 +64,10 @@ const Routing = (): React.ReactElement => {
     // update selected server when servers are fetched
     if (isSyncingUrlAndState && urlParams) {
       const serverUrl = urlParams.serverUrl;
-      const server = servers.find((server: Server) => server.url === serverUrl);
+      const server = servers.find((server: Server) => server.url.toLowerCase() === serverUrl.toLowerCase());
       if (server && !selectedServer) {
         if (hasSelectedServer) {
-          // finish syncing if we already attempted to select a server (such as on login cancellation)
+          // finish syncing if routing has already attempted to navigate to a server (such as on login cancellation)
           setIsSyncingUrlAndState(false);
         } else {
           setHasSelectedServer(true);


### PR DESCRIPTION
## Fixes
This pull request fixes WE-865

## Description
Match servers in routing without checking casing.

## Type of change

* Bugfix

## Impacted Areas in Application
* Frontend

## Checklist:

*Communication*
* [x] PR is related to an issue
* [ ] I have made corresponding changes to the documentation

*Code quality*
* [x] Code follows the style guidelines
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] Existing tests pass
* [ ] New code is covered by passing tests