### PR TITLE
Support copying decreasing and empty logs

### DIFF
--- a/Src/Witsml/Data/WitsmlLog.cs
+++ b/Src/Witsml/Data/WitsmlLog.cs
@@ -17,6 +17,8 @@ namespace Witsml.Data
 
         public const string WITSML_INDEX_TYPE_MD = "measured depth";
         public const string WITSML_INDEX_TYPE_DATE_TIME = "date time";
+        public const string WITSML_DIRECTION_INCREASING = "increasing";
+        public const string WITSML_DIRECTION_DECREASING = "decreasing";
 
         [XmlElement("objectGrowing")]
         public string ObjectGrowing { get; set; }

--- a/Src/Witsml/Extensions/WitsmlLogExtensions.cs
+++ b/Src/Witsml/Extensions/WitsmlLogExtensions.cs
@@ -17,5 +17,25 @@ namespace Witsml.Extensions
                 ? null
                 : witsmlLog.IndexType.Equals(WitsmlLog.WITSML_INDEX_TYPE_MD, System.StringComparison.Ordinal) ? witsmlLog.EndIndex != null ? witsmlLog.EndIndex.ToString() : "" : witsmlLog.EndDateTimeIndex;
         }
+
+
+        public static bool IsDecreasing(this WitsmlLog log)
+        {
+            // A log is only decreasing when the direction is "decreasing". Any other value defaults to increasing.
+            return WitsmlLog.WITSML_DIRECTION_DECREASING.Equals(log.Direction, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsIncreasing(this WitsmlLog log)
+        {
+            return !IsDecreasing(log);
+        }
+
+        public static bool IsEmpty(this WitsmlLog log)
+        {
+            return log.StartIndex == null &&
+                   log.EndIndex == null &&
+                   string.IsNullOrEmpty(log.StartDateTimeIndex) &&
+                   string.IsNullOrEmpty(log.EndDateTimeIndex);
+        }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -275,5 +275,20 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             Assert.Equal(3, updatedLogs.First().Logs.First().LogData.Data.Count);
         }
+
+        [Fact]
+        public async Task Execute_NoRows_NoCopies()
+        {
+            CopyLogDataJob job = LogUtils.CreateJobTemplate();
+            WitsmlLogs sourceLogs = LogUtils.GetSourceLogsEmpty(WitsmlLog.WITSML_INDEX_TYPE_MD, "Depth");
+            LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient, sourceLogs);
+            LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
+            List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlClient);
+
+            (WorkerResult, RefreshAction) result = await _worker.Execute(job);
+
+            Assert.True(result.Item1.IsSuccess);
+            Assert.Empty(updatedLogs);
+        }
     }
 }

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -83,6 +83,24 @@ namespace WitsmlExplorer.Api.Tests.Workers
         }
 
         [Fact]
+        public async Task CopyLogData_DepthIndexed_Decreasing()
+        {
+            CopyLogDataJob job = LogUtils.CreateJobTemplate();
+
+            WitsmlLogs sourceLogs = LogUtils.GetSourceLogsDecreasing(WitsmlLog.WITSML_INDEX_TYPE_MD, 200, 196, "Depth");
+            LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient, sourceLogs);
+            LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
+
+            LogUtils.SetupGetDepthIndexedDecreasing(_witsmlClient);
+            List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlClient);
+
+            await _worker.Execute(job);
+
+            Assert.Equal(string.Join(",", SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD]), updatedLogs.First().Logs.First().LogData.MnemonicList);
+            Assert.Equal(5, updatedLogs.First().Logs.First().LogData.Data.Count);
+        }
+
+        [Fact]
         public async Task CopyLogData_DepthIndexed_SelectedMnemonics()
         {
             CopyLogDataJob job = LogUtils.CreateJobTemplate();

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -114,7 +114,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         [Fact]
         public async Task CopyLog_Empty_EmptyLogAdded()
         {
-            CopyLogJob copyLogJob = CreateJobTemplate();
+            CopyObjectsJob copyLogJob = CreateJobTemplate();
             WitsmlLogs sourceLogs = LogUtils.GetSourceLogsEmpty(WitsmlLog.WITSML_INDEX_TYPE_MD, "Depth");
             SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, sourceLogs);
             SetupGetWellbore();

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using Witsml;
 using Witsml.Data;
 using Witsml.Data.Curves;
+using Witsml.Extensions;
 using Witsml.ServiceReference;
 
 using WitsmlExplorer.Api.Jobs;
@@ -108,6 +109,24 @@ namespace WitsmlExplorer.Api.Tests.Workers
             (WorkerResult Result, RefreshAction) copyTask = await _copyLogWorker.Execute(copyLogJob);
 
             Assert.Contains(errorReason, copyTask.Result.Reason);
+        }
+
+        [Fact]
+        public async Task CopyLog_Empty_EmptyLogAdded()
+        {
+            CopyLogJob copyLogJob = CreateJobTemplate();
+            WitsmlLogs sourceLogs = LogUtils.GetSourceLogsEmpty(WitsmlLog.WITSML_INDEX_TYPE_MD, "Depth");
+            SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, sourceLogs);
+            SetupGetWellbore();
+            IEnumerable<WitsmlLogs> copyLogQuery = CopyTestsUtils.SetupAddInStoreAsync<WitsmlLogs>(_witsmlClient);
+            _copyLogDataWorker.Setup(worker => worker.Execute(It.IsAny<CopyLogDataJob>()))
+                .ReturnsAsync((new WorkerResult(null, true, null), null));
+
+            (WorkerResult, RefreshAction) result = await _copyLogWorker.Execute(copyLogJob);
+
+            WitsmlLog logInQuery = copyLogQuery.First().Logs.First();
+            Assert.True(result.Item1.IsSuccess);
+            Assert.True(logInQuery.IsEmpty());
         }
 
         private void SetupSourceLog(string indexType, WitsmlLogs sourceLogs = null)

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
@@ -172,6 +172,28 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
         }
 
+        public static WitsmlLogs GetSourceLogsEmpty(string indexType, string indexCurveValue = null)
+        {
+            WitsmlLog witsmlLog = new()
+            {
+                UidWell = WellUid,
+                UidWellbore = WellboreUid,
+                Uid = SourceLogUid,
+                IndexType = indexType,
+                IndexCurve = new WitsmlIndexCurve { Value = indexCurveValue ?? SourceMnemonics[indexType][0] },
+                LogCurveInfo = SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD].Select(mnemonic => new WitsmlLogCurveInfo
+                {
+                    Uid = mnemonic,
+                    Mnemonic = mnemonic.Equals(indexCurveValue, StringComparison.OrdinalIgnoreCase) ? indexCurveValue : mnemonic
+                }).ToList()
+            };
+
+            return new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog> { witsmlLog }
+            };
+        }
+
         public static WitsmlLogs GetTargetLogs(string indexType)
         {
             WitsmlLogCurveInfo indexLogCurveInfo = indexType switch

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
@@ -94,6 +94,18 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 });
         }
 
+        public static void SetupGetDepthIndexedDecreasing(Mock<IWitsmlClient> witsmlClient, WitsmlLogs query = null)
+        {
+            witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), new OptionsIn(ReturnElements.DataOnly, null, null)))
+                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+                .ReturnsAsync(() =>
+                {
+                    double startIndex = double.Parse(query!.Logs.First().StartIndex.Value);
+                    double endIndex = double.Parse(query.Logs.First().EndIndex.Value);
+                    return GetSourceLogDataDecreasing(startIndex, endIndex);
+                });
+        }
+
         public static CopyLogDataJob CreateJobTemplate(string startIndex = null, string endIndex = null)
         {
             return new CopyLogDataJob
@@ -163,6 +175,35 @@ namespace WitsmlExplorer.Api.Tests.Workers
                     Mnemonic = mnemonic.Equals(indexCurveValue, StringComparison.OrdinalIgnoreCase) ? indexCurveValue : mnemonic,
                     MinIndex = minIndex,
                     MaxIndex = maxIndex
+                }).ToList()
+            };
+
+            return new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog> { witsmlLog }
+            };
+        }
+
+        public static WitsmlLogs GetSourceLogsDecreasing(string indexType, double startIndex, double endIndex, string indexCurveValue = null)
+        {
+            WitsmlIndex witsmlStartIndex = new(new DepthIndex(startIndex));
+            WitsmlIndex witsmlEndIndex = new(new DepthIndex(endIndex));
+            WitsmlLog witsmlLog = new()
+            {
+                UidWell = WellUid,
+                UidWellbore = WellboreUid,
+                Uid = SourceLogUid,
+                IndexType = indexType,
+                IndexCurve = new WitsmlIndexCurve { Value = indexCurveValue ?? SourceMnemonics[indexType][0] },
+                Direction = WitsmlLog.WITSML_DIRECTION_DECREASING,
+                StartIndex = witsmlStartIndex,
+                EndIndex = witsmlEndIndex,
+                LogCurveInfo = SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD].Select(mnemonic => new WitsmlLogCurveInfo
+                {
+                    Uid = mnemonic,
+                    Mnemonic = mnemonic.Equals(indexCurveValue, StringComparison.OrdinalIgnoreCase) ? indexCurveValue : mnemonic,
+                    MinIndex = witsmlStartIndex,
+                    MaxIndex = witsmlEndIndex
                 }).ToList()
             };
 
@@ -302,6 +343,44 @@ namespace WitsmlExplorer.Api.Tests.Workers
                     {
                         StartIndex = new WitsmlIndex(new DepthIndex(startIndex.Value)),
                         EndIndex = new WitsmlIndex(new DepthIndex(endIndex.Value)),
+                        LogData = new WitsmlLogData
+                        {
+                            MnemonicList = string.Join(",", mnemonics ?? SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD]),
+                            UnitList = "m,m,m",
+                            Data = data
+                        }
+                    }.AsSingletonList()
+                };
+            }
+
+            return new WitsmlLogs();
+        }
+
+        public static WitsmlLogs GetSourceLogDataDecreasing(double startIndexValue, double endIndexValue, IEnumerable<string> mnemonics = null)
+        {
+            DepthIndex startIndex = new(startIndexValue);
+            DepthIndex endIndex = new(endIndexValue);
+            DepthIndex currentIndex = new(startIndexValue);
+
+            List<WitsmlData> data = new();
+            if (startIndex > endIndex)
+            {
+                while (currentIndex >= endIndex)
+                {
+                    data.Add(new WitsmlData { Data = $"{currentIndex.Value},1,1" });
+                    currentIndex = new DepthIndex(currentIndex.Value - 1);
+                }
+            }
+
+            if (data.Any())
+            {
+                return new WitsmlLogs
+                {
+                    Logs = new WitsmlLog
+                    {
+                        StartIndex = new WitsmlIndex(new DepthIndex(startIndex.Value)),
+                        EndIndex = new WitsmlIndex(new DepthIndex(endIndex.Value)),
+                        Direction = WitsmlLog.WITSML_DIRECTION_DECREASING,
                         LogData = new WitsmlLogData
                         {
                             MnemonicList = string.Join(",", mnemonics ?? SourceMnemonics[WitsmlLog.WITSML_INDEX_TYPE_MD]),


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #1824

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

It is now possible to copy logs that have a decreasing index direction or have no data rows in them at all.

The copying of logs with a decreasing index was blocked by the VerifyValidInterval method of CopyLogDataWorker. The issue is resolved by adding IsIncreasing() and IsDecreasing() extension methods for the WitsmlLog class, then using this to determine whether the start index should be before or after the end index.

The copying of empty logs required a few more changes. An IsEmpty() extension method was added for WitsmlLog. This is checked to skip checking indexes or copying data rows where appropriate.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Fronted
* [x] API
* [x] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I haven't yet added any unit tests for decreasing logs. A few tests I did with copying worked fine for me once I updated the VerifyInterval() method. I'm also not sure how many unit tests may be needed.