### PR TITLE
FIX-1908 Add 'Z' as a valid time zone

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/ModalParts.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ModalParts.tsx
@@ -8,7 +8,7 @@ export const validText = (text: string): boolean => {
 };
 
 export const validTimeZone = (timeZone: string): boolean => {
-  const timeZoneValidator = new RegExp("(\\+(0\\d|1[0-4])|-(0\\d|1[0-2])):(00|30|45)");
+  const timeZoneValidator = new RegExp("(^Z$)|(\\+(0\\d|1[0-4])|-(0\\d|1[0-2])):(00|30|45)");
   return timeZoneValidator.test(timeZone);
 };
 

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellBatchUpdateModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellBatchUpdateModal.tsx
@@ -68,7 +68,7 @@ const WellBatchUpdateModal = (props: WellBatchUpdateModalProps): React.ReactElem
                 value={editableWell.timeZone}
                 fullWidth
                 error={!validTimeZone(editableWell.timeZone) && editableWell.timeZone.length !== 0}
-                helperText={"TimeZone has to be in the format -hh:mm or +hh:mm within the range (-12:00 to +14:00) and minutes has to be 00, 30 or 45"}
+                helperText={"TimeZone has to be 'Z' or in the format -hh:mm or +hh:mm within the range (-12:00 to +14:00) and minutes has to be 00, 30 or 45"}
                 inputProps={{ maxLength: 6 }}
                 onChange={(e) => setEditableWell({ ...editableWell, timeZone: e.target.value })}
               />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
@@ -96,7 +96,7 @@ const WellPropertiesModal = (props: WellPropertiesModalProps): React.ReactElemen
                 value={editableWell.timeZone}
                 fullWidth
                 error={!validTimeZone(editableWell.timeZone)}
-                helperText={"TimeZone has to be in the format -hh:mm or +hh:mm within the range (-12:00 to +14:00) and minutes has to be 00, 30 or 45"}
+                helperText={"TimeZone has to be 'Z' or in the format -hh:mm or +hh:mm within the range (-12:00 to +14:00) and minutes has to be 00, 30 or 45"}
                 inputProps={{ maxLength: 6 }}
                 onChange={(e) => setEditableWell({ ...editableWell, timeZone: e.target.value })}
               />


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #1908 

## Description

* The character Z is now accepted as a valid time zone



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


