### PR TITLE
WE-879 do not refresh on no wellbore objects

### DIFF
--- a/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
@@ -115,7 +115,7 @@ export const getWellboreProperties = (wellbore: Wellbore): Map<string, string> =
   ]);
 };
 
-export function getObjectFromWellbore<Key extends ObjectType>(wellbore: Wellbore, uid: string, objectType: Key): ObjectTypeToModel[Key] {
+export function getObjectsFromWellbore<Key extends ObjectType>(wellbore: Wellbore, objectType: Key): ObjectTypeToModel[Key][] {
   let objects: any[] = null;
   switch (objectType) {
     case ObjectType.BhaRun:
@@ -146,5 +146,10 @@ export function getObjectFromWellbore<Key extends ObjectType>(wellbore: Wellbore
       objects = wellbore.wbGeometrys;
       break;
   }
+  return objects;
+}
+
+export function getObjectFromWellbore<Key extends ObjectType>(wellbore: Wellbore, uid: string, objectType: Key): ObjectTypeToModel[Key] {
+  const objects = getObjectsFromWellbore(wellbore, objectType);
   return objects?.find((object) => object.uid === uid);
 }


### PR DESCRIPTION

[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes WE-879

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Do not refresh wellbore objects if they have not been loaded in. This happens when a different user (or same user in a different window) performs a job that causes a refresh on a wellbore that the current user has not opened.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Fronted
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


