### PR TITLE
Remove unnecessary webpack process.env plugin push

### DIFF
--- a/Src/WitsmlExplorer.Frontend/next.config.js
+++ b/Src/WitsmlExplorer.Frontend/next.config.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-undef */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const weURL = process.env.NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL;
 const wePath = weURL && weURL.length > 0 ? new URL(weURL).pathname : "";
 

--- a/Src/WitsmlExplorer.Frontend/next.config.js
+++ b/Src/WitsmlExplorer.Frontend/next.config.js
@@ -1,19 +1,9 @@
 /* eslint-disable no-undef */
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const webpack = require("webpack");
 const weURL = process.env.NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL;
 const wePath = weURL && weURL.length > 0 ? new URL(weURL).pathname : "";
 
 module.exports = {
   distDir: "build",
-  basePath: wePath,
-  webpack: (config) => {
-    const env = Object.keys(process.env).reduce((acc, curr) => {
-      acc[`process.env.NODE_ENV${curr}`] = JSON.stringify(process.env[curr]);
-      return acc;
-    }, {});
-
-    config.plugins.push(new webpack.DefinePlugin(env));
-    return config;
-  }
+  basePath: wePath
 };


### PR DESCRIPTION


## Fixes

This pull request fixes #1816

## Description
In current next.config.js implementation, we are pushing the variables defined in .env files into process.env, and add a NODE_ENV prefix to the variable name references. 
This step is no longer needed now, since the variables with NEXT_PUBLIC_ prefix will directly available in browser runtime with process.env.NEXT_PUBLIC....
https://nextjs.org/docs/basic-features/environment-variables#exposing-environment-variables-to-the-browser

If we keep the plugin pushing code block, we will eventually got 2 duplicate references for each variable defined in .env file.
For example: process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID and process.env.NODE_ENVNEXT_PUBLIC_AZURE_AD_TENANT_ID for the same variable NEXT_PUBLIC_AZURE_AD_TENANT_ID


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Fronted
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


