### PR TITLE
WE-883 add commonData dTims to views and modals

### DIFF
--- a/Src/WitsmlExplorer.Api/Models/LogObject.cs
+++ b/Src/WitsmlExplorer.Api/Models/LogObject.cs
@@ -8,8 +8,7 @@ namespace WitsmlExplorer.Api.Models
         public bool ObjectGrowing { get; set; }
         public string ServiceCompany { get; set; }
         public string RunNumber { get; set; }
-        public string DateTimeCreation { get; set; }
-        public string DateTimeLastChange { get; set; }
         public string IndexCurve { get; set; }
+        public CommonData CommonData { get; set; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/Tubular.cs
+++ b/Src/WitsmlExplorer.Api/Models/Tubular.cs
@@ -3,5 +3,6 @@ namespace WitsmlExplorer.Api.Models
     public class Tubular : ObjectOnWellbore
     {
         public string TypeTubularAssy { get; set; }
+        public CommonData CommonData { get; set; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Query/RigQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/RigQueries.cs
@@ -42,6 +42,8 @@ namespace WitsmlExplorer.Api.Query
                     YearEntService = "",
                     CommonData = new WitsmlCommonData()
                     {
+                        DTimCreation = "",
+                        DTimLastChange = "",
                         ItemState = ""
                     }
                 }.AsSingletonList()

--- a/Src/WitsmlExplorer.Api/Query/TubularQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/TubularQueries.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
+using Witsml.Data;
 using Witsml.Data.Measures;
 using Witsml.Data.Tubular;
 using Witsml.Extensions;
@@ -26,6 +27,11 @@ namespace WitsmlExplorer.Api.Query
                     NameWell = "",
                     NameWellbore = "",
                     TypeTubularAssy = "",
+                    CommonData = new WitsmlCommonData()
+                    {
+                        DTimCreation = "",
+                        DTimLastChange = ""
+                    }
                 }.AsSingletonList()
             };
         }

--- a/Src/WitsmlExplorer.Api/Services/FormationMarkerService.cs
+++ b/Src/WitsmlExplorer.Api/Services/FormationMarkerService.cs
@@ -60,6 +60,8 @@ namespace WitsmlExplorer.Api.Services
                 Description = formationMarker.Description,
                 CommonData = new CommonData()
                 {
+                    DTimCreation = formationMarker.CommonData.DTimCreation,
+                    DTimLastChange = formationMarker.CommonData.DTimLastChange,
                     ItemState = formationMarker.CommonData.ItemState
                 }
             };

--- a/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
+++ b/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
@@ -50,8 +50,12 @@ namespace WitsmlExplorer.Api.Services
                     RunNumber = log.RunNumber,
                     StartIndex = log.GetStartIndexAsString(),
                     EndIndex = log.GetEndIndexAsString(),
-                    DateTimeLastChange = log.CommonData.DTimLastChange,
-                    IndexCurve = log.IndexCurve.Value
+                    IndexCurve = log.IndexCurve.Value,
+                    CommonData = new CommonData()
+                    {
+                        DTimCreation = log.CommonData.DTimCreation,
+                        DTimLastChange = log.CommonData.DTimLastChange,
+                    }
                 }).OrderBy(log => log.Name);
         }
 
@@ -82,7 +86,12 @@ namespace WitsmlExplorer.Api.Services
                 IndexCurve = witsmlLog.IndexCurve.Value,
                 ObjectGrowing = StringHelpers.ToBooleanSafe(witsmlLog.ObjectGrowing),
                 ServiceCompany = witsmlLog.ServiceCompany,
-                RunNumber = witsmlLog.RunNumber
+                RunNumber = witsmlLog.RunNumber,
+                CommonData = new()
+                {
+                    DTimCreation = witsmlLog.CommonData.DTimCreation,
+                    DTimLastChange = witsmlLog.CommonData.DTimLastChange,
+                }
             };
             if (string.IsNullOrEmpty(witsmlLog.IndexType))
             {

--- a/Src/WitsmlExplorer.Api/Services/RigService.cs
+++ b/Src/WitsmlExplorer.Api/Services/RigService.cs
@@ -66,6 +66,8 @@ namespace WitsmlExplorer.Api.Services
                 YearEntService = witsmlRig.YearEntService,
                 CommonData = witsmlRig.CommonData == null ? null : new CommonData()
                 {
+                    DTimCreation = witsmlRig.CommonData.DTimCreation,
+                    DTimLastChange = witsmlRig.CommonData.DTimLastChange,
                     ItemState = witsmlRig.CommonData.ItemState
                 }
             };

--- a/Src/WitsmlExplorer.Api/Services/TubularService.cs
+++ b/Src/WitsmlExplorer.Api/Services/TubularService.cs
@@ -70,7 +70,12 @@ namespace WitsmlExplorer.Api.Services
                 Name = tubular.Name,
                 WellName = tubular.NameWell,
                 WellboreName = tubular.NameWellbore,
-                TypeTubularAssy = tubular.TypeTubularAssy
+                TypeTubularAssy = tubular.TypeTubularAssy,
+                CommonData = new CommonData()
+                {
+                    DTimCreation = tubular.CommonData.DTimCreation,
+                    DTimLastChange = tubular.CommonData.DTimLastChange
+                }
             };
         }
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
@@ -7,6 +7,7 @@ import { measureToString } from "../../models/measure";
 import Struct from "../../models/struct";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import FormationMarkerContextMenu, { FormationMarkerContextMenuProps } from "../ContextMenus/FormationMarkerContextMenu";
+import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 
 export interface FormationMarkerRow extends ContentTableRow {
@@ -15,6 +16,9 @@ export interface FormationMarkerRow extends ContentTableRow {
 
 export const FormationMarkersListView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const { dispatchOperation } = useContext(OperationContext);
   const { selectedWellbore } = navigationState;
   const [formationMarkers, setFormationMarkers] = useState<FormationMarker[]>([]);
@@ -52,6 +56,8 @@ export const FormationMarkersListView = (): React.ReactElement => {
         chronostratigraphic: structToString(formationMarker.chronostratigraphic),
         description: formationMarker.description,
         itemState: formationMarker.commonData.itemState,
+        dTimCreation: formatDateString(formationMarker.commonData.dTimCreation, timeZone),
+        dTimLastChange: formatDateString(formationMarker.commonData.dTimLastChange, timeZone),
         formationMarker
       };
     });
@@ -84,7 +90,9 @@ const columns: ContentTableColumn[] = [
   { property: "dipDirection", label: "dipDirection", type: ContentType.String },
   { property: "lithostratigraphic", label: "lithostratigraphic", type: ContentType.String },
   { property: "chronostratigraphic", label: "chronostratigraphic", type: ContentType.String },
-  { property: "description", label: "description", type: ContentType.String }
+  { property: "description", label: "description", type: ContentType.String },
+  { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+  { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
 ];
 
 export default FormationMarkersListView;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -55,6 +55,8 @@ export const LogsListView = (): React.ReactElement => {
         id: index,
         startIndex: selectedWellbore && isTimeIndexed() ? formatDateString(log.startIndex, timeZone) : log.startIndex,
         endIndex: selectedWellbore && isTimeIndexed() ? formatDateString(log.endIndex, timeZone) : log.endIndex,
+        dTimCreation: formatDateString(log.commonData.dTimCreation, timeZone),
+        dTimLastChange: formatDateString(log.commonData.dTimLastChange, timeZone),
         logObject: log
       };
     });
@@ -66,7 +68,9 @@ export const LogsListView = (): React.ReactElement => {
     { property: "startIndex", label: "startIndex", type: selectedWellbore && isTimeIndexed() ? ContentType.DateTime : ContentType.Measure },
     { property: "endIndex", label: "endIndex", type: selectedWellbore && isTimeIndexed() ? ContentType.DateTime : ContentType.Measure },
     { property: "indexType", label: "indexType", type: ContentType.String },
-    { property: "uid", label: "uid", type: ContentType.String }
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onSelect = (log: LogObjectRow) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
@@ -38,7 +38,9 @@ export const RigsListView = (): React.ReactElement => {
         rig: rig,
         isOffshore: `${rig.isOffshore ?? ""}`,
         dTimStartOp: formatDateString(rig.dTimStartOp, timeZone),
-        dTimEndOp: formatDateString(rig.dTimEndOp, timeZone)
+        dTimEndOp: formatDateString(rig.dTimEndOp, timeZone),
+        dTimCreation: formatDateString(rig.commonData.dTimCreation, timeZone),
+        dTimLastChange: formatDateString(rig.commonData.dTimLastChange, timeZone)
       };
     });
   };
@@ -62,7 +64,9 @@ export const RigsListView = (): React.ReactElement => {
     { property: "isOffshore", label: "isOffshore", type: ContentType.String },
     { property: "airGap", label: "airGap", type: ContentType.String },
     { property: "dTimStartOp", label: "dTimStartOp", type: ContentType.DateTime },
-    { property: "dTimEndOp", label: "dTimEndOp", type: ContentType.DateTime }
+    { property: "dTimEndOp", label: "dTimEndOp", type: ContentType.DateTime },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedRigRows: RigRow[]) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -6,8 +6,8 @@ import RiskObject from "../../models/riskObject";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import RiskObjectContextMenu, { RiskObjectContextMenuProps } from "../ContextMenus/RiskContextMenu";
 import formatDateString from "../DateFormatter";
-import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 import { clipLongString } from "./ViewUtils";
+import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 
 export interface RiskObjectRow extends ContentTableRow, RiskObject {
   risk: RiskObject;
@@ -40,6 +40,8 @@ export const RisksListView = (): React.ReactElement => {
         dTimEnd: formatDateString(risk.dTimEnd, timeZone),
         details: clipLongString(risk.details, 30),
         summary: clipLongString(risk.summary, 40),
+        dTimCreation: formatDateString(risk.commonData.dTimCreation, timeZone),
+        dTimLastChange: formatDateString(risk.commonData.dTimLastChange, timeZone),
         risk: risk
       };
     });
@@ -58,7 +60,9 @@ export const RisksListView = (): React.ReactElement => {
     { property: "category", label: "category", type: ContentType.String },
     { property: "subCategory", label: "subCategory", type: ContentType.String },
     { property: "affectedPersonnel", label: "affectedPersonnel", type: ContentType.String },
-    { property: "details", label: "details", type: ContentType.String }
+    { property: "details", label: "details", type: ContentType.String },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedRiskObjectRows: RiskObjectRow[]) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -7,10 +7,14 @@ import { ObjectType } from "../../models/objectType";
 import Tubular from "../../models/tubular";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import TubularObjectContextMenu, { TubularObjectContextMenuProps } from "../ContextMenus/TubularObjectContextMenu";
+import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentType } from "./table";
 
 export const TubularsListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const { selectedServer, selectedWell, selectedWellbore, servers, wells } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [tubulars, setTubulars] = useState<Tubular[]>([]);
@@ -30,7 +34,9 @@ export const TubularsListView = (): React.ReactElement => {
   const columns: ContentTableColumn[] = [
     { property: "name", label: "name", type: ContentType.String },
     { property: "typeTubularAssy", label: "typeTubularAssy", type: ContentType.String },
-    { property: "uid", label: "uid", type: ContentType.String }
+    { property: "uid", label: "uid", type: ContentType.String },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
 
   const onSelect = (tubular: any) => {
@@ -43,6 +49,8 @@ export const TubularsListView = (): React.ReactElement => {
   const tubularRows = tubulars.map((tubular) => {
     return {
       ...tubular,
+      dTimCreation: formatDateString(tubular.commonData.dTimCreation, timeZone),
+      dTimLastChange: formatDateString(tubular.commonData.dTimLastChange, timeZone),
       id: tubular.uid
     };
   });

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometrysListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometrysListView.tsx
@@ -7,6 +7,7 @@ import { ObjectType } from "../../models/objectType";
 import WbGeometryObject from "../../models/wbGeometry";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import WbGeometryObjectContextMenu, { WbGeometryObjectContextMenuProps } from "../ContextMenus/WbGeometryContextMenu";
+import formatDateString from "../DateFormatter";
 import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
 
 export interface WbGeometryObjectRow extends ContentTableRow, WbGeometryObject {
@@ -15,6 +16,9 @@ export interface WbGeometryObjectRow extends ContentTableRow, WbGeometryObject {
 
 export const WbGeometrysListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const { selectedWellbore, selectedWell, selectedServer, servers } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [wbGeometrys, setWbGeometrys] = useState<WbGeometryObject[]>([]);
@@ -31,6 +35,8 @@ export const WbGeometrysListView = (): React.ReactElement => {
         ...wbGeometry,
         itemState: wbGeometry.commonData.itemState,
         id: wbGeometry.uid,
+        dTimCreation: formatDateString(wbGeometry.commonData.dTimCreation, timeZone),
+        dTimLastChange: formatDateString(wbGeometry.commonData.dTimLastChange, timeZone),
         wbGeometry: wbGeometry
       };
     });
@@ -46,7 +52,9 @@ export const WbGeometrysListView = (): React.ReactElement => {
   const columns: ContentTableColumn[] = [
     { property: "name", label: "name", type: ContentType.String },
     { property: "uid", label: "uid", type: ContentType.String },
-    { property: "itemState", label: "commonData.itemState", type: ContentType.String }
+    { property: "itemState", label: "commonData.itemState", type: ContentType.String },
+    { property: "dTimCreation", label: "commonData.dTimCreation", type: ContentType.DateTime },
+    { property: "dTimLastChange", label: "commonData.dTimLastChange", type: ContentType.DateTime }
   ];
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, {}, checkedWbGeometryObjectRows: WbGeometryObjectRow[]) => {
     const contextProps: WbGeometryObjectContextMenuProps = {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogPropertiesModal.tsx
@@ -95,6 +95,8 @@ const LogPropertiesModal = (props: LogPropertiesModalInterface): React.ReactElem
                 onOptionsChange={onChangeCurve}
                 hideClearButton={true}
               />
+              <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(logObject.commonData.dTimCreation, timeZone)} />
+              <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(logObject.commonData.dTimLastChange, timeZone)} />
             </>
           }
           confirmDisabled={!validText(editableLogObject.uid) || !validText(editableLogObject.name) || !validText(editableLogObject.indexCurve)}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
@@ -1,9 +1,11 @@
 import { TextField } from "@material-ui/core";
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import OperationContext from "../../contexts/operationContext";
 import { HideModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import Well from "../../models/well";
 import JobService, { JobType } from "../../services/jobService";
+import formatDateString from "../DateFormatter";
 import ModalDialog from "./ModalDialog";
 import { PropertiesModalMode, validText, validTimeZone } from "./ModalParts";
 
@@ -15,6 +17,9 @@ export interface WellPropertiesModalProps {
 
 const WellPropertiesModal = (props: WellPropertiesModalProps): React.ReactElement => {
   const { mode, well, dispatchOperation } = props;
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
   const [editableWell, setEditableWell] = useState<Well>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const editMode = mode === PropertiesModalMode.Edit;
@@ -95,6 +100,8 @@ const WellPropertiesModal = (props: WellPropertiesModalProps): React.ReactElemen
                 inputProps={{ maxLength: 6 }}
                 onChange={(e) => setEditableWell({ ...editableWell, timeZone: e.target.value })}
               />
+              <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(well.dateTimeCreation, timeZone)} fullWidth />
+              <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(well.dateTimeLastChange, timeZone)} fullWidth />
             </>
           }
           confirmDisabled={!validText(editableWell.uid) || !validText(editableWell.name) || !validTimeZone(editableWell.timeZone)}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellborePropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellborePropertiesModal.tsx
@@ -291,6 +291,8 @@ const WellborePropertiesModal = (props: WellborePropertiesModalProps): React.Rea
                   />
                 </>
               )}
+              <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(wellbore.dateTimeCreation, timeZone)} fullWidth />
+              <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(wellbore.dateTimeLastChange, timeZone)} fullWidth />
             </>
           }
           confirmDisabled={!validText(editableWellbore.uid) || !validText(editableWellbore.name) || !dTimeKickoffValid || !wellboreHasChanges(pristineWellbore, editableWellbore)}

--- a/Src/WitsmlExplorer.Frontend/models/logObject.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/logObject.tsx
@@ -1,3 +1,4 @@
+import CommonData from "./commonData";
 import ObjectOnWellbore from "./objectOnWellbore";
 
 export default interface LogObject extends ObjectOnWellbore {
@@ -8,6 +9,7 @@ export default interface LogObject extends ObjectOnWellbore {
   serviceCompany?: string;
   runNumber?: string;
   indexCurve?: string;
+  commonData?: CommonData;
 }
 
 export const indexToNumber = (index: string): number => {

--- a/Src/WitsmlExplorer.Frontend/models/tubular.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/tubular.tsx
@@ -1,5 +1,7 @@
+import CommonData from "./commonData";
 import ObjectOnWellbore from "./objectOnWellbore";
 
 export default interface Tubular extends ObjectOnWellbore {
   typeTubularAssy: string;
+  commonData: CommonData;
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes WE-883

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Add commonData.dTimCreation and commonData.dTimLastChange to Well, Wellbore, and Log properties modals.
* Add commonData.dTimCreation and commonData.dTimLastChange to Formation Marker, Log, Rig, Risk, Tubular, and WbGeometry views.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Fronted
* [x] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


