### PR TITLE
WE-862 make Index.AddEpsilon obsolete

### DIFF
--- a/Src/Witsml/Data/Curves/DateTimeIndex.cs
+++ b/Src/Witsml/Data/Curves/DateTimeIndex.cs
@@ -34,6 +34,7 @@ namespace Witsml.Data.Curves
             return false;
         }
 
+        [Obsolete("AddEpsilon is deprecated due to assuming 3 decimals of precision for depth indexes. Some WITSML servers do not use 3 decimals.")]
         public override Index AddEpsilon() => new DateTimeIndex(Value.AddMilliseconds(1));
 
         public override int CompareTo(Index that)

--- a/Src/Witsml/Data/Curves/DepthIndex.cs
+++ b/Src/Witsml/Data/Curves/DepthIndex.cs
@@ -39,6 +39,7 @@ namespace Witsml.Data.Curves
 
         private bool HasSameUnitAs(DepthIndex that) => Uom.Equals(that.Uom);
 
+        [Obsolete("AddEpsilon is deprecated due to assuming 3 decimals of precision for depth indexes. Some WITSML servers do not use 3 decimals.")]
         public override Index AddEpsilon() => new DepthIndex(Value + OffsetEpsilon, Uom);
 
         private Index Subtract(Index that)

--- a/Src/Witsml/Data/Curves/Index.cs
+++ b/Src/Witsml/Data/Curves/Index.cs
@@ -27,6 +27,7 @@ namespace Witsml.Data.Curves
             return index1.CompareTo(index2) >= 0;
         }
 
+        [Obsolete("AddEpsilon is deprecated due to assuming 3 decimals of precision for depth indexes. Some WITSML servers do not use 3 decimals.")]
         public abstract Index AddEpsilon();
 
         public abstract int CompareTo(Index other);

--- a/Src/WitsmlExplorer.Api/Services/LogDataReader.cs
+++ b/Src/WitsmlExplorer.Api/Services/LogDataReader.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Witsml;
+using Witsml.Data;
+using Witsml.Data.Curves;
+using Witsml.ServiceReference;
+
+using WitsmlExplorer.Api.Query;
+
+using Index = Witsml.Data.Curves.Index;
+
+namespace WitsmlExplorer.Api.Services
+{
+    public class LogDataReader
+    {
+        private readonly IWitsmlClient _witsmlClient;
+        private readonly string _uidWell;
+        private readonly string _uidWellbore;
+        private readonly string _uidLog;
+        private readonly string _indexType;
+        private readonly IEnumerable<string> _mnemonics;
+        private Index _startIndex;
+        private readonly Index _endIndex;
+        private bool _dropFirstRow;
+
+        public string StartIndex => _startIndex.GetValueAsString();
+        private bool _finished;
+
+        /// <summary>
+        /// Initializes a LogDataReader that will fetch all data as specified by the <paramref name="sourceLog"/> and <paramref name="mnemonics"/>.
+        /// </summary>
+        /// <param name="witsmlClient">The witsmlClient used to fetch data</param>
+        /// <param name="sourceLog">A WitsmlLog object used to retrieve well, wellbore, and log uids, and the start, end, type, and mnemonic of the index curve.</param>
+        /// <param name="mnemonics">A list of mnemonics to fetch. The index curve will be added to this list if not present.</param>
+        /// <param name="logger">A logger or null</param>
+        public LogDataReader(IWitsmlClient witsmlClient, WitsmlLog sourceLog, List<string> mnemonics, ILogger logger)
+        {
+            _witsmlClient = witsmlClient;
+            _uidWell = sourceLog.UidWell;
+            _uidWellbore = sourceLog.UidWellbore;
+            _uidLog = sourceLog.Uid;
+            _indexType = sourceLog.IndexType;
+
+            _startIndex = Index.Start(sourceLog);
+            _endIndex = Index.End(sourceLog);
+            _mnemonics = mnemonics;
+            if (!mnemonics.Any())
+            {
+                _finished = true;
+                logger?.LogInformation("{ClassName} received an empty mnemonics list. No data will be fetched", GetType().Name);
+            }
+            else
+            {
+                string indexMnemonic = sourceLog.IndexCurve.Value;
+                if (!mnemonics.Contains(indexMnemonic, StringComparer.InvariantCultureIgnoreCase))
+                {
+                    mnemonics.Insert(0, indexMnemonic);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fetches and returns the next batch of log data.
+        /// </summary>
+        /// <returns>WitsmlLogData or, if there is no more data to fetch, null</returns>
+        public async Task<WitsmlLogData> GetNextBatch()
+        {
+            if (_finished)
+            {
+                return null;
+            }
+            WitsmlLogs query = LogQueries.GetLogContent(_uidWell, _uidWellbore, _uidLog, _indexType, _mnemonics, _startIndex, _endIndex);
+            WitsmlLogs sourceData = await _witsmlClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.DataOnly));
+            if (!sourceData.Logs.Any() || sourceData.Logs.First().LogData == null || !sourceData.Logs.First().LogData.Data.Any())
+            {
+                _finished = true;
+                return null;
+            }
+
+            WitsmlLog sourceLogWithData = sourceData.Logs.First();
+            WitsmlLogData sourceLogData = sourceLogWithData.LogData;
+            if (_dropFirstRow)
+            {
+                sourceLogData.Data.RemoveAt(0);
+                if (!sourceLogData.Data.Any())
+                {
+                    _finished = true;
+                    return null;
+                }
+            }
+
+            string index = sourceLogData.Data.Last().Data.Split(",")[0];
+            _startIndex = _indexType == WitsmlLog.WITSML_INDEX_TYPE_MD
+            ? new DepthIndex(double.Parse(index, CultureInfo.InvariantCulture), ((DepthIndex)_endIndex).Uom)
+            : new DateTimeIndex(DateTime.Parse(index));
+
+            _dropFirstRow = true;
+            return sourceLogData;
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
+++ b/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
@@ -129,11 +129,6 @@ namespace WitsmlExplorer.Api.Services
             Index startIndex = Index.Start(log, start);
             Index endIndex = Index.End(log, end);
 
-            if (!startIndexIsInclusive)
-            {
-                startIndex = startIndex.AddEpsilon();
-            }
-
             if (startIndex > endIndex)
             {
                 return new LogData();
@@ -147,12 +142,21 @@ namespace WitsmlExplorer.Api.Services
 
             WitsmlLogs query = LogQueries.GetLogContent(wellUid, wellboreUid, logUid, log.IndexType, mnemonics, startIndex, endIndex);
             WitsmlLogs witsmlLogs = await _witsmlClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.All));
-            if (!witsmlLogs.Logs.Any() || witsmlLogs.Logs.First().LogData == null)
+            if (!witsmlLogs.Logs.Any() || witsmlLogs.Logs.First().LogData == null || !witsmlLogs.Logs.First().LogData.Data.Any())
             {
                 return new LogData();
             }
 
             WitsmlLog witsmlLog = witsmlLogs.Logs.First();
+
+            if (!startIndexIsInclusive)
+            {
+                witsmlLog.LogData.Data.RemoveAt(0);
+                if (witsmlLog.LogData.Data.Count == 0)
+                {
+                    return new LogData();
+                }
+            }
 
             string[] witsmlLogMnemonics = witsmlLog.LogData.MnemonicList.Split(",");
             string[] witsmlLogUnits = witsmlLog.LogData.UnitList.Split(",");

--- a/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Copy/CopyLogDataWorker.cs
@@ -118,52 +118,30 @@ namespace WitsmlExplorer.Api.Workers.Copy
             return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), false, "Failed to copy log data", message), null);
         }
 
-        private async Task<CopyResult> CopyLogData(WitsmlLog sourceLog, WitsmlLog targetLog, CopyLogDataJob job, IReadOnlyCollection<string> mnemonics, int sourceDepthLogDecimals, int targetDepthLogDecimals)
+        private async Task<CopyResult> CopyLogData(WitsmlLog sourceLog, WitsmlLog targetLog, CopyLogDataJob job, List<string> mnemonics, int sourceDepthLogDecimals, int targetDepthLogDecimals)
         {
             if (targetDepthLogDecimals > 0 && targetDepthLogDecimals < sourceDepthLogDecimals && sourceLog.IndexType == WitsmlLog.WITSML_INDEX_TYPE_MD)
             {
                 return await CopyLogDataWithoutDuplicates(sourceLog, targetLog, job, mnemonics, targetDepthLogDecimals);
             }
 
-            Index startIndex = Index.Start(sourceLog);
-            Index endIndex = Index.End(sourceLog);
             int numberOfDataRowsCopied = 0;
-            bool dropFirstRow = false;
-
-            while (startIndex < endIndex)
+            LogDataReader logDataReader = new(GetSourceWitsmlClientOrThrow(), sourceLog, mnemonics, Logger);
+            WitsmlLogData sourceLogData = await logDataReader.GetNextBatch();
+            while (sourceLogData != null)
             {
-                WitsmlLogs query = LogQueries.GetLogContent(job.Source.Parent.WellUid, job.Source.Parent.WellboreUid,
-                    job.Source.Parent.Uid, sourceLog.IndexType, mnemonics, startIndex, endIndex);
-                WitsmlLogs sourceData = await GetSourceWitsmlClientOrThrow().GetFromStoreAsync(query, new OptionsIn(ReturnElements.DataOnly));
-                if (!sourceData.Logs.Any() || sourceData.Logs.First().LogData == null)
-                {
-                    break;
-                }
-
-                WitsmlLog sourceLogWithData = sourceData.Logs.First();
-                if (dropFirstRow)
-                {
-                    sourceLogWithData.LogData.Data.RemoveAt(0);
-                    if (!sourceLogWithData.LogData.Data.Any())
-                    {
-                        break;
-                    }
-                }
-                WitsmlLogs copyNewCurvesQuery = CreateCopyQuery(targetLog, sourceLogWithData);
+                WitsmlLogs copyNewCurvesQuery = CreateCopyQuery(targetLog, sourceLogData);
                 QueryResult result = await GetTargetWitsmlClientOrThrow().UpdateInStoreAsync(copyNewCurvesQuery);
                 if (result.IsSuccessful)
                 {
-                    numberOfDataRowsCopied += copyNewCurvesQuery.Logs.First().LogData.Data.Count;
-                    string index = sourceLogWithData.LogData.Data.Last().Data.Split(",")[0];
-                    sourceLogWithData.IndexType = sourceLog.IndexType;
-                    startIndex = Index.End(sourceLogWithData, index);
-                    dropFirstRow = true;
+                    numberOfDataRowsCopied += sourceLogData.Data.Count;
                 }
                 else
                 {
-                    Logger.LogError("Failed to copy log data. - {Description} - Current index: {StartIndex}", job.Description(), startIndex.GetValueAsString());
+                    Logger.LogError("Failed to copy log data. - {Description} - Current index: {StartIndex}", job.Description(), logDataReader.StartIndex);
                     return new CopyResult { Success = false, NumberOfRowsCopied = numberOfDataRowsCopied, ErrorReason = result.Reason };
                 }
+                sourceLogData = await logDataReader.GetNextBatch();
             }
 
             return new CopyResult { Success = true, NumberOfRowsCopied = numberOfDataRowsCopied };
@@ -175,7 +153,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
             double endIndex = StringHelpers.ToDouble(sourceLog.EndIndex.Value);
             int numberOfDataRowsCopied = 0;
             int originalNumberOfRows = 0;
-            while (startIndex < endIndex)
+            do
             {
                 WitsmlLogs query = LogQueries.GetLogContent(
                     job.Source.Parent.WellUid,
@@ -221,7 +199,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
 
                 sourceLogWithData.LogData.Data = newData;
 
-                WitsmlLogs copyNewCurvesQuery = CreateCopyQuery(targetLog, sourceLogWithData);
+                WitsmlLogs copyNewCurvesQuery = CreateCopyQuery(targetLog, sourceLogWithData.LogData);
                 QueryResult result = await GetTargetWitsmlClientOrThrow().UpdateInStoreAsync(copyNewCurvesQuery);
                 if (result.IsSuccessful)
                 {
@@ -233,7 +211,7 @@ namespace WitsmlExplorer.Api.Workers.Copy
                     Logger.LogError("Failed to copy log data. - {Description} - Current index: {StartIndex}", job.Description(), startIndex.ToString());
                     return new CopyResult { Success = false, NumberOfRowsCopied = numberOfDataRowsCopied, ErrorReason = result.Reason };
                 }
-            }
+            } while (startIndex < endIndex);
 
             return new CopyResult { Success = true, NumberOfRowsCopied = numberOfDataRowsCopied, OriginalNumberOfRows = originalNumberOfRows };
         }
@@ -283,21 +261,19 @@ namespace WitsmlExplorer.Api.Workers.Copy
             }
         }
 
-        private static WitsmlLogs CreateCopyQuery(WitsmlLog targetLog, WitsmlLog sourceLogWithData)
+        private static WitsmlLogs CreateCopyQuery(WitsmlLog targetLog, WitsmlLogData logData)
         {
-            WitsmlLog updatedData = new()
+            return new()
             {
-                UidWell = targetLog.UidWell,
-                UidWellbore = targetLog.UidWellbore,
-                Uid = targetLog.Uid,
-                LogData = sourceLogWithData.LogData
+                Logs = new List<WitsmlLog> {
+                    new(){
+                        UidWell = targetLog.UidWell,
+                        UidWellbore = targetLog.UidWellbore,
+                        Uid = targetLog.Uid,
+                        LogData = logData
+                    }
+                }
             };
-
-            WitsmlLogs updatedWitsmlLog = new()
-            {
-                Logs = new List<WitsmlLog> { updatedData }
-            };
-            return updatedWitsmlLog;
         }
 
         private static void VerifyMatchingIndexTypes(WitsmlLog sourceLog, WitsmlLog targetLog)

--- a/Src/WitsmlExplorer.Api/Workers/RenameMnemonicWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/RenameMnemonicWorker.cs
@@ -10,12 +10,9 @@ using Witsml.Data;
 using Witsml.ServiceReference;
 
 using WitsmlExplorer.Api.Jobs;
-using WitsmlExplorer.Api.Jobs.Common;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Query;
 using WitsmlExplorer.Api.Services;
-
-using Index = Witsml.Data.Curves.Index;
 
 namespace WitsmlExplorer.Api.Workers
 {
@@ -28,31 +25,37 @@ namespace WitsmlExplorer.Api.Workers
         public override async Task<(WorkerResult, RefreshAction)> Execute(RenameMnemonicJob job)
         {
             Verify(job);
+            IWitsmlClient client = GetTargetWitsmlClientOrThrow();
 
-            var logHeader = await GetLog(job.LogReference);
+            WitsmlLog logHeader = await WorkerTools.GetLog(client, job.LogReference, ReturnElements.HeaderOnly);
 
-            var mnemonics = GetMnemonics(logHeader, job.Mnemonic);
-            var startIndex = Index.Start(logHeader);
-            var endIndex = Index.End(logHeader);
-
-            while (startIndex < endIndex)
+            List<string> mnemonics = GetMnemonics(logHeader, job.Mnemonic);
+            WitsmlLog updatedLog = new()
             {
-                var logData = await GetLogData(logHeader, mnemonics, startIndex, endIndex);
-                if (logData == null) break;
+                UidWell = logHeader.UidWell,
+                UidWellbore = logHeader.UidWellbore,
+                Uid = logHeader.Uid,
+                LogCurveInfo = logHeader.LogCurveInfo.Where(lci => mnemonics.Contains(lci.Mnemonic, StringComparer.OrdinalIgnoreCase)).ToList(),
+            };
+            updatedLog.LogCurveInfo.Find(c => c.Mnemonic == job.Mnemonic)!.Mnemonic = job.NewMnemonic;
+            WitsmlLogs updatedLogs = new() { Logs = new() { updatedLog } };
 
-                var updatedWitsmlLog = CreateNewLogWithRenamedMnemonic(job, logHeader, mnemonics, logData);
-
-                var result = await GetTargetWitsmlClientOrThrow().UpdateInStoreAsync(updatedWitsmlLog);
+            LogDataReader logDataReader = new(client, logHeader, mnemonics, Logger);
+            WitsmlLogData logData = await logDataReader.GetNextBatch();
+            while (logData != null)
+            {
+                logData.MnemonicList = string.Join(",", GetMnemonics(logHeader, job.NewMnemonic));
+                updatedLog.LogData = logData;
+                QueryResult result = await client.UpdateInStoreAsync(updatedLogs);
                 if (!result.IsSuccessful)
                 {
                     Logger.LogError("Failed to rename mnemonic. {jobDescription}", job.Description());
-                    return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), false, $"Failed to rename Mnemonic from {job.Mnemonic} to {job.NewMnemonic}", result.Reason), null);
+                    return (new WorkerResult(client.GetServerHostname(), false, $"Failed to rename Mnemonic from {job.Mnemonic} to {job.NewMnemonic}", result.Reason), null);
                 }
-
-                startIndex = Index.End(logData).AddEpsilon();
+                logData = await logDataReader.GetNextBatch();
             }
 
-            var resultDeleteOldMnemonic = await DeleteOldMnemonic(job.LogReference.WellUid, job.LogReference.WellboreUid, job.LogReference.Uid, job.Mnemonic);
+            WorkerResult resultDeleteOldMnemonic = await DeleteOldMnemonic(job.LogReference.WellUid, job.LogReference.WellboreUid, job.LogReference.Uid, job.Mnemonic);
             if (!resultDeleteOldMnemonic.IsSuccess)
             {
                 return (resultDeleteOldMnemonic, null);
@@ -60,47 +63,14 @@ namespace WitsmlExplorer.Api.Workers
 
             Logger.LogInformation("{JobType} - Job successful. Mnemonic renamed from {Mnemonic} to {NewMnemonic}", GetType().Name, job.Mnemonic, job.NewMnemonic);
             return (
-                new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Mnemonic renamed from {job.Mnemonic} to {job.NewMnemonic}"),
-                new RefreshObjects(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogReference.WellUid, job.LogReference.WellboreUid, EntityType.Log, job.LogReference.Uid));
-        }
-
-        private static WitsmlLogs CreateNewLogWithRenamedMnemonic(RenameMnemonicJob job, WitsmlLog logHeader, IEnumerable<string> mnemonics, WitsmlLog logData)
-        {
-            var updatedData = new WitsmlLog
-            {
-                UidWell = logHeader.UidWell,
-                UidWellbore = logHeader.UidWellbore,
-                Uid = logHeader.Uid,
-                LogCurveInfo = logHeader.LogCurveInfo.Where(lci => mnemonics.Contains(lci.Mnemonic, StringComparer.OrdinalIgnoreCase)).ToList(),
-                LogData = logData.LogData
-            };
-            updatedData.LogCurveInfo.Find(c => c.Mnemonic == job.Mnemonic)!.Mnemonic = job.NewMnemonic;
-            updatedData.LogData.MnemonicList = string.Join(",", GetMnemonics(logHeader, job.NewMnemonic));
-
-            return new WitsmlLogs
-            {
-                Logs = new List<WitsmlLog> { updatedData }
-            };
-        }
-
-        private async Task<WitsmlLog> GetLogData(WitsmlLog log, IEnumerable<string> mnemonics, Index startIndex, Index endIndex)
-        {
-            var query = LogQueries.GetLogContent(
-                log.UidWell,
-                log.UidWellbore,
-                log.Uid,
-                log.IndexType,
-                mnemonics,
-                startIndex, endIndex);
-
-            var data = await GetTargetWitsmlClientOrThrow().GetFromStoreAsync(query, new OptionsIn(ReturnElements.DataOnly));
-            return data.Logs.Any() ? data.Logs.First() : null;
+                new WorkerResult(client.GetServerHostname(), true, $"Mnemonic renamed from {job.Mnemonic} to {job.NewMnemonic}"),
+                new RefreshObjects(client.GetServerHostname(), job.LogReference.WellUid, job.LogReference.WellboreUid, EntityType.Log, job.LogReference.Uid));
         }
 
         private async Task<WorkerResult> DeleteOldMnemonic(string wellUid, string wellboreUid, string logUid, string mnemonic)
         {
-            var query = LogQueries.DeleteMnemonics(wellUid, wellboreUid, logUid, new[] { mnemonic });
-            var result = await GetTargetWitsmlClientOrThrow().DeleteFromStoreAsync(query);
+            WitsmlLogs query = LogQueries.DeleteMnemonics(wellUid, wellboreUid, logUid, new[] { mnemonic });
+            QueryResult result = await GetTargetWitsmlClientOrThrow().DeleteFromStoreAsync(query);
             if (result.IsSuccessful)
             {
                 return new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Successfully deleted old mnemonic");
@@ -116,26 +86,19 @@ namespace WitsmlExplorer.Api.Workers
             {
                 throw new InvalidOperationException("Empty name given when trying to rename a mnemonic. Make sure valid names are given");
             }
-            else if (job.Mnemonic.Equals(job.NewMnemonic))
+            else if (job.Mnemonic.Equals(job.NewMnemonic, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException("Cannot rename a mnemonic to the same name it already has. Make sure new mnemonic is a unique name");
             }
         }
 
-        private static IReadOnlyCollection<string> GetMnemonics(WitsmlLog log, string mnemonic)
+        private static List<string> GetMnemonics(WitsmlLog log, string mnemonic)
         {
             return new List<string>
             {
                 log.IndexCurve.Value,
                 mnemonic
             };
-        }
-
-        private async Task<WitsmlLog> GetLog(ObjectReference logReference)
-        {
-            var logQuery = LogQueries.GetWitsmlLogById(logReference.WellUid, logReference.WellboreUid, logReference.Uid);
-            var logs = await GetTargetWitsmlClientOrThrow().GetFromStoreAsync(logQuery, new OptionsIn(ReturnElements.HeaderOnly));
-            return !logs.Logs.Any() ? null : logs.Logs.First();
         }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Services/LogDataReaderTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/LogDataReaderTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Threading.Tasks;
+
+using Moq;
+
+using Witsml;
+using Witsml.Data;
+
+using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Tests.Workers;
+
+using Xunit;
+
+namespace WitsmlExplorer.Api.Tests.Services
+{
+    public class LogDataReaderTests
+    {
+        private readonly Mock<IWitsmlClient> _witsmlClient;
+
+        public LogDataReaderTests()
+        {
+            Mock<IWitsmlClientProvider> witsmlClientProvider = new();
+            _witsmlClient = new Mock<IWitsmlClient>();
+            witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+        }
+
+        [Fact]
+        public async Task GetNextBatch_LastBatch_SingleRowDisregarded()
+        {
+            WitsmlLog sourceLog = LogUtils.GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, 123.11, 123.12, "Depth").Logs.First();
+            LogUtils.SetupGetDepthIndexed(_witsmlClient, (logs) => logs.Logs.First().StartIndex?.Value == "123.11",
+            new() { new() { Data = "123.11,1," }, new() { Data = "123.12,,2" } });
+            LogUtils.SetupGetDepthIndexed(_witsmlClient, (logs) => logs.Logs.First().StartIndex?.Value == "123.12",
+            new() { new() { Data = "123.12,,2" } });
+            LogDataReader logDataReader = new(_witsmlClient.Object, sourceLog, LogUtils.SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD].ToList(), null);
+
+            WitsmlLogData firstBatch = await logDataReader.GetNextBatch();
+            WitsmlLogData lastBatch = await logDataReader.GetNextBatch();
+
+            Assert.Equal("123.11,1,", firstBatch.Data.First().Data);
+            Assert.Equal("123.12,,2", firstBatch.Data.Last().Data);
+            Assert.Null(lastBatch);
+        }
+    }
+}

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerDuplicateTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerDuplicateTests.cs
@@ -9,9 +9,6 @@ using Moq;
 
 using Witsml;
 using Witsml.Data;
-using Witsml.Data.Curves;
-using Witsml.Extensions;
-using Witsml.ServiceReference;
 
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Models;
@@ -42,15 +39,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlTargetClient.Object);
             witsmlClientProvider.Setup(provider => provider.GetSourceClient()).Returns(_witsmlSourceClient.Object);
             _documentRepository = new();
-            Mock<ILogger<CopyLogDataJob>> logger = new();
-            _worker = new CopyLogDataWorker(witsmlClientProvider.Object, logger.Object, _documentRepository.Object);
-        }
-
-        [Fact]
-        public async Task Execute_FewerTargetDecimals_DuplicatesCollated()
-        {
             _documentRepository.Setup(client => client.GetDocumentsAsync())
-                        .ReturnsAsync(new List<Server>(){
+            .ReturnsAsync(new List<Server>(){
                             new(){
                                 Url = _targetUri,
                                 DepthLogDecimals = 1
@@ -59,13 +49,22 @@ namespace WitsmlExplorer.Api.Tests.Workers
                                 Url = _sourceUri,
                                 DepthLogDecimals = 2
                             }
-                        });
+            });
+            Mock<ILogger<CopyLogDataJob>> logger = new();
+            _worker = new CopyLogDataWorker(witsmlClientProvider.Object, logger.Object, _documentRepository.Object);
+        }
+
+        [Fact]
+        public async Task Execute_FewerTargetDecimals_DuplicatesCollated()
+        {
             CopyLogDataJob job = LogUtils.CreateJobTemplate();
             WitsmlLogs sourceLogs = LogUtils.GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, 123.11, 123.15, "Depth");
             LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlSourceClient, sourceLogs);
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlTargetClient);
-            SetupGetDepthIndexed(_witsmlSourceClient, (logs) => true,
+            LogUtils.SetupGetDepthIndexed(_witsmlSourceClient, (logs) => logs.Logs.First().StartIndex?.Value == "123.11",
             new() { new() { Data = "123.11,1," }, new() { Data = "123.12,,2" }, new() { Data = "123.13,3," }, new() { Data = "123.15,4," } });
+            LogUtils.SetupGetDepthIndexed(_witsmlSourceClient, (logs) => logs.Logs.First().StartIndex?.Value == "123.15",
+            new() { new() { Data = "123.15,4," } });
             List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlTargetClient);
 
             await _worker.Execute(job);
@@ -77,25 +76,15 @@ namespace WitsmlExplorer.Api.Tests.Workers
         [Fact]
         public async Task Execute_FewerTargetDecimalsNewRowSplitBetweenBatches_NoSourceRowsOmitted()
         {
-            _documentRepository.Setup(client => client.GetDocumentsAsync())
-                        .ReturnsAsync(new List<Server>(){
-                            new(){
-                                Url = _targetUri,
-                                DepthLogDecimals = 1
-                            },
-                            new(){
-                                Url = _sourceUri,
-                                DepthLogDecimals = 2
-                            }
-                        });
             CopyLogDataJob job = LogUtils.CreateJobTemplate();
             WitsmlLogs sourceLogs = LogUtils.GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, 123.11, 123.18, "Depth");
             LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlSourceClient, sourceLogs);
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlTargetClient);
-            SetupGetDepthIndexed(_witsmlSourceClient, logs => logs.Logs.First().StartIndex?.Value == "123.11",
+            LogUtils.SetupGetDepthIndexed(_witsmlSourceClient, logs => logs.Logs.First().StartIndex?.Value == "123.11",
             new() { new() { Data = "123.11,1," }, new() { Data = "123.16,,2" } });
-            SetupGetDepthIndexed(_witsmlSourceClient, logs => logs.Logs.First().StartIndex?.Value == "123.16",
+            LogUtils.SetupGetDepthIndexed(_witsmlSourceClient, logs => logs.Logs.First().StartIndex?.Value == "123.16",
             new() { new() { Data = "123.16,,2" }, new() { Data = "123.17,3," }, new() { Data = "123.18,,4" } });
+            LogUtils.SetupGetDepthIndexed(_witsmlSourceClient, logs => logs.Logs.First().StartIndex?.Value == "123.18", new() { new() { Data = "123.18,,4" } });
             List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlTargetClient);
 
             await _worker.Execute(job);
@@ -104,24 +93,19 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Assert.Equal("123.2,3,2", updatedLogs[1].Logs.First().LogData.Data[0].Data);
         }
 
-        private static void SetupGetDepthIndexed(Mock<IWitsmlClient> witsmlClient, Func<WitsmlLogs, bool> predicate, List<WitsmlData> data)
+        [Fact]
+        public async Task Execute_FewerTargetDecimalsOneDepthRow_CopiedCorrectly()
         {
-            witsmlClient.Setup(client => client.GetFromStoreAsync(It.Is<WitsmlLogs>(logs => predicate(logs)), new OptionsIn(ReturnElements.DataOnly, null, null)))
-                .ReturnsAsync(() => new WitsmlLogs
-                {
-                    Logs = new WitsmlLog
-                    {
-                        StartIndex = new WitsmlIndex(new DepthIndex(StringHelpers.ToDouble(data.First().Data.Split(",")[0]))),
-                        EndIndex = new WitsmlIndex(new DepthIndex(StringHelpers.ToDouble(data.Last().Data.Split(",")[0]))),
-                        IndexType = WitsmlLog.WITSML_INDEX_TYPE_MD,
-                        LogData = new WitsmlLogData
-                        {
-                            MnemonicList = string.Join(",", LogUtils.SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD]),
-                            UnitList = "m,m,m",
-                            Data = data
-                        }
-                    }.AsSingletonList()
-                });
+            CopyLogDataJob job = LogUtils.CreateJobTemplate();
+            WitsmlLogs sourceLogs = LogUtils.GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, 123.11, 123.11, "Depth");
+            LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlSourceClient, sourceLogs);
+            LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlTargetClient);
+            LogUtils.SetupGetDepthIndexed(_witsmlSourceClient, (logs) => true, new() { new() { Data = "123.11,1,2" }, });
+            List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlTargetClient);
+
+            await _worker.Execute(job);
+
+            Assert.Equal("123.1,1,2", updatedLogs.First().Logs.First().LogData.Data[0].Data);
         }
 
     }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -181,5 +181,20 @@ namespace WitsmlExplorer.Api.Tests.Workers
             Assert.Equal(3, updatedLogs.First().Logs.First().LogCurveInfo.Count);
             Assert.Equal(targetIndexCurve, updatedLogs.First().Logs.First().LogCurveInfo.First().Mnemonic);
         }
+
+        [Fact]
+        public async Task Execute_OneDepthRow_CopiedCorrectly()
+        {
+            CopyLogDataJob job = LogUtils.CreateJobTemplate();
+            WitsmlLogs sourceLogs = LogUtils.GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, 123.11, 123.11, "Depth");
+            LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient, sourceLogs);
+            LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
+            LogUtils.SetupGetDepthIndexed(_witsmlClient, (logs) => true, new() { new() { Data = "123.11,1,2" }, });
+            List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlClient);
+
+            await _worker.Execute(job);
+
+            Assert.Equal("123.11,1,2", updatedLogs.First().Logs.First().LogData.Data[0].Data);
+        }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
@@ -12,6 +12,7 @@ using Witsml.ServiceReference;
 
 using WitsmlExplorer.Api.Jobs;
 using WitsmlExplorer.Api.Jobs.Common;
+using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.Tests.Workers
 {
@@ -288,6 +289,26 @@ namespace WitsmlExplorer.Api.Tests.Workers
             }
 
             return new WitsmlLogs();
+        }
+
+        public static void SetupGetDepthIndexed(Mock<IWitsmlClient> witsmlClient, Func<WitsmlLogs, bool> predicate, List<WitsmlData> data)
+        {
+            witsmlClient.Setup(client => client.GetFromStoreAsync(It.Is<WitsmlLogs>(logs => predicate(logs)), new OptionsIn(ReturnElements.DataOnly, null, null)))
+                .ReturnsAsync(() => new WitsmlLogs
+                {
+                    Logs = new WitsmlLog
+                    {
+                        StartIndex = new WitsmlIndex(new DepthIndex(StringHelpers.ToDouble(data.First().Data.Split(",")[0]))),
+                        EndIndex = new WitsmlIndex(new DepthIndex(StringHelpers.ToDouble(data.Last().Data.Split(",")[0]))),
+                        IndexType = WitsmlLog.WITSML_INDEX_TYPE_MD,
+                        LogData = new WitsmlLogData
+                        {
+                            MnemonicList = string.Join(",", SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD]),
+                            UnitList = "m,m,m",
+                            Data = new(data)
+                        }
+                    }.AsSingletonList()
+                });
         }
     }
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes WE-862

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Make Index.AddEpsilon obsolete in WITSML due to DepthIndex using 3 decimals of precision, whilst some servers might use 2 or 4.
* Implement LogDataReader to avoid using bad indexes and use it in CopyLogDataWorker and RenameMnemonicWorker.
* Remove use of AddEpsilon in LogObjectServer.ReadLogData and drop the first fetched row if startIndexInclusive is false.
* Fix RenameMnemonicWorker crashing due to repeated calls to CreateNewLogWithRenamedMnemonic that overwrote the original mnemonic.
* Make CopyLogDataWithoutDuplicates manage to copy a single row.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Fronted
* [x] API
* [x] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


