### PR TITLE
Revert "FIX-1868 add dotnet format to CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,5 @@ jobs:
           dotnet-version: 7.0.x
       - name: Build
         run: dotnet build /warnaserror --configuration Release
-      - name: Install dotnet format
-        run: dotnet tool update --global dotnet-format
-      - name: Run dotnet format
-        run: dotnet format --verify-no-changes --no-restore
       - name: Test
         run: dotnet test --configuration Release --logger "console;verbosity=detailed"


### PR DESCRIPTION
Reverts equinor/witsml-explorer#1869 due to dotnet-format being broken.
Revert this revert once actions/setup-dotnet@v2 uses a newer version than 7.0.302.