### PR TITLE
WE-914 rewrite navigation context to use selectedObject

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentView.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { ReactElement, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import NavigationContext, { selectedJobsFlag, selectedServerManagerFlag } from "../contexts/navigationContext";
 import { ObjectType } from "../models/objectType";
@@ -8,66 +8,66 @@ import { CurveValuesView } from "./ContentViews/CurveValuesView";
 import FormationMarkersListView from "./ContentViews/FormationMarkersListView";
 import JobsView from "./ContentViews/JobsView";
 import LogCurveInfoListView from "./ContentViews/LogCurveInfoListView";
-import { LogsListView } from "./ContentViews/LogsListView";
 import { LogTypeListView } from "./ContentViews/LogTypeListView";
+import { LogsListView } from "./ContentViews/LogsListView";
 import { MessagesListView } from "./ContentViews/MessagesListView";
-import { MudLogsListView } from "./ContentViews/MudLogsListView";
 import MudLogView from "./ContentViews/MudLogView";
+import { MudLogsListView } from "./ContentViews/MudLogsListView";
 import { RigsListView } from "./ContentViews/RigsListView";
 import { RisksListView } from "./ContentViews/RisksListView";
 import ServerManager from "./ContentViews/ServerManager";
 import TrajectoriesListView from "./ContentViews/TrajectoriesListView";
 import TrajectoryView from "./ContentViews/TrajectoryView";
-import TubularsListView from "./ContentViews/TubularsListView";
 import TubularView from "./ContentViews/TubularView";
-import { WbGeometrysListView } from "./ContentViews/WbGeometrysListView";
+import TubularsListView from "./ContentViews/TubularsListView";
 import WbGeometryView from "./ContentViews/WbGeometryView";
+import { WbGeometrysListView } from "./ContentViews/WbGeometrysListView";
 import WellboreObjectTypesListView from "./ContentViews/WellboreObjectTypesListView";
 import { WellboresListView } from "./ContentViews/WellboresListView";
 import { WellsListView } from "./ContentViews/WellsListView";
 
+const objectGroupViews: Record<ObjectType, ReactElement> = {
+  [ObjectType.BhaRun]: <BhaRunsListView />,
+  [ObjectType.ChangeLog]: <ChangeLogsListView />,
+  [ObjectType.FormationMarker]: <FormationMarkersListView />,
+  [ObjectType.Log]: <LogTypeListView />,
+  [ObjectType.Message]: <MessagesListView />,
+  [ObjectType.MudLog]: <MudLogsListView />,
+  [ObjectType.Rig]: <RigsListView />,
+  [ObjectType.Risk]: <RisksListView />,
+  [ObjectType.Trajectory]: <TrajectoriesListView />,
+  [ObjectType.Tubular]: <TubularsListView />,
+  [ObjectType.WbGeometry]: <WbGeometrysListView />
+};
+
 const ContentView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
-  const {
-    selectedWell,
-    selectedWellbore,
-    selectedLogTypeGroup,
-    selectedLog,
-    selectedLogCurveInfo,
-    selectedMudLog,
-    selectedObjectGroup,
-    selectedTrajectory,
-    selectedTubular,
-    selectedWbGeometry,
-    selectedServer,
-    currentSelected
-  } = navigationState;
+  const { selectedWell, selectedWellbore, selectedLogTypeGroup, selectedLogCurveInfo, selectedObjectGroup, selectedObject, selectedServer, currentSelected } = navigationState;
   const [view, setView] = useState(<WellsListView />);
 
   useEffect(() => {
     const setObjectGroupView = () => {
-      if (currentSelected === ObjectType.BhaRun) {
-        setView(<BhaRunsListView />);
-      } else if (currentSelected === ObjectType.ChangeLog) {
-        setView(<ChangeLogsListView />);
-      } else if (currentSelected === ObjectType.FormationMarker) {
-        setView(<FormationMarkersListView />);
-      } else if (currentSelected === ObjectType.Log) {
-        setView(<LogTypeListView />);
-      } else if (currentSelected === ObjectType.Message) {
-        setView(<MessagesListView />);
-      } else if (currentSelected === ObjectType.MudLog) {
-        setView(<MudLogsListView />);
-      } else if (currentSelected === ObjectType.Rig) {
-        setView(<RigsListView />);
-      } else if (currentSelected === ObjectType.Risk) {
-        setView(<RisksListView />);
-      } else if (currentSelected === ObjectType.Trajectory) {
-        setView(<TrajectoriesListView />);
-      } else if (currentSelected === ObjectType.Tubular) {
-        setView(<TubularsListView />);
-      } else if (currentSelected === ObjectType.WbGeometry) {
-        setView(<WbGeometrysListView />);
+      const groupView = objectGroupViews[currentSelected as ObjectType];
+      if (groupView != null) {
+        setView(groupView);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(`Don't know how to render this item: ${JSON.stringify(currentSelected)}`);
+        setView(undefined);
+      }
+    };
+
+    const setObjectView = () => {
+      if (selectedObjectGroup === ObjectType.Log) {
+        setView(<LogCurveInfoListView />);
+      } else if (selectedObjectGroup === ObjectType.MudLog) {
+        setView(<MudLogView />);
+      } else if (selectedObjectGroup === ObjectType.Trajectory) {
+        setView(<TrajectoryView />);
+      } else if (selectedObjectGroup === ObjectType.Tubular) {
+        setView(<TubularView />);
+      } else if (selectedObjectGroup === ObjectType.WbGeometry) {
+        setView(<WbGeometryView />);
       } else {
         // eslint-disable-next-line no-console
         console.error(`Don't know how to render this item: ${JSON.stringify(currentSelected)}`);
@@ -88,18 +88,10 @@ const ContentView = (): React.ReactElement => {
         setObjectGroupView();
       } else if (currentSelected === selectedLogTypeGroup) {
         setView(<LogsListView />);
-      } else if (currentSelected === selectedLog) {
-        setView(<LogCurveInfoListView />);
-      } else if (currentSelected == selectedMudLog) {
-        setView(<MudLogView />);
+      } else if (currentSelected === selectedObject) {
+        setObjectView();
       } else if (currentSelected === selectedLogCurveInfo) {
         setView(<CurveValuesView />);
-      } else if (currentSelected === selectedTrajectory) {
-        setView(<TrajectoryView />);
-      } else if (currentSelected === selectedTubular) {
-        setView(<TubularView />);
-      } else if (currentSelected === selectedWbGeometry) {
-        setView(<WbGeometryView />);
       } else if (currentSelected === selectedJobsFlag) {
         setView(<JobsView />);
       } else if (currentSelected === selectedServerManagerFlag) {

--- a/Src/WitsmlExplorer.Frontend/components/ContentView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentView.tsx
@@ -40,38 +40,27 @@ const objectGroupViews: Record<ObjectType, ReactElement> = {
   [ObjectType.WbGeometry]: <WbGeometrysListView />
 };
 
+const objectViews: Partial<Record<ObjectType, ReactElement>> = {
+  [ObjectType.Log]: <LogCurveInfoListView />,
+  [ObjectType.MudLog]: <MudLogView />,
+  [ObjectType.Trajectory]: <TrajectoryView />,
+  [ObjectType.Tubular]: <TubularView />,
+  [ObjectType.WbGeometry]: <WbGeometryView />
+};
+
 const ContentView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
   const { selectedWell, selectedWellbore, selectedLogTypeGroup, selectedLogCurveInfo, selectedObjectGroup, selectedObject, selectedServer, currentSelected } = navigationState;
   const [view, setView] = useState(<WellsListView />);
 
   useEffect(() => {
-    const setObjectGroupView = () => {
-      const groupView = objectGroupViews[currentSelected as ObjectType];
-      if (groupView != null) {
-        setView(groupView);
+    const setObjectView = (isGroup: boolean): void => {
+      const views = isGroup ? objectGroupViews : objectViews;
+      const view = views[selectedObjectGroup as ObjectType];
+      if (view != null) {
+        setView(view);
       } else {
-        // eslint-disable-next-line no-console
-        console.error(`Don't know how to render this item: ${JSON.stringify(currentSelected)}`);
-        setView(undefined);
-      }
-    };
-
-    const setObjectView = () => {
-      if (selectedObjectGroup === ObjectType.Log) {
-        setView(<LogCurveInfoListView />);
-      } else if (selectedObjectGroup === ObjectType.MudLog) {
-        setView(<MudLogView />);
-      } else if (selectedObjectGroup === ObjectType.Trajectory) {
-        setView(<TrajectoryView />);
-      } else if (selectedObjectGroup === ObjectType.Tubular) {
-        setView(<TubularView />);
-      } else if (selectedObjectGroup === ObjectType.WbGeometry) {
-        setView(<WbGeometryView />);
-      } else {
-        // eslint-disable-next-line no-console
-        console.error(`Don't know how to render this item: ${JSON.stringify(currentSelected)}`);
-        setView(undefined);
+        throw new Error(`No ${isGroup ? "group" : "object"} view is implemented for item: ${JSON.stringify(selectedObjectGroup)}`);
       }
     };
 
@@ -85,11 +74,11 @@ const ContentView = (): React.ReactElement => {
       } else if (currentSelected === selectedWellbore) {
         setView(<WellboreObjectTypesListView />);
       } else if (currentSelected === selectedObjectGroup) {
-        setObjectGroupView();
+        setObjectView(true);
       } else if (currentSelected === selectedLogTypeGroup) {
         setView(<LogsListView />);
       } else if (currentSelected === selectedObject) {
-        setObjectView();
+        setObjectView(false);
       } else if (currentSelected === selectedLogCurveInfo) {
         setView(<CurveValuesView />);
       } else if (currentSelected === selectedJobsFlag) {
@@ -97,9 +86,7 @@ const ContentView = (): React.ReactElement => {
       } else if (currentSelected === selectedServerManagerFlag) {
         setView(<ServerManager />);
       } else {
-        // eslint-disable-next-line no-console
-        console.error(`Don't know how to render this item: ${JSON.stringify(currentSelected)}`);
-        setView(undefined);
+        throw new Error(`No view is implemented for item: ${JSON.stringify(currentSelected)}`);
       }
     }
   }, [currentSelected]);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -16,16 +16,16 @@ import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import MnemonicsContextMenu from "../ContextMenus/MnemonicsContextMenu";
 import { LogCurveInfoRow } from "./LogCurveInfoListView";
 import {
-  calculateProgress,
   ContentTableColumn,
   ContentTableRow,
   ExportableContentTableColumn,
+  Order,
+  VirtualizedContentTable,
+  calculateProgress,
   getColumnType,
   getComparatorByColumn,
   getIndexRanges,
-  getProgressRange,
-  Order,
-  VirtualizedContentTable
+  getProgressRange
 } from "./table";
 
 interface CurveValueRow extends LogDataRow, ContentTableRow {}
@@ -33,12 +33,13 @@ interface CurveValueRow extends LogDataRow, ContentTableRow {}
 export const CurveValuesView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
   const { dispatchOperation } = useContext(OperationContext);
-  const { selectedWell, selectedWellbore, selectedLog, selectedLogCurveInfo } = navigationState;
+  const { selectedWell, selectedWellbore, selectedObject, selectedLogCurveInfo } = navigationState;
   const [columns, setColumns] = useState<ExportableContentTableColumn<CurveSpecification>[]>([]);
   const [tableData, setTableData] = useState<CurveValueRow[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [progress, setProgress] = useState<number>(0);
   const [selectedRows, setSelectedRows] = useState<CurveValueRow[]>([]);
+  const selectedLog = selectedObject as LogObject;
   const { exportData, properties: exportOptions } = useExport({
     fileExtension: ".csv",
     newLineCharacter: "\n",

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
@@ -4,6 +4,7 @@ import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import LogCurveInfo from "../../models/logCurveInfo";
+import LogObject from "../../models/logObject";
 import { measureToString } from "../../models/measure";
 import { truncateAbortHandler } from "../../services/apiClient";
 import LogObjectService from "../../services/logObjectService";
@@ -33,7 +34,8 @@ export const LogCurveInfoListView = (): React.ReactElement => {
   const {
     operationState: { timeZone }
   } = useContext(OperationContext);
-  const { selectedServer, selectedWell, selectedWellbore, selectedLog, selectedCurveThreshold, servers } = navigationState;
+  const { selectedServer, selectedWell, selectedWellbore, selectedObject, selectedCurveThreshold, servers } = navigationState;
+  const selectedLog = selectedObject as LogObject;
   const { dispatchOperation } = useContext(OperationContext);
   const [logCurveInfoList, setLogCurveInfoList] = useState<LogCurveInfo[]>([]);
   const isDepthIndex = !!logCurveInfoList?.[0]?.maxDepthIndex;
@@ -98,9 +100,9 @@ export const LogCurveInfoListView = (): React.ReactElement => {
         };
       })
       .sort((curve, curve2) => {
-        if (curve.mnemonic.toLowerCase() === selectedLog.indexCurve.toLowerCase()) {
+        if (curve.mnemonic.toLowerCase() === selectedLog.indexCurve?.toLowerCase()) {
           return -1;
-        } else if (curve2.mnemonic.toLowerCase() === selectedLog.indexCurve.toLowerCase()) {
+        } else if (curve2.mnemonic.toLowerCase() === selectedLog.indexCurve?.toLowerCase()) {
           return 1;
         }
         return curve.mnemonic.localeCompare(curve2.mnemonic);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
@@ -4,6 +4,7 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import GeologyInterval from "../../models/geologyInterval";
 import { measureToString } from "../../models/measure";
+import MudLog from "../../models/mudLog";
 import MudLogService from "../../services/mudLogService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import GeologyIntervalContextMenu, { GeologyIntervalContextMenuProps } from "../ContextMenus/GeologyIntervalContextMenu";
@@ -30,10 +31,11 @@ export interface GeologyIntervalRow extends ContentTableRow {
 
 export const MudLogView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
-  const { selectedMudLog } = navigationState;
+  const { selectedObject } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [geologyIntervals, setGeologyIntervals] = useState<GeologyInterval[]>([]);
   const [isFetchingData, setIsFetchingData] = useState<boolean>(true);
+  const selectedMudLog = selectedObject as MudLog;
 
   useEffect(() => {
     setIsFetchingData(true);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
+import Trajectory from "../../models/trajectory";
 import TrajectoryStation from "../../models/trajectoryStation";
 import TrajectoryService from "../../services/trajectoryService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
@@ -25,10 +26,11 @@ export const TrajectoryView = (): React.ReactElement => {
   const {
     operationState: { timeZone }
   } = useContext(OperationContext);
-  const { selectedServer, selectedTrajectory, servers } = navigationState;
+  const { selectedServer, selectedObject, servers } = navigationState;
   const [trajectoryStations, setTrajectoryStations] = useState<TrajectoryStation[]>([]);
   const { dispatchOperation } = useContext(OperationContext);
   const [isFetchingData, setIsFetchingData] = useState<boolean>(true);
+  const selectedTrajectory = selectedObject as Trajectory;
 
   useEffect(() => {
     setIsFetchingData(true);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
+import Tubular from "../../models/tubular";
 import TubularComponent from "../../models/tubularComponent";
 import TubularService from "../../services/tubularService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
@@ -22,10 +23,11 @@ export interface TubularComponentRow extends ContentTableRow {
 
 export const TubularView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { selectedServer, selectedTubular, servers } = navigationState;
+  const { selectedServer, selectedObject, servers } = navigationState;
   const [tubularComponents, setTubularComponents] = useState<TubularComponent[]>([]);
   const { dispatchOperation } = useContext(OperationContext);
   const [isFetchingData, setIsFetchingData] = useState<boolean>(true);
+  const selectedTubular = selectedObject as Tubular;
 
   useEffect(() => {
     setIsFetchingData(true);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
@@ -3,6 +3,7 @@ import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { measureToString } from "../../models/measure";
+import WbGeometryObject from "../../models/wbGeometry";
 import WbGeometrySection from "../../models/wbGeometrySection";
 import WbGeometryService from "../../services/wbGeometryService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
@@ -15,10 +16,11 @@ interface WbGeometrySectionRow extends ContentTableRow {
 
 export const WbGeometryView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
-  const { selectedWbGeometry, selectedServer, servers } = navigationState;
+  const { selectedObject, selectedServer, servers } = navigationState;
   const [wbGeometrySections, setWbGeometrySections] = useState<WbGeometrySection[]>([]);
   const { dispatchOperation } = useContext(OperationContext);
   const [isFetchingData, setIsFetchingData] = useState<boolean>(true);
+  const selectedWbGeometry = selectedObject as WbGeometryObject;
 
   useEffect(() => {
     setIsFetchingData(true);

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/GeologyIntervalContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/GeologyIntervalContextMenu.tsx
@@ -7,11 +7,12 @@ import OperationType from "../../contexts/operationType";
 import { ComponentType } from "../../models/componentType";
 import GeologyInterval from "../../models/geologyInterval";
 import { createComponentReferences } from "../../models/jobs/componentReferences";
+import MudLog from "../../models/mudLog";
 import { JobType } from "../../services/jobService";
 import { colors } from "../../styles/Colors";
 import GeologyIntervalPropertiesModal from "../Modals/GeologyIntervalPropertiesModal";
 import ContextMenu from "./ContextMenu";
-import { menuItemText, onClickDeleteComponents, StyledIcon } from "./ContextMenuUtils";
+import { StyledIcon, menuItemText, onClickDeleteComponents } from "./ContextMenuUtils";
 import { copyComponents, pasteComponents } from "./CopyUtils";
 import { useClipboardComponentReferencesOfType } from "./UseClipboardComponentReferences";
 
@@ -23,9 +24,10 @@ const GeologyIntervalContextMenu = (props: GeologyIntervalContextMenuProps): Rea
   const { checkedGeologyIntervals } = props;
   const { dispatchOperation } = useContext(OperationContext);
   const {
-    navigationState: { selectedServer, selectedMudLog, servers }
+    navigationState: { selectedServer, selectedObject, servers }
   } = useContext(NavigationContext);
   const geologyIntervalReferences = useClipboardComponentReferencesOfType(ComponentType.GeologyInterval);
+  const selectedMudLog = selectedObject as MudLog;
 
   const onClickProperties = async () => {
     const geologyIntervalPropertiesModalProps = { geologyInterval: checkedGeologyIntervals[0] };

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ObjectMenuItems.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ObjectMenuItems.tsx
@@ -47,7 +47,7 @@ export const ObjectMenuItems = (
           )
       )}
     </NestedMenuItem>,
-    <MenuItem key={"paste"} onClick={() => pasteObjectOnWellbore(servers, objectReferences, dispatchOperation, wellbore)} disabled={objectReferences === null}>
+    <MenuItem key={"pasteObject"} onClick={() => pasteObjectOnWellbore(servers, objectReferences, dispatchOperation, wellbore)} disabled={objectReferences === null}>
       <StyledIcon name="paste" color={colors.interactive.primaryResting} />
       <Typography color={"primary"}>{menuItemText("paste", objectType, objectReferences?.objectUids)}</Typography>
     </MenuItem>,

--- a/Src/WitsmlExplorer.Frontend/components/Modals/CopyRangeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/CopyRangeModal.tsx
@@ -4,7 +4,7 @@ import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import { ComponentType } from "../../models/componentType";
 import { CopyRangeClipboard, createComponentReferences } from "../../models/jobs/componentReferences";
-import { indexToNumber } from "../../models/logObject";
+import LogObject, { indexToNumber } from "../../models/logObject";
 import { WITSML_INDEX_TYPE_DATE_TIME, WITSML_INDEX_TYPE_MD } from "../Constants";
 import ModalDialog from "./ModalDialog";
 import AdjustDateTimeModal from "./TrimLogObject/AdjustDateTimeModal";
@@ -16,12 +16,13 @@ export interface CopyRangeModalProps {
 
 const CopyRangeModal = (props: CopyRangeModalProps): React.ReactElement => {
   const {
-    navigationState: { selectedServer, selectedLog }
+    navigationState: { selectedServer, selectedObject }
   } = useContext(NavigationContext);
   const { dispatchOperation } = useContext(OperationContext);
   const [startIndex, setStartIndex] = useState<string | number>();
   const [endIndex, setEndIndex] = useState<string | number>();
   const [confirmDisabled, setConfirmDisabled] = useState<boolean>(true);
+  const selectedLog = selectedObject as LogObject;
 
   const onSubmit = async () => {
     const componentReferences: CopyRangeClipboard = createComponentReferences(props.mnemonics, selectedLog, ComponentType.Mnemonic, selectedServer.url);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/GeologyIntervalPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/GeologyIntervalPropertiesModal.tsx
@@ -12,6 +12,7 @@ import { lithologyTypes } from "../../models/lithologyTypes";
 import MaxLength from "../../models/maxLength";
 import Measure from "../../models/measure";
 import MeasureWithDatum from "../../models/measureWithDatum";
+import MudLog from "../../models/mudLog";
 import { toObjectReference } from "../../models/objectOnWellbore";
 import JobService, { JobType } from "../../services/jobService";
 import ModalDialog from "./ModalDialog";
@@ -62,11 +63,12 @@ const GeologyIntervalPropertiesModal = (props: GeologyIntervalPropertiesModalInt
   const { geologyInterval } = props;
   const { dispatchOperation } = useContext(OperationContext);
   const {
-    navigationState: { selectedMudLog }
+    navigationState: { selectedObject }
   } = useContext(NavigationContext);
   const [editable, setEditable] = useState<EditableGeologyInterval>({});
   const [editableLithologies, setEditableLithologies] = useState<Record<string, EditableLithology>>({});
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const selectedMudLog = selectedObject as MudLog;
 
   useEffect(() => {
     if (geologyInterval != null) {

--- a/Src/WitsmlExplorer.Frontend/components/Nav.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Nav.tsx
@@ -5,7 +5,6 @@ import { NavigationAction } from "../contexts/navigationAction";
 import { SelectLogTypeAction, SelectObjectGroupAction, SelectServerAction, SelectWellAction, SelectWellboreAction } from "../contexts/navigationActions";
 import NavigationContext, { NavigationState, Selectable, selectedJobsFlag } from "../contexts/navigationContext";
 import NavigationType from "../contexts/navigationType";
-import ObjectOnWellbore from "../models/objectOnWellbore";
 import { ObjectType, pluralizeObjectType } from "../models/objectType";
 import { Server } from "../models/server";
 import Well from "../models/well";
@@ -145,35 +144,16 @@ const getLogTypeCrumb = (selectedLogTypeGroup: string, selectedWell: Well, selec
 };
 
 const getObjectCrumb = (navigationState: NavigationState, dispatch: (action: NavigationAction) => void) => {
-  let selectedObject: ObjectOnWellbore = null;
-  switch (navigationState.selectedObjectGroup) {
-    case ObjectType.Log:
-      selectedObject = navigationState.selectedLog;
-      break;
-    case ObjectType.MudLog:
-      selectedObject = navigationState.selectedMudLog;
-      break;
-    case ObjectType.Trajectory:
-      selectedObject = navigationState.selectedTrajectory;
-      break;
-    case ObjectType.Tubular:
-      selectedObject = navigationState.selectedTubular;
-      break;
-    case ObjectType.WbGeometry:
-      selectedObject = navigationState.selectedWbGeometry;
-      break;
-  }
-
-  return selectedObject?.name
+  return navigationState.selectedObject?.name
     ? {
-        name: selectedObject.name,
+        name: navigationState.selectedObject.name,
         onClick: () =>
           dispatch({
             type: NavigationType.SelectObject,
             payload: {
               well: navigationState.selectedWell,
               wellbore: navigationState.selectedWellbore,
-              object: selectedObject,
+              object: navigationState.selectedObject,
               objectType: navigationState.selectedObjectGroup
             }
           })

--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -23,20 +23,7 @@ import { WITSML_INDEX_TYPE_MD } from "./Constants";
 
 const Routing = (): React.ReactElement => {
   const { dispatchNavigation, navigationState } = useContext(NavigationContext);
-  const {
-    selectedServer,
-    servers,
-    wells,
-    selectedWell,
-    selectedWellbore,
-    selectedLog,
-    selectedMudLog,
-    selectedObjectGroup,
-    selectedTrajectory,
-    selectedTubular,
-    selectedWbGeometry,
-    selectedLogTypeGroup
-  } = navigationState;
+  const { selectedServer, servers, wells, selectedWell, selectedWellbore, selectedObject, selectedObjectGroup, selectedLogTypeGroup } = navigationState;
   const router = useRouter();
   const [isSyncingUrlAndState, setIsSyncingUrlAndState] = useState<boolean>(true);
   const [hasSelectedServer, setHasSelectedServer] = useState<boolean>(false);
@@ -58,18 +45,7 @@ const Routing = (): React.ReactElement => {
     if (finishedSyncingStateAndUrl) {
       setIsSyncingUrlAndState(false);
     }
-  }, [
-    selectedServer,
-    selectedWell,
-    selectedWellbore,
-    selectedLog,
-    selectedTubular,
-    selectedMudLog,
-    selectedObjectGroup,
-    selectedTrajectory,
-    selectedWbGeometry,
-    selectedLogTypeGroup
-  ]);
+  }, [selectedServer, selectedWell, selectedWellbore, selectedObject, selectedObjectGroup, selectedLogTypeGroup]);
 
   useEffect(() => {
     //update router on params change
@@ -227,11 +203,7 @@ export const getQueryParamsFromState = (state: NavigationState): QueryParams => 
     ...(state.selectedWellbore && { wellboreUid: state.selectedWellbore.uid }),
     ...(state.selectedObjectGroup && { group: state.selectedObjectGroup }),
     ...(state.selectedLogTypeGroup && { logType: logTypeToQuery(state.selectedLogTypeGroup) }),
-    ...(state.selectedLog && { objectUid: state.selectedLog.uid }),
-    ...(state.selectedTrajectory && { objectUid: state.selectedTrajectory.uid }),
-    ...(state.selectedTubular && { objectUid: state.selectedTubular.uid }),
-    ...(state.selectedMudLog && { objectUid: state.selectedMudLog.uid }),
-    ...(state.selectedWbGeometry && { objectUid: state.selectedWbGeometry.uid })
+    ...(state.selectedObject && { objectUid: state.selectedObject.uid })
   };
 };
 

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
 import { SelectWellboreAction, ToggleTreeNodeAction } from "../../contexts/navigationActions";
 import NavigationContext from "../../contexts/navigationContext";
 import NavigationType from "../../contexts/navigationType";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
-import { calculateObjectNodeId } from "../../models/objectOnWellbore";
+import ObjectOnWellbore, { calculateObjectNodeId } from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
 import Well from "../../models/well";
 import Wellbore, { calculateObjectGroupId } from "../../models/wellbore";
@@ -33,7 +33,7 @@ interface WellboreItemProps {
 const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
   const { wellbore, well, selected, nodeId } = props;
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { selectedMudLog, selectedTrajectory, selectedTubular, selectedWbGeometry, servers, expandedTreeNodes } = navigationState;
+  const { selectedObject, selectedObjectGroup, servers, expandedTreeNodes } = navigationState;
   const { dispatchOperation } = useContext(OperationContext);
   const [isFetchingData, setIsFetchingData] = useState(false);
 
@@ -128,6 +128,19 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
     }
   };
 
+  const isSelected = useCallback(
+    (objectType: ObjectType, objectOnWellbore: ObjectOnWellbore) => {
+      return selectedObject &&
+        selectedObjectGroup === objectType &&
+        selectedObject.uid === objectOnWellbore.uid &&
+        selectedObject.wellboreUid === objectOnWellbore.wellboreUid &&
+        selectedObject.wellUid === objectOnWellbore.wellUid
+        ? true
+        : undefined;
+    },
+    [selectedObject, selectedObjectGroup]
+  );
+
   return (
     <TreeItem
       onContextMenu={(event) => onContextMenu(event, wellbore)}
@@ -188,7 +201,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
               well={well}
               wellbore={wellbore}
               nodeId={calculateObjectNodeId(mudLog, ObjectType.MudLog)}
-              selected={selectedMudLog && selectedMudLog.uid === mudLog.uid ? true : undefined}
+              selected={isSelected(ObjectType.MudLog, mudLog)}
             />
           ))}
       </TreeItem>
@@ -219,7 +232,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
               well={well}
               wellbore={wellbore}
               nodeId={calculateObjectNodeId(trajectory, ObjectType.Trajectory)}
-              selected={selectedTrajectory && selectedTrajectory.uid === trajectory.uid ? true : undefined}
+              selected={isSelected(ObjectType.Trajectory, trajectory)}
             />
           ))}
       </TreeItem>
@@ -238,7 +251,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
               well={well}
               wellbore={wellbore}
               nodeId={calculateObjectNodeId(tubular, ObjectType.Tubular)}
-              selected={selectedTubular && selectedTubular.uid === tubular.uid ? true : undefined}
+              selected={isSelected(ObjectType.Tubular, tubular)}
             />
           ))}
       </TreeItem>
@@ -257,7 +270,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
               well={well}
               wellbore={wellbore}
               nodeId={calculateObjectNodeId(wbGeometry, ObjectType.WbGeometry)}
-              selected={selectedWbGeometry && selectedWbGeometry.uid === wbGeometry.uid ? true : undefined}
+              selected={isSelected(ObjectType.WbGeometry, wbGeometry)}
             />
           ))}
       </TreeItem>

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
@@ -7,7 +7,7 @@ import { RemoveWellAction, RemoveWellboreAction, RemoveWitsmlServerAction } from
 import ModificationType from "../modificationType";
 import { EMPTY_NAVIGATION_STATE, NavigationState, Selectable } from "../navigationContext";
 import { reducer } from "../navigationStateReducer";
-import { getInitialState, LOG_1, SERVER_1, TRAJECTORY_1, WELLBORE_1, WELLBORE_2, WELLS, WELL_1, WELL_2, WELL_3 } from "../stateReducerTestUtils";
+import { LOG_1, SERVER_1, TRAJECTORY_1, WELLBORE_1, WELLBORE_2, WELLS, WELL_1, WELL_2, WELL_3, getInitialState } from "../stateReducerTestUtils";
 
 it("Should only update list of servers if no server selected", () => {
   const editedServer: Server = { ...SERVER_1, description: "Another description" };
@@ -44,7 +44,7 @@ it("Should update list of servers, and current selected, if editing current sele
 });
 
 it("Should update list of servers when adding a server", () => {
-  const newServer: Server = { id: "1", name: "New server", url: "https://example.com", description: "A new server", roles: [] };
+  const newServer: Server = { id: "1", name: "New server", url: "https://example.com", description: "A new server", roles: [], depthLogDecimals: 0 };
   const selectServerAction = { type: ModificationType.AddServer, payload: { server: newServer } };
   const actual = reducer({ ...getInitialState() }, selectServerAction);
   expect(actual).toStrictEqual({
@@ -100,7 +100,7 @@ it("Should update trajectories for selected wellbore", () => {
     selectedWell: { ...WELL_1 },
     selectedWellbore: { ...WELLBORE_1 },
     selectedObjectGroup: ObjectType.Trajectory,
-    selectedTrajectory: { ...TRAJECTORY_1 }
+    selectedObject: { ...TRAJECTORY_1 }
   };
   const updatedWellbore = { ...WELLBORE_1, trajectories: [updatedTrajectory] };
   const actual = reducer(initialState, updateTrajectoryOnWellbore);
@@ -111,7 +111,7 @@ it("Should update trajectories for selected wellbore", () => {
     selectedWell: updatedWell,
     selectedWellbore: updatedWellbore,
     selectedObjectGroup: ObjectType.Trajectory,
-    selectedTrajectory: updatedTrajectory,
+    selectedObject: updatedTrajectory,
     wells: [updatedWell, WELL_2, WELL_3],
     filteredWells: [updatedWell, WELL_2, WELL_3]
   });
@@ -132,7 +132,7 @@ it("Should update currentSelected if deleted", () => {
     selectedWell: { ...WELL_1 },
     selectedWellbore: { ...WELLBORE_1 },
     selectedObjectGroup: ObjectType.Trajectory,
-    selectedTrajectory: TRAJECTORY_1,
+    selectedObject: TRAJECTORY_1,
     currentSelected: TRAJECTORY_1
   };
   const updatedWellbore = { ...WELLBORE_1, trajectories: newTrajectories };
@@ -144,7 +144,7 @@ it("Should update currentSelected if deleted", () => {
     selectedWell: updatedWell,
     selectedWellbore: updatedWellbore,
     selectedObjectGroup: ObjectType.Trajectory,
-    selectedTrajectory: null,
+    selectedObject: null,
     currentSelected: ObjectType.Trajectory,
     wells: [updatedWell, WELL_2, WELL_3],
     filteredWells: [updatedWell, WELL_2, WELL_3]
@@ -232,7 +232,7 @@ it("Should update refreshed log object", () => {
   const wells = [{ ...WELL_1, wellbores: [{ ...WELLBORE_1, logs: [LOG_1] }] }, WELL_2, WELL_3];
   const initialState = {
     ...getInitialState(),
-    selectedLog: LOG_1,
+    selectedObject: LOG_1,
     wells,
     filteredWells: wells
   };
@@ -247,7 +247,7 @@ it("Should update refreshed log object", () => {
     ...getInitialState(),
     wells: expectedListOfWells,
     filteredWells: expectedListOfWells,
-    selectedLog: refreshedLog
+    selectedObject: refreshedLog
   };
   expect(afterRefreshLog).toStrictEqual(expectedState);
 });

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/modificationStateReducer.test.ts
@@ -233,6 +233,7 @@ it("Should update refreshed log object", () => {
   const initialState = {
     ...getInitialState(),
     selectedObject: LOG_1,
+    selectedObjectGroup: ObjectType.Log,
     wells,
     filteredWells: wells
   };
@@ -247,7 +248,8 @@ it("Should update refreshed log object", () => {
     ...getInitialState(),
     wells: expectedListOfWells,
     filteredWells: expectedListOfWells,
-    selectedObject: refreshedLog
+    selectedObject: refreshedLog,
+    selectedObjectGroup: ObjectType.Log
   };
   expect(afterRefreshLog).toStrictEqual(expectedState);
 });

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -24,7 +24,6 @@ import {
   CHANGELOG_1,
   FILTER_1,
   FORMATIONMARKER_1,
-  getInitialState,
   LOG_1,
   MESSAGE_1,
   MUDLOG_1,
@@ -41,7 +40,8 @@ import {
   WELLS,
   WELL_1,
   WELL_2,
-  WELL_3
+  WELL_3,
+  getInitialState
 } from "../stateReducerTestUtils";
 
 it("Should not update state when selecting current selected server", () => {
@@ -170,7 +170,7 @@ it("Should also update well and wellbore when a trajectory is selected", () => {
     selectedServer: SERVER_1,
     selectedWell: WELL_2,
     selectedWellbore: WELLBORE_2,
-    selectedTrajectory: TRAJECTORY_1,
+    selectedObject: TRAJECTORY_1,
     selectedObjectGroup: ObjectType.Trajectory,
     currentSelected: TRAJECTORY_1,
     servers: [SERVER_1],

--- a/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
@@ -2,6 +2,7 @@ import BhaRun from "../models/bhaRun";
 import LogObject from "../models/logObject";
 import MessageObject from "../models/messageObject";
 import ObjectOnWellbore from "../models/objectOnWellbore";
+import { ObjectType } from "../models/objectType";
 import Rig from "../models/rig";
 import RiskObject from "../models/riskObject";
 import Trajectory from "../models/trajectory";
@@ -336,13 +337,13 @@ const updateWellboreLogs = (state: NavigationState, { payload }: UpdateWellboreL
   const { wells } = state;
   const { logs, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { logs });
-  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, logs, state.selectedLog, wellboreUid, wellUid);
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, logs, state.selectedObject, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
     wells: freshWells,
     currentSelected,
-    selectedLog: newSelectedObject
+    selectedObject: newSelectedObject
   };
 };
 
@@ -350,13 +351,12 @@ const updateWellboreLog = (state: NavigationState, { payload }: UpdateWellboreLo
   const { wells } = state;
   const { log } = payload;
   const updatedWells = insertLogIntoWellsStructure(wells, log);
-  const selectedLog = state.selectedLog?.uid === log.uid ? log : state.selectedLog;
-
+  const selectedObject = sameUids(log, state.selectedObject) && state.selectedObjectGroup == ObjectType.Log ? log : state.selectedObject;
   return {
     ...state,
     wells: updatedWells,
     filteredWells: filterWells(updatedWells, state.selectedFilter),
-    selectedLog
+    selectedObject
   };
 };
 
@@ -374,11 +374,11 @@ const updateWellboreMudLogs = (state: NavigationState, { payload }: UpdateWellbo
   const { wells } = state;
   const { mudLogs, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { mudLogs });
-  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, mudLogs, state.selectedMudLog, wellboreUid, wellUid);
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, mudLogs, state.selectedObject, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
-    selectedMudLog: newSelectedObject,
+    selectedObject: newSelectedObject,
     currentSelected,
     wells: freshWells
   };
@@ -392,15 +392,15 @@ const updateWellboreTrajectory = (state: NavigationState, { payload }: UpdateWel
   const wellboreIndex = getWellboreIndex(freshWells, wellIndex, wellboreUid);
   const freshTrajectories = [...wells[wellIndex].wellbores[wellboreIndex].trajectories];
   const trajectoryIndex = freshTrajectories.findIndex((t) => t.uid === trajectory.uid);
-  let selectedTrajectory = null;
+  let selectedObject = null;
   freshTrajectories[trajectoryIndex] = trajectory;
-  selectedTrajectory = state.selectedTrajectory?.uid === trajectory.uid ? trajectory : state.selectedTrajectory;
+  selectedObject = sameUids(trajectory, state.selectedObject) && state.selectedObjectGroup == ObjectType.Trajectory ? trajectory : state.selectedObject;
   wells[wellIndex].wellbores[wellboreIndex].trajectories = freshTrajectories;
   return {
     ...state,
     wells: freshWells,
     filteredWells: filterWells(freshWells, state.selectedFilter),
-    selectedTrajectory
+    selectedObject
   };
 };
 
@@ -408,11 +408,11 @@ const updateWellboreTrajectories = (state: NavigationState, { payload }: UpdateW
   const { wells } = state;
   const { trajectories, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { trajectories });
-  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, trajectories, state.selectedTrajectory, wellboreUid, wellUid);
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, trajectories, state.selectedObject, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
-    selectedTrajectory: newSelectedObject,
+    selectedObject: newSelectedObject,
     currentSelected,
     wells: freshWells
   };
@@ -422,11 +422,11 @@ const updateWellboreTubulars = (state: NavigationState, { payload }: UpdateWellb
   const { wells } = state;
   const { tubulars, wellUid, wellboreUid } = payload;
   const freshWells = replacePropertiesInWellbore(wellUid, wells, wellboreUid, { tubulars });
-  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, tubulars, state.selectedTubular, wellboreUid, wellUid);
+  const { currentSelected, newSelectedObject } = getCurrentSelectedObjectIfRemoved(state, tubulars, state.selectedObject, wellboreUid, wellUid);
   return {
     ...state,
     ...updateSelectedWellAndWellboreIfNeeded(state, freshWells, wellUid, wellboreUid),
-    selectedTubular: newSelectedObject,
+    selectedObject: newSelectedObject,
     currentSelected,
     wells: freshWells
   };
@@ -440,10 +440,10 @@ const updateWellboreTubular = (state: NavigationState, { payload }: UpdateWellbo
   const wellboreIndex = getWellboreIndex(freshWells, wellIndex, tubular.wellboreUid);
   const freshTubulars = [...wells[wellIndex].wellbores[wellboreIndex].tubulars];
   const tubularIndex = freshTubulars.findIndex((t) => t.uid === tubular.uid);
-  let selectedTubular = null;
+  let selectedObject = null;
   if (exists) {
     freshTubulars[tubularIndex] = tubular;
-    selectedTubular = state.selectedTubular?.uid === tubular.uid ? tubular : state.selectedTubular;
+    selectedObject = sameUids(tubular, state.selectedObject) && state.selectedObjectGroup == ObjectType.Tubular ? tubular : state.selectedObject;
   } else {
     freshTubulars.splice(tubularIndex, 1);
   }
@@ -453,7 +453,7 @@ const updateWellboreTubular = (state: NavigationState, { payload }: UpdateWellbo
     ...state,
     wells: freshWells,
     filteredWells: filterWells(freshWells, state.selectedFilter),
-    selectedTubular
+    selectedObject
   };
 };
 
@@ -476,15 +476,15 @@ const updateWellboreWbGeometry = (state: NavigationState, { payload }: UpdateWel
   const wellboreIndex = getWellboreIndex(freshWells, wellIndex, wellboreUid);
   const freshWbGeometries = [...wells[wellIndex].wellbores[wellboreIndex].wbGeometrys];
   const wbGeometryIndex = freshWbGeometries.findIndex((wbg) => wbg.uid === wbGeometry.uid);
-  let selectedWbGeometry = null;
+  let selectedObject = null;
   freshWbGeometries[wbGeometryIndex] = wbGeometry;
-  selectedWbGeometry = state.selectedWbGeometry?.uid === wbGeometry.uid ? wbGeometry : state.selectedWbGeometry;
+  selectedObject = sameUids(wbGeometry, state.selectedObject) && state.selectedObjectGroup == ObjectType.WbGeometry ? wbGeometry : state.selectedObject;
   wells[wellIndex].wellbores[wellboreIndex].wbGeometrys = freshWbGeometries;
   return {
     ...state,
     wells: freshWells,
     filteredWells: filterWells(freshWells, state.selectedFilter),
-    selectedWbGeometry: selectedWbGeometry
+    selectedObject: selectedObject
   };
 };
 
@@ -573,4 +573,8 @@ const updateWells = (state: NavigationState, { payload }: UpdateWellsAction) => 
     wells: wells,
     filteredWells: filterWells(wells, state.selectedFilter)
   };
+};
+
+const sameUids = (object1: ObjectOnWellbore, object2: ObjectOnWellbore) => {
+  return object1.uid === object2.uid && object1.wellboreUid === object2.wellboreUid && object1.wellUid === object2.wellUid;
 };

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationContext.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationContext.ts
@@ -3,13 +3,12 @@ import { LogCurveInfoRow } from "../components/ContentViews/LogCurveInfoListView
 import BhaRun from "../models/bhaRun";
 import LogObject from "../models/logObject";
 import MessageObject from "../models/messageObject";
-import MudLog from "../models/mudLog";
+import ObjectOnWellbore from "../models/objectOnWellbore";
 import { ObjectType } from "../models/objectType";
 import Rig from "../models/rig";
 import RiskObject from "../models/riskObject";
 import { Server } from "../models/server";
 import Trajectory from "../models/trajectory";
-import Tubular from "../models/tubular";
 import WbGeometryObject from "../models/wbGeometry";
 import Well from "../models/well";
 import Wellbore from "../models/wellbore";
@@ -34,15 +33,9 @@ export interface NavigationState {
   selectedWell: Well;
   selectedWellbore: Wellbore;
   selectedLogTypeGroup: string;
-  selectedLog: LogObject;
-  selectedMudLog: MudLog;
   selectedObjectGroup: ObjectType;
-  selectedRig: Rig;
-  selectedRisk: RiskObject;
+  selectedObject: ObjectOnWellbore;
   selectedLogCurveInfo: LogCurveInfoRow[];
-  selectedTrajectory: Trajectory;
-  selectedTubular: Tubular;
-  selectedWbGeometry: WbGeometryObject;
   servers: Server[];
   currentSelected: Selectable;
   wells: Well[];
@@ -58,15 +51,9 @@ export const allDeselected: any = {
   selectedWell: null,
   selectedWellbore: null,
   selectedLogTypeGroup: null,
-  selectedLog: null,
-  selectedMudLog: null,
   selectedObjectGroup: null,
-  selectedRisk: null,
+  selectedObject: null,
   selectedLogCurveInfo: null,
-  selectedRig: null,
-  selectedTrajectory: null,
-  selectedTubular: null,
-  selectedWbGeometry: null,
   currentSelected: null,
   currentProperties: new Map()
 };
@@ -76,15 +63,9 @@ export const EMPTY_NAVIGATION_STATE: NavigationState = {
   selectedWell: null,
   selectedWellbore: null,
   selectedLogTypeGroup: null,
-  selectedLog: null,
-  selectedMudLog: null,
   selectedObjectGroup: null,
-  selectedRig: null,
-  selectedRisk: null,
+  selectedObject: null,
   selectedLogCurveInfo: null,
-  selectedTrajectory: null,
-  selectedTubular: null,
-  selectedWbGeometry: null,
   servers: [],
   currentSelected: null,
   wells: [],

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -220,7 +220,7 @@ const selectObject = (state: NavigationState, { payload }: SelectObjectAction): 
     selectedWellbore: wellbore,
     selectedObjectGroup: objectType,
     selectedLogTypeGroup: logTypeGroup,
-    ["selected" + objectType]: object,
+    selectedObject: object,
     currentSelected: object,
     currentProperties: getObjectOnWellboreProperties(object, objectType),
     expandedTreeNodes


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes WE-914

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Rewrite navigationContext to use selectedObject
* Fix duplicate key in ObjectMenuItems 
* Fix LogCurveInfoListView crashing on null indexCurve when switching views
* Fix tree items being selected when object uids match but well/wellbore differs
* Refactor setObjectGroupView in ContentView
* Fix matching selectedObject in modificationStateReducer

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [ ] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


