### PR TITLE
FIX-1912 Show number of (selected) items in content tables

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -1,4 +1,4 @@
-import { Button, Grid, LinearProgress } from "@material-ui/core";
+import { Button, LinearProgress } from "@material-ui/core";
 import orderBy from "lodash/orderBy";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
@@ -160,32 +160,28 @@ export const CurveValuesView = (): React.ReactElement => {
     };
   }, [selectedLogCurveInfo, selectedLog]);
 
+  const panelElements = [
+    <Button key="downloadall" disabled={isLoading} onClick={() => exportSelectedIndexRange()}>
+      Download all as .csv
+    </Button>,
+    <Button key="downloadselected" disabled={isLoading || !selectedRows.length} onClick={() => exportSelectedDataPoints()}>
+      Download selected as .csv
+    </Button>
+  ];
+
   return (
     <Container>
-      {Boolean(tableData.length) && (
-        <ExportButtonGrid container spacing={1}>
-          <Grid item>
-            {
-              <Button disabled={isLoading} onClick={() => exportSelectedIndexRange()}>
-                Download all as .csv
-              </Button>
-            }
-          </Grid>
-          {Boolean(selectedRows.length) && (
-            <Grid item>
-              {
-                <Button disabled={isLoading} onClick={() => exportSelectedDataPoints()}>
-                  Download selected as .csv
-                </Button>
-              }
-            </Grid>
-          )}
-        </ExportButtonGrid>
-      )}
       {isLoading && <LinearProgress variant={"determinate"} value={progress} />}
       {!isLoading && !tableData.length && <Message>No data</Message>}
       {Boolean(columns.length) && Boolean(tableData.length) && (
-        <VirtualizedContentTable columns={columns} onRowSelectionChange={rowSelectionCallback} onContextMenu={onContextMenu} data={tableData} checkableRows={true} />
+        <VirtualizedContentTable
+          columns={columns}
+          onRowSelectionChange={rowSelectionCallback}
+          onContextMenu={onContextMenu}
+          data={tableData}
+          checkableRows={true}
+          panelElements={panelElements}
+        />
       )}
     </Container>
   );
@@ -194,10 +190,6 @@ export const CurveValuesView = (): React.ReactElement => {
 const Container = styled.div`
   height: calc(100% - 65px);
   width: calc(100% - 14px);
-`;
-
-const ExportButtonGrid = styled(Grid)`
-  padding: 10px;
 `;
 
 const Message = styled.div`

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -121,6 +121,7 @@ export const JobsView = (): React.ReactElement => {
     </Button>,
     msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) ? (
       <Switch
+        key="showAllUsersJobs"
         label="Show all users' jobs"
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
           setShowAll(e.target.checked);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -1,6 +1,5 @@
 import { Button, Icon, Switch, Typography } from "@equinor/eds-core-react";
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
-import styled from "styled-components";
 import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
@@ -12,8 +11,8 @@ import NotificationService, { Notification } from "../../services/notificationSe
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import JobInfoContextMenu, { JobInfoContextMenuProps } from "../ContextMenus/JobInfoContextMenu";
 import formatDateString from "../DateFormatter";
-import { ContentTable, ContentTableColumn, ContentType, Order } from "./table";
 import { clipLongString } from "./ViewUtils";
+import { ContentTable, ContentTableColumn, ContentType, Order } from "./table";
 
 export const JobsView = (): React.ReactElement => {
   const { navigationState } = useContext(NavigationContext);
@@ -108,32 +107,30 @@ export const JobsView = (): React.ReactElement => {
     };
   });
 
-  return (
-    <>
-      <Panel>
-        <Button
-          variant="outlined"
-          aria-disabled={shouldRefresh ? true : false}
-          aria-label={shouldRefresh ? "loading data" : null}
-          onClick={shouldRefresh ? undefined : () => setShouldRefresh(true)}
-          disabled={shouldRefresh}
-        >
-          <Icon name="refresh" />
-          Refresh
-        </Button>
-        {msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) && (
-          <Switch
-            label="Show all users' jobs"
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              setShowAll(e.target.checked);
-            }}
-          />
-        )}
-        <Typography>Last fetched: {lastFetched}</Typography>
-      </Panel>
-      <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} />
-    </>
-  );
+  const panelElements = [
+    <Button
+      key="refreshJobs"
+      variant="outlined"
+      aria-disabled={shouldRefresh ? true : false}
+      aria-label={shouldRefresh ? "loading data" : null}
+      onClick={shouldRefresh ? undefined : () => setShouldRefresh(true)}
+      disabled={shouldRefresh}
+    >
+      <Icon name="refresh" />
+      Refresh
+    </Button>,
+    msalEnabled && (getUserAppRoles().includes(adminRole) || getUserAppRoles().includes(developerRole)) ? (
+      <Switch
+        label="Show all users' jobs"
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
+          setShowAll(e.target.checked);
+        }}
+      />
+    ) : null,
+    <Typography key="lastFetched">Last fetched: {lastFetched}</Typography>
+  ];
+
+  return <ContentTable columns={columns} data={jobInfoRows} order={Order.Descending} onContextMenu={onContextMenu} panelElements={panelElements} />;
 };
 
 const serverUrlToName = (servers: Server[], url: string): string => {
@@ -143,11 +140,5 @@ const serverUrlToName = (servers: Server[], url: string): string => {
   const server = servers.find((server) => server.url == url);
   return server ? server.name : url;
 };
-
-const Panel = styled.div`
-  display: flex;
-  gap: 20px;
-  align-items: center;
-`;
 
 export default JobsView;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/__tests__/ContentTable.tests.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/__tests__/ContentTable.tests.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ContentTable, ContentTableRow, ContentType } from "../table";
 
 describe("<ContentTable />", () => {
@@ -60,5 +61,39 @@ describe("<ContentTable />", () => {
     bodyRows.forEach((row) => {
       expect(row.querySelectorAll("input")).toHaveLength(1);
     });
+  });
+
+  it("Tables with checkable rows should display the number of checked rows", async () => {
+    const noSelectedRegex = new RegExp(`selected: 0/${data.length}`, "i");
+    const oneSelectedRegex = new RegExp(`selected: 1/${data.length}`, "i");
+    const allSelectedRegex = new RegExp(`selected: ${data.length}/${data.length}`, "i");
+
+    const user = userEvent.setup();
+    render(<ContentTable columns={columns} data={data} checkableRows />);
+    const [toggleAll, ...toggleRows] = screen.getAllByRole("checkbox");
+    const selected = screen.getByText(/selected:/i);
+
+    expect(selected).toHaveTextContent(noSelectedRegex);
+
+    await user.click(toggleRows[0]);
+    expect(selected).toHaveTextContent(oneSelectedRegex);
+
+    await user.click(toggleRows[0]);
+    expect(selected).toHaveTextContent(noSelectedRegex);
+
+    await user.click(toggleAll);
+    expect(selected).toHaveTextContent(allSelectedRegex);
+
+    await user.click(toggleAll);
+    expect(selected).toHaveTextContent(noSelectedRegex);
+  });
+
+  it("Tables without checkable rows should display the number of items", async () => {
+    const numberOfItemsRegex = new RegExp(`items: ${data.length}`, "i");
+
+    render(<ContentTable columns={columns} data={data} />);
+    const selected = screen.getByText(/items:/i);
+
+    expect(selected).toHaveTextContent(numberOfItemsRegex);
   });
 });

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@equinor/eds-core-react";
 import { Checkbox, TableCell as MuiTableCell, TableRow as MuiTableRow, Table, TableBody, TableHead, TableSortLabel } from "@material-ui/core";
 import orderBy from "lodash/orderBy";
 import React, { useEffect, useState } from "react";
@@ -8,7 +9,7 @@ import { ContentTableColumn, ContentTableProps, ContentTableRow, ContentType, Or
 import { InsetHeader, InsetRow, InsetToggle } from "./Inset";
 
 export const ContentTable = (props: ContentTableProps): React.ReactElement => {
-  const { columns, onSelect, onContextMenu, checkableRows, order, inset } = props;
+  const { columns, onSelect, onContextMenu, checkableRows, order, inset, panelElements } = props;
   const [data, setData] = useState<any[]>(props.data ?? []);
   const [checkedContentItems, setCheckedContentItems] = useState<ContentTableRow[]>([]);
   const [sortOrder, setSortOrder] = useState<Order>(order ?? Order.Ascending);
@@ -58,71 +59,83 @@ export const ContentTable = (props: ContentTableProps): React.ReactElement => {
   };
 
   return (
-    <Table>
-      <TableHead>
-        <TableRow>
-          {checkableRows && (
-            <TableHeaderCell>
-              <Checkbox
-                onChange={toggleAllRows}
-                checked={checkedContentItems.length === data.length}
-                indeterminate={checkedContentItems.length > 0 && checkedContentItems.length < data.length}
-              />
-            </TableHeaderCell>
-          )}
-          <InsetHeader inset={inset} openInsets={openInsets} data={data} setOpenInsets={setOpenInsets} />
-          {columns &&
-            columns.map(
-              (column) =>
-                column && (
-                  <TableHeaderCell key={column.property} align={getColumnAlignment(column)}>
-                    <TableSortLabel active={sortedColumn === column} direction={sortOrder} onClick={() => sortByColumn(column)}>
-                      {column.label}
-                    </TableSortLabel>
-                  </TableHeaderCell>
-                )
+    <>
+      <Panel>
+        {checkableRows ? (
+          <Typography>
+            Selected: {checkedContentItems.length}/{data.length}
+          </Typography>
+        ) : (
+          <Typography>Items: {data.length}</Typography>
+        )}
+        {panelElements}
+      </Panel>
+      <Table>
+        <TableHead>
+          <TableRow>
+            {checkableRows && (
+              <TableHeaderCell>
+                <Checkbox
+                  onChange={toggleAllRows}
+                  checked={checkedContentItems.length === data.length}
+                  indeterminate={checkedContentItems.length > 0 && checkedContentItems.length < data.length}
+                />
+              </TableHeaderCell>
             )}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {data.map((item, index) => {
-          return (
-            checkVisibility(item.isVisibleFunction) && (
-              <React.Fragment key={index}>
-                <TableRow hover onContextMenu={onContextMenu ? (event) => onContextMenu(event, item, checkedContentItems) : (e) => e.preventDefault()}>
-                  {checkableRows && (
-                    <TableDataCell>
-                      <Checkbox
-                        onClick={(event) => toggleRow(event, item)}
-                        checked={checkedContentItems?.length > 0 && checkedContentItems.findIndex((checkedRow: ContentTableRow) => item.id === checkedRow.id) !== -1}
-                      />
-                    </TableDataCell>
-                  )}
-                  <InsetToggle inset={inset} openInsets={openInsets} uid={item.uid} setOpenInsets={setOpenInsets} />
-                  {columns &&
-                    columns.map(
-                      (column) =>
-                        column && (
-                          <TableDataCell
-                            id={item[column.property] + column.property}
-                            key={item[column.property] + column.property}
-                            clickable={onSelect ? "true" : "false"}
-                            type={column.type}
-                            align={getColumnAlignment(column)}
-                            onClick={(event) => selectRow(event, item)}
-                          >
-                            {formatCell(column.type, item[column.property])}
-                          </TableDataCell>
-                        )
+            <InsetHeader inset={inset} openInsets={openInsets} data={data} setOpenInsets={setOpenInsets} />
+            {columns &&
+              columns.map(
+                (column) =>
+                  column && (
+                    <TableHeaderCell key={column.property} align={getColumnAlignment(column)}>
+                      <TableSortLabel active={sortedColumn === column} direction={sortOrder} onClick={() => sortByColumn(column)}>
+                        {column.label}
+                      </TableSortLabel>
+                    </TableHeaderCell>
+                  )
+              )}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.map((item, index) => {
+            return (
+              checkVisibility(item.isVisibleFunction) && (
+                <React.Fragment key={index}>
+                  <TableRow hover onContextMenu={onContextMenu ? (event) => onContextMenu(event, item, checkedContentItems) : (e) => e.preventDefault()}>
+                    {checkableRows && (
+                      <TableDataCell>
+                        <Checkbox
+                          onClick={(event) => toggleRow(event, item)}
+                          checked={checkedContentItems?.length > 0 && checkedContentItems.findIndex((checkedRow: ContentTableRow) => item.id === checkedRow.id) !== -1}
+                        />
+                      </TableDataCell>
                     )}
-                </TableRow>
-                <InsetRow inset={inset} openInsets={openInsets} columnsLength={columns.length} uid={item.uid} />
-              </React.Fragment>
-            )
-          );
-        })}
-      </TableBody>
-    </Table>
+                    <InsetToggle inset={inset} openInsets={openInsets} uid={item.uid} setOpenInsets={setOpenInsets} />
+                    {columns &&
+                      columns.map(
+                        (column) =>
+                          column && (
+                            <TableDataCell
+                              id={item[column.property] + column.property}
+                              key={item[column.property] + column.property}
+                              clickable={onSelect ? "true" : "false"}
+                              type={column.type}
+                              align={getColumnAlignment(column)}
+                              onClick={(event) => selectRow(event, item)}
+                            >
+                              {formatCell(column.type, item[column.property])}
+                            </TableDataCell>
+                          )
+                      )}
+                  </TableRow>
+                  <InsetRow inset={inset} openInsets={openInsets} columnsLength={columns.length} uid={item.uid} />
+                </React.Fragment>
+              )
+            );
+          })}
+        </TableBody>
+      </Table>
+    </>
   );
 };
 
@@ -178,6 +191,14 @@ export const TableDataCell = styled(MuiTableCell)<{ type?: ContentType; clickabl
     `
     font-feature-settings: "tnum";
   `};
+`;
+
+const Panel = styled.div`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  padding: 4px;
+  white-space: nowrap;
 `;
 
 export default ContentTable;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -9,7 +9,7 @@ import { ContentTableColumn, ContentTableProps, ContentTableRow, ContentType, Or
 import { InsetHeader, InsetRow, InsetToggle } from "./Inset";
 
 export const ContentTable = (props: ContentTableProps): React.ReactElement => {
-  const { columns, onSelect, onContextMenu, checkableRows, order, inset, panelElements } = props;
+  const { columns, onSelect, onContextMenu, checkableRows, order, inset, panelElements, showTotalItems = true } = props;
   const [data, setData] = useState<any[]>(props.data ?? []);
   const [checkedContentItems, setCheckedContentItems] = useState<ContentTableRow[]>([]);
   const [sortOrder, setSortOrder] = useState<Order>(order ?? Order.Ascending);
@@ -58,18 +58,24 @@ export const ContentTable = (props: ContentTableProps): React.ReactElement => {
     return isVisibleFunction();
   };
 
-  return (
-    <>
+  const renderPanel = () => {
+    if (!showTotalItems && !panelElements) return null;
+
+    const selectedItemsText = checkableRows ? `Selected: ${checkedContentItems.length}/${data.length}` : `Items: ${data.length}`;
+
+    const selectedItemsElement = showTotalItems ? <Typography>{selectedItemsText}</Typography> : null;
+
+    return (
       <Panel>
-        {checkableRows ? (
-          <Typography>
-            Selected: {checkedContentItems.length}/{data.length}
-          </Typography>
-        ) : (
-          <Typography>Items: {data.length}</Typography>
-        )}
+        {selectedItemsElement}
         {panelElements}
       </Panel>
+    );
+  };
+
+  return (
+    <>
+      {renderPanel()}
       <Table>
         <TableHead>
           <TableRow>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -1,4 +1,3 @@
-import { Typography } from "@equinor/eds-core-react";
 import { Checkbox, TableCell as MuiTableCell, TableRow as MuiTableRow, Table, TableBody, TableHead, TableSortLabel } from "@material-ui/core";
 import orderBy from "lodash/orderBy";
 import React, { useEffect, useState } from "react";
@@ -7,6 +6,7 @@ import { colors } from "../../../styles/Colors";
 import Icon from "../../../styles/Icons";
 import { ContentTableColumn, ContentTableProps, ContentTableRow, ContentType, Order, getCheckedRows, getColumnAlignment, getComparatorByColumn, getSelectedRange } from "./";
 import { InsetHeader, InsetRow, InsetToggle } from "./Inset";
+import Panel from "./Panel";
 
 export const ContentTable = (props: ContentTableProps): React.ReactElement => {
   const { columns, onSelect, onContextMenu, checkableRows, order, inset, panelElements, showTotalItems = true } = props;
@@ -58,24 +58,15 @@ export const ContentTable = (props: ContentTableProps): React.ReactElement => {
     return isVisibleFunction();
   };
 
-  const renderPanel = () => {
-    if (!showTotalItems && !panelElements) return null;
-
-    const selectedItemsText = checkableRows ? `Selected: ${checkedContentItems.length}/${data.length}` : `Items: ${data.length}`;
-
-    const selectedItemsElement = showTotalItems ? <Typography>{selectedItemsText}</Typography> : null;
-
-    return (
-      <Panel>
-        {selectedItemsElement}
-        {panelElements}
-      </Panel>
-    );
-  };
-
   return (
     <>
-      {renderPanel()}
+      <Panel
+        showTotalItems={showTotalItems}
+        showCheckedItems={checkableRows}
+        panelElements={panelElements}
+        numberOfCheckedItems={checkedContentItems?.length}
+        numberOfItems={data?.length}
+      />
       <Table>
         <TableHead>
           <TableRow>
@@ -197,14 +188,6 @@ export const TableDataCell = styled(MuiTableCell)<{ type?: ContentType; clickabl
     `
     font-feature-settings: "tnum";
   `};
-`;
-
-const Panel = styled.div`
-  display: flex;
-  gap: 20px;
-  align-items: center;
-  padding: 4px;
-  white-space: nowrap;
 `;
 
 export default ContentTable;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Inset.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Inset.tsx
@@ -86,7 +86,7 @@ export const InsetRow = (props: InsetRowProps): ReactElement => {
       <MuiTableCell colSpan={1} padding="none"></MuiTableCell>
       <MuiTableCell colSpan={columnsLength} padding="none">
         <div style={{ maxWidth: "400px" }}>
-          <ContentTable columns={inset.columns} data={inset.data[uid]} />
+          <ContentTable columns={inset.columns} data={inset.data[uid]} showTotalItems={false} />
         </div>
       </MuiTableCell>
     </MuiTableRow>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
@@ -1,0 +1,38 @@
+import { Typography } from "@equinor/eds-core-react";
+import React from "react";
+import styled from "styled-components";
+
+export interface PanelProps {
+  showTotalItems: boolean;
+  showCheckedItems: boolean;
+  panelElements?: React.ReactElement[];
+  numberOfCheckedItems?: number;
+  numberOfItems?: number;
+}
+
+const Panel = (props: PanelProps) => {
+  const { showTotalItems, showCheckedItems, panelElements, numberOfCheckedItems, numberOfItems } = props;
+
+  if (!showTotalItems && !panelElements) return null;
+
+  const selectedItemsText = showCheckedItems ? `Selected: ${numberOfCheckedItems}/${numberOfItems}` : `Items: ${numberOfItems}`;
+
+  const selectedItemsElement = showTotalItems ? <Typography>{selectedItemsText}</Typography> : null;
+
+  return (
+    <Div>
+      {selectedItemsElement}
+      {panelElements}
+    </Div>
+  );
+};
+
+const Div = styled.div`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  padding: 4px;
+  white-space: nowrap;
+`;
+
+export default Panel;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
@@ -145,7 +145,7 @@ const innerGridElementType = forwardRef<HTMLDivElement, any>(({ children, ...res
 innerGridElementType.displayName = "innerGridElementType";
 
 export const VirtualizedContentTable = (props: ContentTableProps): React.ReactElement => {
-  const { columns, onSelect, onContextMenu, checkableRows, onRowSelectionChange, panelElements } = props;
+  const { columns, onSelect, onContextMenu, checkableRows, onRowSelectionChange, panelElements, showTotalItems = true } = props;
   const [data, setData] = useState<any[]>(props.data ?? []);
   const [checkedContentItems, setCheckedContentItems] = useState<ContentTableRow[]>([]);
   const [sortOrder, setSortOrder] = useState<Order>(Order.Ascending);
@@ -228,6 +228,21 @@ export const VirtualizedContentTable = (props: ContentTableProps): React.ReactEl
     [checkableRows, columnRefs.length]
   );
 
+  const renderPanel = () => {
+    if (!showTotalItems && !panelElements) return null;
+
+    const selectedItemsText = checkableRows ? `Selected: ${checkedContentItems.length}/${data.length}` : `Items: ${data.length}`;
+
+    const selectedItemsElement = showTotalItems ? <Typography>{selectedItemsText}</Typography> : null;
+
+    return (
+      <Panel>
+        {selectedItemsElement}
+        {panelElements}
+      </Panel>
+    );
+  };
+
   return (
     <>
       {columns && (
@@ -248,16 +263,7 @@ export const VirtualizedContentTable = (props: ContentTableProps): React.ReactEl
                 toggleAllRows: toggleAllRows
               }}
             >
-              <Panel>
-                {checkableRows ? (
-                  <Typography>
-                    Selected: {checkedContentItems.length}/{data.length}
-                  </Typography>
-                ) : (
-                  <Typography>Items: {data.length}</Typography>
-                )}
-                {panelElements}
-              </Panel>
+              {renderPanel()}
               <AutoSizer>
                 {({ height, width }) => {
                   const itemData = getItemData(columns, width, data, onContextMenu, onSelect, toggleRow);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
@@ -1,3 +1,4 @@
+import { Typography } from "@equinor/eds-core-react";
 import { Checkbox, TableCell as MuiTableCell, TableSortLabel, Tooltip } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
 import orderBy from "lodash/orderBy";
@@ -144,7 +145,7 @@ const innerGridElementType = forwardRef<HTMLDivElement, any>(({ children, ...res
 innerGridElementType.displayName = "innerGridElementType";
 
 export const VirtualizedContentTable = (props: ContentTableProps): React.ReactElement => {
-  const { columns, onSelect, onContextMenu, checkableRows, onRowSelectionChange } = props;
+  const { columns, onSelect, onContextMenu, checkableRows, onRowSelectionChange, panelElements } = props;
   const [data, setData] = useState<any[]>(props.data ?? []);
   const [checkedContentItems, setCheckedContentItems] = useState<ContentTableRow[]>([]);
   const [sortOrder, setSortOrder] = useState<Order>(Order.Ascending);
@@ -247,6 +248,16 @@ export const VirtualizedContentTable = (props: ContentTableProps): React.ReactEl
                 toggleAllRows: toggleAllRows
               }}
             >
+              <Panel>
+                {checkableRows ? (
+                  <Typography>
+                    Selected: {checkedContentItems.length}/{data.length}
+                  </Typography>
+                ) : (
+                  <Typography>Items: {data.length}</Typography>
+                )}
+                {panelElements}
+              </Panel>
               <AutoSizer>
                 {({ height, width }) => {
                   const itemData = getItemData(columns, width, data, onContextMenu, onSelect, toggleRow);
@@ -376,5 +387,13 @@ const TableDataCell = styled(MuiTableCell)<{ clickable?: string }>`
   font-feature-settings: "tnum";
 `;
 TableDataCell.displayName = "TableDataCell";
+
+const Panel = styled.div`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  padding: 4px;
+  white-space: nowrap;
+`;
 
 export default VirtualizedContentTable;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/VirtualizedContentTable.tsx
@@ -1,4 +1,3 @@
-import { Typography } from "@equinor/eds-core-react";
 import { Checkbox, TableCell as MuiTableCell, TableSortLabel, Tooltip } from "@material-ui/core";
 import { useTheme } from "@material-ui/core/styles";
 import orderBy from "lodash/orderBy";
@@ -11,6 +10,7 @@ import { IndexRange } from "../../../models/jobs/deleteLogCurveValuesJob";
 import LogObject from "../../../models/logObject";
 import { colors } from "../../../styles/Colors";
 import { formatCell } from "./ContentTable";
+import Panel from "./Panel";
 import {
   ContentTableColumn,
   ContentTableProps,
@@ -228,21 +228,6 @@ export const VirtualizedContentTable = (props: ContentTableProps): React.ReactEl
     [checkableRows, columnRefs.length]
   );
 
-  const renderPanel = () => {
-    if (!showTotalItems && !panelElements) return null;
-
-    const selectedItemsText = checkableRows ? `Selected: ${checkedContentItems.length}/${data.length}` : `Items: ${data.length}`;
-
-    const selectedItemsElement = showTotalItems ? <Typography>{selectedItemsText}</Typography> : null;
-
-    return (
-      <Panel>
-        {selectedItemsElement}
-        {panelElements}
-      </Panel>
-    );
-  };
-
   return (
     <>
       {columns && (
@@ -263,7 +248,13 @@ export const VirtualizedContentTable = (props: ContentTableProps): React.ReactEl
                 toggleAllRows: toggleAllRows
               }}
             >
-              {renderPanel()}
+              <Panel
+                showTotalItems={showTotalItems}
+                showCheckedItems={checkableRows}
+                panelElements={panelElements}
+                numberOfCheckedItems={checkedContentItems?.length}
+                numberOfItems={data?.length}
+              />
               <AutoSizer>
                 {({ height, width }) => {
                   const itemData = getItemData(columns, width, data, onContextMenu, onSelect, toggleRow);
@@ -393,13 +384,5 @@ const TableDataCell = styled(MuiTableCell)<{ clickable?: string }>`
   font-feature-settings: "tnum";
 `;
 TableDataCell.displayName = "TableDataCell";
-
-const Panel = styled.div`
-  display: flex;
-  gap: 20px;
-  align-items: center;
-  padding: 4px;
-  white-space: nowrap;
-`;
 
 export default VirtualizedContentTable;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/tableParts.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/tableParts.ts
@@ -28,6 +28,7 @@ export interface ContentTableProps {
   onRowSelectionChange?: (rows: ContentTableRow[], sortOrder: Order, sortedColumn: ContentTableColumn) => void;
   order?: Order;
   inset?: Inset;
+  panelElements?: React.ReactElement[];
 }
 
 export enum Order {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/tableParts.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/tableParts.ts
@@ -29,6 +29,7 @@ export interface ContentTableProps {
   order?: Order;
   inset?: Inset;
   panelElements?: React.ReactElement[];
+  showTotalItems?: boolean;
 }
 
 export enum Order {

--- a/Src/WitsmlExplorer.Frontend/package.json
+++ b/Src/WitsmlExplorer.Frontend/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/enzyme": "^3.10.12",
     "@types/jest": "^29.1.0",
     "@types/lodash": "^4.14.186",

--- a/yarn.lock
+++ b/yarn.lock
@@ -976,6 +976,11 @@
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #1912 

## Description

* Content tables with checkable rows now shows the number of total and selected items.
* Content tables without checkable rows now shows the total number of items.
* Created tests to test the details above.



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


