### PR TITLE
WE-890 fix crash on create log modal

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogPropertiesModal.tsx
@@ -95,8 +95,12 @@ const LogPropertiesModal = (props: LogPropertiesModalInterface): React.ReactElem
                 onOptionsChange={onChangeCurve}
                 hideClearButton={true}
               />
-              <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(logObject.commonData.dTimCreation, timeZone)} />
-              <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(logObject.commonData.dTimLastChange, timeZone)} />
+              {mode !== PropertiesModalMode.New && (
+                <>
+                  <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(logObject?.commonData?.dTimCreation, timeZone)} />
+                  <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(logObject?.commonData?.dTimLastChange, timeZone)} />
+                </>
+              )}
             </>
           }
           confirmDisabled={!validText(editableLogObject.uid) || !validText(editableLogObject.name) || !validText(editableLogObject.indexCurve)}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
@@ -100,8 +100,12 @@ const WellPropertiesModal = (props: WellPropertiesModalProps): React.ReactElemen
                 inputProps={{ maxLength: 6 }}
                 onChange={(e) => setEditableWell({ ...editableWell, timeZone: e.target.value })}
               />
-              <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(well.dateTimeCreation, timeZone)} fullWidth />
-              <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(well.dateTimeLastChange, timeZone)} fullWidth />
+              {mode !== PropertiesModalMode.New && (
+                <>
+                  <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(well.dateTimeCreation, timeZone)} fullWidth />
+                  <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(well.dateTimeLastChange, timeZone)} fullWidth />
+                </>
+              )}
             </>
           }
           confirmDisabled={!validText(editableWell.uid) || !validText(editableWell.name) || !validTimeZone(editableWell.timeZone)}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellborePropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellborePropertiesModal.tsx
@@ -287,10 +287,10 @@ const WellborePropertiesModal = (props: WellborePropertiesModalProps): React.Rea
                       })
                     }
                   />
+                  <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(wellbore.dateTimeCreation, timeZone)} fullWidth />
+                  <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(wellbore.dateTimeLastChange, timeZone)} fullWidth />
                 </>
               )}
-              <TextField disabled id="dTimCreation" label="commonData.dTimCreation" defaultValue={formatDateString(wellbore.dateTimeCreation, timeZone)} fullWidth />
-              <TextField disabled id="dTimLastChange" label="commonData.dTimLastChange" defaultValue={formatDateString(wellbore.dateTimeLastChange, timeZone)} fullWidth />
             </>
           }
           confirmDisabled={!validText(editableWellbore.uid) || !validText(editableWellbore.name) || !dTimeKickoffValid || !wellboreHasChanges(pristineWellbore, editableWellbore)}


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes WE-890

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Fix crash when opening create log modal caused by #1830 
* Hide common data dtim fields in create log, wellbore, and well modals.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Fronted
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


