### PR TITLE
fix: fix env variable references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,8 +267,8 @@ Verify successful deployment by accessing the url in browser or postman; Expect 
 #### Deploy Frontend
 Edit .env.local file in WitsmlExplorer.Frontend project and set these values
 ```
-	WITSMLEXPLORER_FRONTEND_URL=https://localhost/witsmlexplorer
-	WITSMLEXPLORER_API_URL=https://localhost/witsmlexplorerbackend
+	NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL=https://localhost/witsmlexplorer
+	NEXT_PUBLIC_WITSMLEXPLORER_API_URL=https://localhost/witsmlexplorerbackend
 ```
 
 Build and export the application to a folder. Eg.: C:\WE_Frontend

--- a/Src/WitsmlExplorer.Frontend/components/AssetsLoader.ts
+++ b/Src/WitsmlExplorer.Frontend/components/AssetsLoader.ts
@@ -1,6 +1,6 @@
 export class AssetsLoader {
   static getAssetsRoot(): string {
-    const wePath = process.env.WITSMLEXPLORER_FRONTEND_URL;
+    const wePath = process.env.NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL;
     return wePath && wePath.length > 0 ? new URL(wePath).pathname : "";
   }
 }

--- a/Src/WitsmlExplorer.Frontend/next.config.js
+++ b/Src/WitsmlExplorer.Frontend/next.config.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const webpack = require("webpack");
-const weURL = process.env.WITSMLEXPLORER_FRONTEND_URL;
+const weURL = process.env.NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL;
 const wePath = weURL && weURL.length > 0 ? new URL(weURL).pathname : "";
 
 module.exports = {

--- a/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/apiClient.tsx
@@ -166,7 +166,7 @@ function getBasePathName(): string {
 export function getBaseUrl(): URL {
   let baseUrl: URL;
   try {
-    const configuredUrl = process.env.WITSMLEXPLORER_API_URL;
+    const configuredUrl = process.env.NEXT_PUBLIC_WITSMLEXPLORER_API_URL;
     if (configuredUrl && configuredUrl.length > 0) {
       baseUrl = new URL(configuredUrl);
     } else {


### PR DESCRIPTION
## Fixes



This pull request fixes #1816

## Description
Changed the variable name of frontend and backend url to 
NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL
and
NEXT_PUBLIC_WITSMLEXPLORER_API_URL
the references of these variables resumed to work
with env.process.NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL and env.process.NEXT_PUBLIC_WITSMLEXPLORER_API_URL

Please also see my comments in the related bug.

Documentation is also updated accordingly

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Fronted
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [x] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

The fix has been manually verified


