### PR TITLE
FIX-1928 Lazy load wellbore objects

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/ObjectHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/ObjectHandler.cs
@@ -24,5 +24,12 @@ namespace WitsmlExplorer.Api.HttpHandlers
             IEnumerable<ObjectOnWellbore> result = await objectService.GetObjectIdOnly(wellUid, wellboreUid, objectUid, objectType);
             return TypedResults.Ok(result?.First());
         }
+
+        [Produces(typeof(Dictionary<EntityType, int>))]
+        public static async Task<IResult> GetExpandableObjectsCount(string wellUid, string wellboreUid, IObjectService objectService)
+        {
+            Dictionary<EntityType, int> result = await objectService.GetExpandableObjectsCount(wellUid, wellboreUid);
+            return TypedResults.Ok(result);
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -29,6 +29,7 @@ namespace WitsmlExplorer.Api
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}", WellboreHandler.GetWellbore, useOAuth2);
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/idonly/{objectType}", ObjectHandler.GetObjectsIdOnly, useOAuth2);
             app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/idonly/{objectType}/{objectUid}", ObjectHandler.GetObjectIdOnly, useOAuth2);
+            app.MapGet("/wells/{wellUid}/wellbores/{wellboreUid}/countexpandable", ObjectHandler.GetExpandableObjectsCount, useOAuth2);
 
             Dictionary<EntityType, string> types = EntityTypeHelper.ToPluralLowercase();
             Dictionary<EntityType, string> routes = types.ToDictionary(entry => entry.Key, entry => "/wells/{wellUid}/wellbores/{wellboreUid}/" + entry.Value);

--- a/Src/WitsmlExplorer.Api/Services/WellboreService.cs
+++ b/Src/WitsmlExplorer.Api/Services/WellboreService.cs
@@ -42,6 +42,7 @@ namespace WitsmlExplorer.Api.Services
                     SuffixAPI = witsmlWellbore.SuffixAPI,
                     NumGovt = witsmlWellbore.NumGovt,
                     WellStatus = witsmlWellbore.StatusWellbore,
+                    IsActive = StringHelpers.ToBooleanSafe(witsmlWellbore.IsActive),
                     WellborePurpose = witsmlWellbore.PurposeWellbore,
                     WellboreParentUid = witsmlWellbore.ParentWellbore?.UidRef,
                     WellboreParentName = witsmlWellbore.ParentWellbore?.Value,

--- a/Src/WitsmlExplorer.Api/Workers/Create/CreateLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Create/CreateLogWorker.cs
@@ -36,7 +36,7 @@ namespace WitsmlExplorer.Api.Workers.Create
             }
 
             Logger.LogInformation("Log object created. {jobDescription}", job.Description());
-            RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogObject.WellUid, job.LogObject.WellboreUid, RefreshType.Update);
+            RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), job.LogObject.WellUid, job.LogObject.WellboreUid, EntityType.Log);
             WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Log object {job.LogObject.Name} created for {targetWellbore.Name}");
 
             return (workerResult, refreshAction);

--- a/Src/WitsmlExplorer.Api/Workers/Create/CreateMudLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Create/CreateMudLogWorker.cs
@@ -35,7 +35,7 @@ namespace WitsmlExplorer.Api.Workers.Create
                 await WaitUntilMudLogHasBeenCreated(mudLog);
                 Logger.LogInformation("MudLog created. {jobDescription}", job.Description());
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"MudLog created ({mudLog.Name} [{mudLog.Uid}])");
-                RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), mudLog.WellUid, mudLog.Uid, RefreshType.Add);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), mudLog.WellUid, mudLog.WellboreUid, EntityType.MudLog);
                 return (workerResult, refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Create/CreateRiskWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Create/CreateRiskWorker.cs
@@ -36,7 +36,7 @@ namespace WitsmlExplorer.Api.Workers.Create
                 await WaitUntilRiskHasBeenCreated(risk);
                 Logger.LogInformation("Risk created. {jobDescription}", job.Description());
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Risk created ({risk.Name} [{risk.Uid}])");
-                RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), risk.WellUid, risk.Uid, RefreshType.Add);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), risk.WellUid, risk.WellboreUid, EntityType.Risk);
                 return (workerResult, refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Create/CreateWbGeometryWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Create/CreateWbGeometryWorker.cs
@@ -38,7 +38,7 @@ namespace WitsmlExplorer.Api.Workers.Create
                 await WaitUntilWbGeometryHasBeenCreated(wbGeometry);
                 Logger.LogInformation("WbGeometry created. {jobDescription}", job.Description());
                 WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"WbGeometry created ({wbGeometry.Name} [{wbGeometry.Uid}])");
-                RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wbGeometry.WellUid, wbGeometry.Uid, RefreshType.Add);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wbGeometry.WellUid, wbGeometry.WellboreUid, EntityType.WbGeometry);
                 return (workerResult, refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyFormationMarkerWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyFormationMarkerWorker.cs
@@ -28,7 +28,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("FormationMarker modified. {jobDescription}", job.Description());
-                RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), formationMarker.WellUid, formationMarker.WellboreUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), formationMarker.WellUid, formationMarker.WellboreUid, EntityType.FormationMarker);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"FormationMarker updated ({formationMarker.Name} [{formationMarker.Uid}])"), refreshAction);
 
             }

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyLogObjectWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyLogObjectWorker.cs
@@ -42,7 +42,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("Log modified. {jobDescription}", job.Description());
-                RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), wellUid, wellboreUid, EntityType.Log);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Log updated ({job.LogObject.Name} [{logUid}])"), refreshAction);
             }
 

--- a/Src/WitsmlExplorer.Api/Workers/Modify/ModifyMudLogWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Modify/ModifyMudLogWorker.cs
@@ -28,7 +28,7 @@ namespace WitsmlExplorer.Api.Workers.Modify
             if (result.IsSuccessful)
             {
                 Logger.LogInformation("MudLog modified. {jobDescription}", job.Description());
-                RefreshWellbore refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), mudLog.WellUid, mudLog.WellboreUid, RefreshType.Update);
+                RefreshObjects refreshAction = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), mudLog.WellUid, mudLog.WellboreUid, EntityType.MudLog);
                 return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"MudLog updated ({mudLog.Name} [{mudLog.Uid}])"), refreshAction);
 
             }

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboreObjectTypesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboreObjectTypesListView.tsx
@@ -3,7 +3,14 @@ import { SelectObjectGroupAction } from "../../contexts/navigationActions";
 import NavigationContext from "../../contexts/navigationContext";
 import NavigationType from "../../contexts/navigationType";
 import { ObjectType, pluralizeObjectType } from "../../models/objectType";
-import { ContentTable, ContentTableColumn, ContentType } from "./table";
+import ObjectService from "../../services/objectService";
+import { ContentTable, ContentTableColumn, ContentTableRow, ContentType } from "./table";
+
+interface ObjectTypeRow extends ContentTableRow {
+  uid: number;
+  name: string;
+  objectType: ObjectType;
+}
 
 export const WellboreObjectTypesListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
@@ -11,9 +18,10 @@ export const WellboreObjectTypesListView = (): React.ReactElement => {
 
   const columns: ContentTableColumn[] = [{ property: "name", label: "Name", type: ContentType.String }];
 
-  const getRows = () => {
+  const getRows = (): ObjectTypeRow[] => {
     return Object.keys(ObjectType).map((key, index) => {
       return {
+        id: index,
         uid: index,
         name: pluralizeObjectType(key as ObjectType),
         objectType: key as ObjectType
@@ -21,8 +29,12 @@ export const WellboreObjectTypesListView = (): React.ReactElement => {
     });
   };
 
-  const onSelect = async (row: any) => {
-    const action: SelectObjectGroupAction = { type: NavigationType.SelectObjectGroup, payload: { objectType: row.objectType, well: selectedWell, wellbore: selectedWellbore } };
+  const onSelect = async (row: ObjectTypeRow) => {
+    const objects = await ObjectService.getObjectsIfMissing(selectedWellbore, row.objectType);
+    const action: SelectObjectGroupAction = {
+      type: NavigationType.SelectObjectGroup,
+      payload: { objectType: row.objectType, well: selectedWell, wellbore: selectedWellbore, objects }
+    };
     dispatchNavigation(action);
   };
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboreObjectTypesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboreObjectTypesListView.tsx
@@ -33,7 +33,7 @@ export const WellboreObjectTypesListView = (): React.ReactElement => {
     const objects = await ObjectService.getObjectsIfMissing(selectedWellbore, row.objectType);
     const action: SelectObjectGroupAction = {
       type: NavigationType.SelectObjectGroup,
-      payload: { objectType: row.objectType, well: selectedWell, wellbore: selectedWellbore, objects }
+      payload: { objectType: row.objectType, wellUid: selectedWell.uid, wellboreUid: selectedWellbore.uid, objects }
     };
     dispatchNavigation(action);
   };

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -13,7 +13,7 @@ import { ContentTable, ContentTableColumn, ContentType } from "./table";
 
 export const WellboresListView = (): React.ReactElement => {
   const { navigationState, dispatchNavigation } = useContext(NavigationContext);
-  const { selectedWell, servers } = navigationState;
+  const { selectedWell } = navigationState;
   const {
     dispatchOperation,
     operationState: { timeZone }
@@ -29,7 +29,7 @@ export const WellboresListView = (): React.ReactElement => {
   ];
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore) => {
-    const contextMenuProps: WellboreContextMenuProps = { dispatchNavigation, dispatchOperation, servers, wellbore };
+    const contextMenuProps: WellboreContextMenuProps = { wellbore, well: selectedWell };
     const position = getContextMenuPosition(event);
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <WellboreContextMenu {...contextMenuProps} />, position } });
   };

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -1,9 +1,11 @@
 import React, { useContext } from "react";
+import ModificationType from "../../contexts/modificationType";
 import NavigationContext from "../../contexts/navigationContext";
 import NavigationType from "../../contexts/navigationType";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import Wellbore from "../../models/wellbore";
+import ObjectService from "../../services/objectService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import WellboreContextMenu, { WellboreContextMenuProps } from "../ContextMenus/WellboreContextMenu";
 import formatDateString from "../DateFormatter";
@@ -38,16 +40,22 @@ export const WellboresListView = (): React.ReactElement => {
         ...wellbore,
         id: wellbore.uid,
         dateTimeCreation: formatDateString(wellbore.dateTimeCreation, timeZone),
-        dateTimeLastChange: formatDateString(wellbore.dateTimeLastChange, timeZone)
+        dateTimeLastChange: formatDateString(wellbore.dateTimeLastChange, timeZone),
+        wellbore: wellbore
       };
     });
   };
 
-  const onSelect = async (wellbore: any) => {
+  const onSelect = async (wellboreRow: any) => {
+    const wellbore = wellboreRow.wellbore;
     dispatchNavigation({
       type: NavigationType.SelectWellbore,
       payload: { well: selectedWell, wellbore }
     });
+    if (wellbore.objectCount == null) {
+      const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);
+      dispatchNavigation({ type: ModificationType.UpdateWellbore, payload: { wellbore: { ...wellbore, objectCount } } });
+    }
   };
 
   return selectedWell && <ContentTable columns={columns} data={getTableData()} onSelect={onSelect} onContextMenu={onContextMenu} />;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -47,14 +47,14 @@ export const WellboresListView = (): React.ReactElement => {
   };
 
   const onSelect = async (wellboreRow: any) => {
-    const wellbore = wellboreRow.wellbore;
+    const wellbore: Wellbore = wellboreRow.wellbore;
     dispatchNavigation({
       type: NavigationType.SelectWellbore,
       payload: { well: selectedWell, wellbore }
     });
     if (wellbore.objectCount == null) {
       const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);
-      dispatchNavigation({ type: ModificationType.UpdateWellbore, payload: { wellbore: { ...wellbore, objectCount } } });
+      dispatchNavigation({ type: ModificationType.UpdateWellborePartial, payload: { wellboreUid: wellbore.uid, wellUid: wellbore.wellUid, wellboreProperties: { objectCount } } });
     }
   };
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -4,7 +4,6 @@ import NavigationType from "../../contexts/navigationType";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import Wellbore from "../../models/wellbore";
-import WellboreService from "../../services/wellboreService";
 import { getContextMenuPosition } from "../ContextMenus/ContextMenu";
 import WellboreContextMenu, { WellboreContextMenuProps } from "../ContextMenus/WellboreContextMenu";
 import formatDateString from "../DateFormatter";
@@ -45,10 +44,9 @@ export const WellboresListView = (): React.ReactElement => {
   };
 
   const onSelect = async (wellbore: any) => {
-    const wellboreObjects = await WellboreService.getWellboreObjects(selectedWell.uid, wellbore.uid);
     dispatchNavigation({
       type: NavigationType.SelectWellbore,
-      payload: { well: selectedWell, wellbore, ...wellboreObjects }
+      payload: { well: selectedWell, wellbore }
     });
   };
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -31,7 +31,7 @@ export const WellsListView = (): React.ReactElement => {
   ];
 
   const onSelect = (well: any) => {
-    dispatchNavigation({ type: NavigationType.SelectWell, payload: { well, wellbores: well.wellbores } });
+    dispatchNavigation({ type: NavigationType.SelectWell, payload: { well } });
   };
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, well: Well, checkedWellRows: WellRow[]) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -1,16 +1,21 @@
 import { Typography } from "@equinor/eds-core-react";
 import { Divider, MenuItem } from "@material-ui/core";
-import React from "react";
+import React, { useContext } from "react";
 import { v4 as uuid } from "uuid";
-import { UpdateWellboreAction } from "../../contexts/modificationActions";
 import ModificationType from "../../contexts/modificationType";
-import { DisplayModalAction, HideContextMenuAction, HideModalAction } from "../../contexts/operationStateReducer";
+import NavigationContext from "../../contexts/navigationContext";
+import { treeNodeIsExpanded } from "../../contexts/navigationStateReducer";
+import NavigationType from "../../contexts/navigationType";
+import OperationContext from "../../contexts/operationContext";
+import { DisplayModalAction } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import { DeleteWellboreJob } from "../../models/jobs/deleteJobs";
 import LogObject from "../../models/logObject";
 import { Server } from "../../models/server";
-import Wellbore from "../../models/wellbore";
+import Well from "../../models/well";
+import Wellbore, { calculateWellboreNodeId } from "../../models/wellbore";
 import JobService, { JobType } from "../../services/jobService";
+import ObjectService from "../../services/objectService";
 import WellboreService from "../../services/wellboreService";
 import { colors } from "../../styles/Colors";
 import ConfirmModal from "../Modals/ConfirmModal";
@@ -24,14 +29,17 @@ import NestedMenuItem from "./NestedMenuItem";
 import { useClipboardReferences } from "./UseClipboardReferences";
 
 export interface WellboreContextMenuProps {
-  dispatchNavigation: (action: UpdateWellboreAction) => void;
-  dispatchOperation: (action: DisplayModalAction | HideContextMenuAction | HideModalAction) => void;
   wellbore: Wellbore;
-  servers?: Server[];
+  well: Well;
 }
 
 const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElement => {
-  const { dispatchNavigation, dispatchOperation, wellbore, servers } = props;
+  const { wellbore, well } = props;
+  const {
+    dispatchNavigation,
+    navigationState: { servers, expandedTreeNodes }
+  } = useContext(NavigationContext);
+  const { dispatchOperation } = useContext(OperationContext);
   const objectReferences = useClipboardReferences();
 
   const onClickNewWellbore = () => {
@@ -100,12 +108,27 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
   };
 
   const onClickRefresh = async () => {
+    dispatchOperation({ type: OperationType.HideContextMenu });
+    // toggle the wellbore node and navigate to parent well to reset the sidebar and content view
+    //   because we do not load in objects that have been loaded in before the refresh
+    const nodeId = calculateWellboreNodeId(wellbore);
+    if (treeNodeIsExpanded(expandedTreeNodes, nodeId)) {
+      dispatchNavigation({
+        type: NavigationType.ToggleTreeNode,
+        payload: { nodeId }
+      });
+    }
+    dispatchNavigation({
+      type: NavigationType.SelectWell,
+      payload: { well }
+    });
+
     const refreshedWellbore = await WellboreService.getWellbore(wellbore.wellUid, wellbore.uid);
+    const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);
     dispatchNavigation({
       type: ModificationType.UpdateWellbore,
-      payload: { wellbore: refreshedWellbore }
+      payload: { wellbore: { ...refreshedWellbore, objectCount } }
     });
-    dispatchOperation({ type: OperationType.HideContextMenu });
   };
 
   const onClickProperties = async () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -114,7 +114,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
     const nodeId = calculateWellboreNodeId(wellbore);
     if (treeNodeIsExpanded(expandedTreeNodes, nodeId)) {
       dispatchNavigation({
-        type: NavigationType.ToggleTreeNodeChildren,
+        type: NavigationType.CollapseTreeNodeChildren,
         payload: { nodeId }
       });
     }

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -37,7 +37,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
   const { wellbore, well } = props;
   const {
     dispatchNavigation,
-    navigationState: { servers, expandedTreeNodes }
+    navigationState: { servers, expandedTreeNodes, selectedWell, selectedWellbore }
   } = useContext(NavigationContext);
   const { dispatchOperation } = useContext(OperationContext);
   const objectReferences = useClipboardReferences();
@@ -109,19 +109,21 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
 
   const onClickRefresh = async () => {
     dispatchOperation({ type: OperationType.HideContextMenu });
-    // toggle the wellbore node and navigate to parent well to reset the sidebar and content view
+    // toggle the wellbore node and navigate to parent wellbore to reset the sidebar and content view
     //   because we do not load in objects that have been loaded in before the refresh
     const nodeId = calculateWellboreNodeId(wellbore);
     if (treeNodeIsExpanded(expandedTreeNodes, nodeId)) {
       dispatchNavigation({
-        type: NavigationType.ToggleTreeNode,
+        type: NavigationType.ToggleTreeNodeChildren,
         payload: { nodeId }
       });
     }
-    dispatchNavigation({
-      type: NavigationType.SelectWell,
-      payload: { well }
-    });
+    if (selectedWell?.uid == well.uid && selectedWellbore?.uid == wellbore.uid) {
+      dispatchNavigation({
+        type: NavigationType.SelectWellbore,
+        payload: { well, wellbore }
+      });
+    }
 
     const refreshedWellbore = await WellboreService.getWellbore(wellbore.wellUid, wellbore.uid);
     const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -100,7 +100,7 @@ const WellboreContextMenu = (props: WellboreContextMenuProps): React.ReactElemen
   };
 
   const onClickRefresh = async () => {
-    const refreshedWellbore = await WellboreService.getCompleteWellbore(wellbore.wellUid, wellbore.uid);
+    const refreshedWellbore = await WellboreService.getWellbore(wellbore.wellUid, wellbore.uid);
     dispatchNavigation({
       type: ModificationType.UpdateWellbore,
       payload: { wellbore: refreshedWellbore }

--- a/Src/WitsmlExplorer.Frontend/components/Nav.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Nav.tsx
@@ -79,7 +79,7 @@ const getWellCrumb = (selectedWell: Well, dispatch: (action: SelectWellAction) =
   return selectedWell
     ? {
         name: selectedWell.name,
-        onClick: () => dispatch({ type: NavigationType.SelectWell, payload: { well: selectedWell, wellbores: selectedWell.wellbores } })
+        onClick: () => dispatch({ type: NavigationType.SelectWell, payload: { well: selectedWell } })
       }
     : {};
 };
@@ -88,26 +88,7 @@ const getWellboreCrumb = (selectedWellbore: Wellbore, selectedWell: Well, dispat
   return selectedWellbore
     ? {
         name: selectedWellbore.name,
-        onClick: () =>
-          dispatch({
-            type: NavigationType.SelectWellbore,
-            payload: {
-              well: selectedWell,
-              wellbore: selectedWellbore,
-              bhaRuns: selectedWellbore.bhaRuns,
-              changeLogs: selectedWellbore.changeLogs,
-              fluidsReports: selectedWellbore.fluidsReports,
-              formationMarkers: selectedWellbore.formationMarkers,
-              logs: selectedWellbore.logs,
-              rigs: selectedWellbore.rigs,
-              trajectories: selectedWellbore.trajectories,
-              messages: selectedWellbore.messages,
-              mudLogs: selectedWellbore.mudLogs,
-              risks: selectedWellbore.risks,
-              tubulars: selectedWellbore.tubulars,
-              wbGeometries: selectedWellbore.wbGeometries
-            }
-          })
+        onClick: () => dispatch({ type: NavigationType.SelectWellbore, payload: { well: selectedWell, wellbore: selectedWellbore } })
       }
     : {};
 };
@@ -125,7 +106,7 @@ const getObjectGroupCrumb = (
         onClick: () =>
           dispatch({
             type: NavigationType.SelectObjectGroup,
-            payload: { well: selectedWell, wellbore: selectedWellbore, objectType }
+            payload: { well: selectedWell, wellbore: selectedWellbore, objectType, objects: null }
           })
       }
     : {};

--- a/Src/WitsmlExplorer.Frontend/components/Nav.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Nav.tsx
@@ -106,7 +106,7 @@ const getObjectGroupCrumb = (
         onClick: () =>
           dispatch({
             type: NavigationType.SelectObjectGroup,
-            payload: { well: selectedWell, wellbore: selectedWellbore, objectType, objects: null }
+            payload: { wellUid: selectedWell.uid, wellboreUid: selectedWellbore.uid, objectType, objects: null }
           })
       }
     : {};

--- a/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
@@ -131,7 +131,7 @@ const RefreshHandler = (): React.ReactElement => {
         dispatchNavigation({ type: modificationType, payload: { wellbore } });
       }
     } else if (modificationType === ModificationType.UpdateWellbore) {
-      const wellbore = await WellboreService.getCompleteWellbore(refreshAction.wellUid, refreshAction.wellboreUid);
+      const wellbore = await WellboreService.getWellbore(refreshAction.wellUid, refreshAction.wellboreUid);
       dispatchNavigation({
         type: ModificationType.UpdateWellbore,
         payload: { wellbore }

--- a/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/RefreshHandler.tsx
@@ -4,7 +4,7 @@ import ModificationType from "../contexts/modificationType";
 import NavigationContext from "../contexts/navigationContext";
 import EntityType from "../models/entityType";
 import { ObjectType } from "../models/objectType";
-import { getObjectsFromWellbore } from "../models/wellbore";
+import { getObjectsFromWellbore, objectTypeToWellboreObjects } from "../models/wellbore";
 import NotificationService, { RefreshAction } from "../services/notificationService";
 import ObjectService from "../services/objectService";
 import WellService from "../services/wellService";
@@ -132,6 +132,16 @@ const RefreshHandler = (): React.ReactElement => {
       }
     } else if (modificationType === ModificationType.UpdateWellbore) {
       const wellbore = await WellboreService.getWellbore(refreshAction.wellUid, refreshAction.wellboreUid);
+      const previousWellbore = wells?.find((well) => well.uid === refreshAction.wellUid)?.wellbores?.find((wellbore) => wellbore.uid === refreshAction.wellboreUid);
+      if (previousWellbore) {
+        // keep the wellbore objects that have been already loaded in
+        Object.values(ObjectType).forEach((objectType) => {
+          const label = objectTypeToWellboreObjects(objectType);
+          // @ts-ignore
+          wellbore[label] = previousWellbore[label];
+        });
+        wellbore.objectCount = previousWellbore.objectCount;
+      }
       dispatchNavigation({
         type: ModificationType.UpdateWellbore,
         payload: { wellbore }

--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -125,7 +125,10 @@ const Routing = (): React.ReactElement => {
           };
           dispatchNavigation(selectWellbore);
           const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);
-          dispatchNavigation({ type: ModificationType.UpdateWellbore, payload: { wellbore: { ...wellbore, objectCount } } });
+          dispatchNavigation({
+            type: ModificationType.UpdateWellborePartial,
+            payload: { wellboreUid: wellbore.uid, wellUid: wellbore.wellUid, wellboreProperties: { objectCount } }
+          });
         } else {
           NotificationService.Instance.alertDispatcher.dispatch({
             serverUrl: new URL(selectedServer?.url),
@@ -146,7 +149,7 @@ const Routing = (): React.ReactElement => {
   }, [selectedWell]);
 
   useEffect(() => {
-    if (isSyncingUrlAndState && selectedWellbore && selectedWellbore.objectCount) {
+    if (isSyncingUrlAndState && selectedWellbore) {
       const group = urlParams?.group as ObjectType;
       const objectUid = urlParams?.objectUid;
       if (group != null && getObjectsFromWellbore(selectedWellbore, group) == null) {
@@ -182,6 +185,8 @@ const Routing = (): React.ReactElement => {
             isSuccess: false
           });
         }
+        setIsSyncingUrlAndState(false);
+      } else {
         setIsSyncingUrlAndState(false);
       }
     }

--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -154,7 +154,7 @@ const Routing = (): React.ReactElement => {
           const objects = await ObjectService.getObjects(selectedWell.uid, selectedWellbore.uid, group);
           const action: SelectObjectGroupAction = {
             type: NavigationType.SelectObjectGroup,
-            payload: { objectType: group, well: selectedWell, wellbore: selectedWellbore, objects }
+            payload: { objectType: group, wellUid: selectedWell.uid, wellboreUid: selectedWellbore.uid, objects }
           };
           dispatchNavigation(action);
         };

--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import React, { useContext, useEffect, useState } from "react";
+import ModificationType from "../contexts/modificationType";
 import {
   SelectLogTypeAction,
   SelectObjectAction,
@@ -123,6 +124,8 @@ const Routing = (): React.ReactElement => {
             payload: { well: selectedWell, wellbore }
           };
           dispatchNavigation(selectWellbore);
+          const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);
+          dispatchNavigation({ type: ModificationType.UpdateWellbore, payload: { wellbore: { ...wellbore, objectCount } } });
         } else {
           NotificationService.Instance.alertDispatcher.dispatch({
             serverUrl: new URL(selectedServer?.url),

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/LogTypeItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/LogTypeItem.tsx
@@ -78,7 +78,7 @@ const LogTypeItem = (): React.ReactElement => {
 };
 
 const filterLogsByType = (wellbore: Wellbore, logType: string) => {
-  return wellbore && wellbore.logs && wellbore.logs.filter((log) => log.indexType === logType);
+  return wellbore && wellbore.logs ? wellbore.logs.filter((log) => log.indexType === logType) : [];
 };
 
 const listLogItemsByType = (logObjects: LogObject[], logType: string, well: Well, wellbore: Wellbore, logGroup: string, isSelected: (log: LogObject) => boolean) => {

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
@@ -70,7 +70,7 @@ const ObjectGroupItem = (props: ObjectGroupItemProps): React.ReactElement => {
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>) => {
     return onGroupContextMenu == null ? onGenericGroupContextMenu(event, objectType, wellbore, dispatchOperation) : onGroupContextMenu(event, wellbore);
   };
-
+  const showStub = wellbore.objectCount != null && wellbore.objectCount[objectType] != null && wellbore.objectCount[objectType] != 0;
   return (
     <TreeItem
       nodeId={calculateObjectGroupId(wellbore, objectType)}
@@ -80,7 +80,7 @@ const ObjectGroupItem = (props: ObjectGroupItemProps): React.ReactElement => {
       isLoading={isLoading}
       onIconClick={toggleTreeNode}
     >
-      {wellbore &&
+      {(wellbore &&
         objectsOnWellbore &&
         objectsOnWellbore.map((objectOnWellbore) => (
           <ObjectOnWellboreItem
@@ -91,7 +91,8 @@ const ObjectGroupItem = (props: ObjectGroupItemProps): React.ReactElement => {
             selected={isSelected(objectType, objectOnWellbore)}
             ContextMenu={ObjectContextMenu}
           />
-        ))}
+        ))) ||
+        (showStub && ["", ""])}
     </TreeItem>
   );
 };

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
@@ -40,7 +40,7 @@ const ObjectGroupItem = (props: ObjectGroupItemProps): React.ReactElement => {
   const onSelectObjectGroup = useCallback(async () => {
     setIsLoading(true);
     const objects = await ObjectService.getObjectsIfMissing(wellbore, objectType);
-    dispatchNavigation({ type: NavigationType.SelectObjectGroup, payload: { well, wellbore, objectType, objects } });
+    dispatchNavigation({ type: NavigationType.SelectObjectGroup, payload: { wellUid: well.uid, wellboreUid: wellbore.uid, objectType, objects } });
     setIsLoading(false);
   }, [well, wellbore, objectType]);
 

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { ReactNode, useCallback, useContext, useState } from "react";
 import ModificationType from "../../contexts/modificationType";
 import { ToggleTreeNodeAction } from "../../contexts/navigationActions";
 import NavigationContext from "../../contexts/navigationContext";
@@ -23,10 +23,12 @@ interface ObjectGroupItemProps {
   objectType: ObjectType;
   ObjectContextMenu?: React.ComponentType<ObjectContextMenuProps>; //required only if objectsOnWellbore array is provided
   onGroupContextMenu?: (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore) => void;
+  children?: ReactNode;
+  isActive?: boolean;
 }
 
 const ObjectGroupItem = (props: ObjectGroupItemProps): React.ReactElement => {
-  const { objectsOnWellbore, objectType, ObjectContextMenu, onGroupContextMenu } = props;
+  const { objectsOnWellbore, objectType, ObjectContextMenu, onGroupContextMenu, children, isActive } = props;
   const {
     dispatchNavigation,
     navigationState: { selectedObject, selectedObjectGroup }
@@ -79,19 +81,21 @@ const ObjectGroupItem = (props: ObjectGroupItemProps): React.ReactElement => {
       onContextMenu={onContextMenu}
       isLoading={isLoading}
       onIconClick={toggleTreeNode}
+      isActive={isActive}
     >
-      {(wellbore &&
-        objectsOnWellbore &&
-        objectsOnWellbore.map((objectOnWellbore) => (
-          <ObjectOnWellboreItem
-            key={calculateObjectNodeId(objectOnWellbore, objectType)}
-            nodeId={calculateObjectNodeId(objectOnWellbore, objectType)}
-            objectOnWellbore={objectOnWellbore}
-            objectType={objectType}
-            selected={isSelected(objectType, objectOnWellbore)}
-            ContextMenu={ObjectContextMenu}
-          />
-        ))) ||
+      {children ||
+        (wellbore &&
+          objectsOnWellbore &&
+          objectsOnWellbore.map((objectOnWellbore) => (
+            <ObjectOnWellboreItem
+              key={calculateObjectNodeId(objectOnWellbore, objectType)}
+              nodeId={calculateObjectNodeId(objectOnWellbore, objectType)}
+              objectOnWellbore={objectOnWellbore}
+              objectType={objectType}
+              selected={isSelected(objectType, objectOnWellbore)}
+              ContextMenu={ObjectContextMenu}
+            />
+          ))) ||
         (showStub && ["", ""])}
     </TreeItem>
   );

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
@@ -28,7 +28,7 @@ const WellItem = (props: WellItemProps): React.ReactElement => {
   };
 
   const onSelectWell = async (well: Well) => {
-    dispatchNavigation({ type: NavigationType.SelectWell, payload: { well, wellbores: well.wellbores } });
+    dispatchNavigation({ type: NavigationType.SelectWell, payload: { well } });
   };
 
   return (

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -46,7 +46,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
 
   const onContextMenu = (event: React.MouseEvent<HTMLLIElement>, wellbore: Wellbore) => {
     preventContextMenuPropagation(event);
-    const contextMenuProps: WellboreContextMenuProps = { wellbore, servers, dispatchOperation, dispatchNavigation };
+    const contextMenuProps: WellboreContextMenuProps = { wellbore, well };
     const position = getContextMenuPosition(event);
     dispatchOperation({ type: OperationType.DisplayContextMenu, payload: { component: <WellboreContextMenu {...contextMenuProps} />, position } });
   };

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -74,7 +74,7 @@ const WellboreItem = (props: WellboreItemProps): React.ReactElement => {
     if (wellbore.objectCount == null) {
       setIsFetchingCount(true);
       const objectCount = await ObjectService.getExpandableObjectsCount(wellbore);
-      dispatchNavigation({ type: ModificationType.UpdateWellbore, payload: { wellbore: { ...wellbore, objectCount } } });
+      dispatchNavigation({ type: ModificationType.UpdateWellborePartial, payload: { wellboreUid: wellbore.uid, wellUid: well.uid, wellboreProperties: { objectCount } } });
       setIsFetchingCount(false);
     }
   }, [wellbore]);

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -221,7 +221,7 @@ it("Selecting an object group node twice should change nothing", () => {
   };
   const action: SelectObjectGroupAction = {
     type: NavigationType.SelectObjectGroup,
-    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Log, objects: null }
+    payload: { wellUid: WELL_1.uid, wellboreUid: WELLBORE_1.uid, objectType: ObjectType.Log, objects: null }
   };
   const afterLogGroupSelect = reducer(initialState, action);
   const expected = { ...initialState };
@@ -261,7 +261,7 @@ it("Selecting a different object group should update the selectedObjectGroup", (
   };
   const action: SelectObjectGroupAction = {
     type: NavigationType.SelectObjectGroup,
-    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Rig, objects: null }
+    payload: { wellUid: WELL_1.uid, wellboreUid: WELLBORE_1.uid, objectType: ObjectType.Rig, objects: null }
   };
   const afterRigGroupSelect = reducer(initialState, action);
   const expected: NavigationState = {
@@ -284,7 +284,7 @@ it("Selecting an object group should update the wellbore if passing objects", ()
   };
   const action: SelectObjectGroupAction = {
     type: NavigationType.SelectObjectGroup,
-    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Log, objects: [LOG_1] }
+    payload: { wellUid: WELL_1.uid, wellboreUid: WELLBORE_1.uid, objectType: ObjectType.Log, objects: [LOG_1] }
   };
   const afterLogGroupSelect = reducer(initialState, action);
   const updatedWellbore = { ...WELLBORE_1, logs: [LOG_1] };

--- a/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/__tests__/navigationStateReducer.test.ts
@@ -9,24 +9,13 @@ import { EMPTY_NAVIGATION_STATE, NavigationState } from "../navigationContext";
 import { reducer } from "../navigationStateReducer";
 import NavigationType from "../navigationType";
 import {
-  BHARUN_1,
-  CHANGELOG_1,
   FILTER_1,
-  FLUIDSREPORT_1,
-  FORMATIONMARKER_1,
   LOG_1,
-  MESSAGE_1,
-  MUDLOG_1,
-  RIG_1,
-  RISK_1,
   SERVER_1,
   SERVER_2,
   TRAJECTORY_1,
-  TUBULAR_1,
-  WBGEOMETRY_1,
   WELLBORE_1,
   WELLBORE_2,
-  WELLBORE_3,
   WELLS,
   WELL_1,
   WELL_2,
@@ -87,57 +76,6 @@ it("Should also update selected well when a wellbore is selected", () => {
     filteredWells: WELLS,
     expandedTreeNodes: [WELL_2.uid, "well2wellbore2"],
     currentProperties: getWellboreProperties(WELLBORE_2)
-  });
-});
-
-it("Should add all objects to a wellbore if it is selected for the first time", () => {
-  const selectWellboreAction = {
-    type: NavigationType.SelectWellbore,
-    payload: {
-      well: WELL_3,
-      wellbore: WELLBORE_3,
-      bhaRuns: [BHARUN_1],
-      changeLogs: [CHANGELOG_1],
-      fluidsReports: [FLUIDSREPORT_1],
-      formationMarkers: [FORMATIONMARKER_1],
-      logs: [LOG_1],
-      rigs: [RIG_1],
-      trajectories: [TRAJECTORY_1],
-      messages: [MESSAGE_1],
-      mudLogs: [MUDLOG_1],
-      risks: [RISK_1],
-      tubulars: [TUBULAR_1],
-      wbGeometries: [WBGEOMETRY_1]
-    }
-  };
-  const actual = reducer({ ...getInitialState(), expandedTreeNodes: [WELL_3.uid] }, selectWellboreAction);
-  const expectedWellbore = {
-    ...WELLBORE_3,
-    bhaRuns: [BHARUN_1],
-    changeLogs: [CHANGELOG_1],
-    fluidsReports: [FLUIDSREPORT_1],
-    formationMarkers: [FORMATIONMARKER_1],
-    logs: [LOG_1],
-    rigs: [RIG_1],
-    trajectories: [TRAJECTORY_1],
-    messages: [MESSAGE_1],
-    mudLogs: [MUDLOG_1],
-    risks: [RISK_1],
-    tubulars: [TUBULAR_1],
-    wbGeometries: [WBGEOMETRY_1]
-  };
-  const expectedWell = { ...WELL_3, wellbores: [expectedWellbore] };
-  expect(actual).toStrictEqual({
-    ...EMPTY_NAVIGATION_STATE,
-    selectedServer: SERVER_1,
-    selectedWell: expectedWell,
-    selectedWellbore: expectedWellbore,
-    currentSelected: expectedWellbore,
-    servers: [SERVER_1],
-    wells: [WELL_1, WELL_2, expectedWell],
-    filteredWells: [WELL_1, WELL_2, expectedWell],
-    expandedTreeNodes: ["well3", "well3wellbore3"],
-    currentProperties: getWellboreProperties(WELLBORE_3)
   });
 });
 
@@ -283,7 +221,7 @@ it("Selecting an object group node twice should change nothing", () => {
   };
   const action: SelectObjectGroupAction = {
     type: NavigationType.SelectObjectGroup,
-    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Log }
+    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Log, objects: null }
   };
   const afterLogGroupSelect = reducer(initialState, action);
   const expected = { ...initialState };
@@ -323,7 +261,7 @@ it("Selecting a different object group should update the selectedObjectGroup", (
   };
   const action: SelectObjectGroupAction = {
     type: NavigationType.SelectObjectGroup,
-    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Rig }
+    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Rig, objects: null }
   };
   const afterRigGroupSelect = reducer(initialState, action);
   const expected: NavigationState = {
@@ -333,6 +271,35 @@ it("Selecting a different object group should update the selectedObjectGroup", (
     expandedTreeNodes: [WELL_1.uid, calculateWellboreNodeId(WELLBORE_1), calculateObjectGroupId(WELLBORE_1, ObjectType.Log), calculateObjectGroupId(WELLBORE_1, ObjectType.Rig)]
   };
   expect(afterRigGroupSelect).toStrictEqual(expected);
+});
+
+it("Selecting an object group should update the wellbore if passing objects", () => {
+  const initialState: NavigationState = {
+    ...getInitialState(),
+    selectedWell: WELL_1,
+    selectedWellbore: WELLBORE_1,
+    currentSelected: WELLBORE_1,
+    expandedTreeNodes: [WELL_1.uid, calculateWellboreNodeId(WELLBORE_1)],
+    currentProperties: getWellboreProperties(WELLBORE_1)
+  };
+  const action: SelectObjectGroupAction = {
+    type: NavigationType.SelectObjectGroup,
+    payload: { well: WELL_1, wellbore: WELLBORE_1, objectType: ObjectType.Log, objects: [LOG_1] }
+  };
+  const afterLogGroupSelect = reducer(initialState, action);
+  const updatedWellbore = { ...WELLBORE_1, logs: [LOG_1] };
+  const updatedWell = { ...WELL_1, wellbores: [updatedWellbore] };
+  const expected: NavigationState = {
+    ...initialState,
+    wells: [updatedWell, initialState.wells[1], initialState.wells[2]],
+    filteredWells: [updatedWell, initialState.wells[1], initialState.wells[2]],
+    selectedWell: updatedWell,
+    selectedWellbore: updatedWellbore,
+    selectedObjectGroup: ObjectType.Log,
+    currentSelected: ObjectType.Log,
+    expandedTreeNodes: [WELL_1.uid, calculateWellboreNodeId(WELLBORE_1), calculateObjectGroupId(WELLBORE_1, ObjectType.Log)]
+  };
+  expect(afterLogGroupSelect).toStrictEqual(expected);
 });
 
 it("Should expand (not select) a collapsed node when toggled", () => {

--- a/Src/WitsmlExplorer.Frontend/contexts/modificationActions.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationActions.tsx
@@ -45,6 +45,11 @@ export interface UpdateWellboreAction extends Action {
   payload: { wellbore: Wellbore };
 }
 
+export interface UpdateWellborePartialAction extends Action {
+  type: ModificationType.UpdateWellborePartial;
+  payload: { wellUid: string; wellboreUid: string; wellboreProperties: Partial<Wellbore> };
+}
+
 export interface RemoveWellAction extends Action {
   type: ModificationType.RemoveWell;
   payload: { wellUid: string };

--- a/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationStateReducer.tsx
@@ -24,6 +24,7 @@ import {
   UpdateWellboreAction,
   UpdateWellboreLogAction,
   UpdateWellboreObjectsAction,
+  UpdateWellborePartialAction,
   UpdateWellboreTrajectoryAction,
   UpdateWellboreTubularAction,
   UpdateWellboreWbGeometryAction,
@@ -54,6 +55,8 @@ export const performModificationAction = (state: NavigationState, action: Action
       return addWellbore(state, action);
     case ModificationType.UpdateWellbore:
       return updateWellbore(state, action);
+    case ModificationType.UpdateWellborePartial:
+      return updateWellborePartial(state, action);
     case ModificationType.UpdateLogObject:
       return updateWellboreLog(state, action);
     case ModificationType.UpdateTrajectoryOnWellbore:
@@ -166,6 +169,29 @@ const updateWellbore = (state: NavigationState, { payload }: UpdateWellboreActio
     wells,
     filteredWells: filterWells(wells, state.selectedFilter),
     selectedWellbore: refreshedWellboreIsSelected ? wells[wellIndex].wellbores[wellboreIndex] : state.selectedWellbore
+  };
+};
+
+const updateWellborePartial = (state: NavigationState, { payload }: UpdateWellborePartialAction) => {
+  const { wellboreUid, wellUid, wellboreProperties } = payload;
+  const wellIndex = state.wells.findIndex((w) => w.uid === wellUid);
+  const well = state.wells[wellIndex];
+  const wellboreIndex = well.wellbores.findIndex((w) => w.uid === wellboreUid);
+  const wellbore = well.wellbores[wellboreIndex];
+  const updatedWellbore: Wellbore = { ...wellboreProperties, ...wellbore };
+  const updatedWell = { ...well };
+  updatedWell.wellbores.splice(wellboreIndex, 1, updatedWellbore);
+  const freshWells = [...state.wells];
+  freshWells.splice(wellIndex, 1, updatedWell);
+
+  const refreshedWellboreIsSelected = state.selectedWellbore?.uid === wellbore.uid;
+  const refreshedWellIsSelected = state.selectedWell?.uid === wellbore.wellUid;
+  return {
+    ...state,
+    wells: freshWells,
+    filteredWells: filterWells(freshWells, state.selectedFilter),
+    selectedWellbore: refreshedWellboreIsSelected ? updatedWellbore : state.selectedWellbore,
+    selectedWell: refreshedWellIsSelected ? updatedWell : state.selectedWellbore
   };
 };
 

--- a/Src/WitsmlExplorer.Frontend/contexts/modificationType.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/modificationType.ts
@@ -15,6 +15,7 @@ enum ModificationType {
   UpdateWellboreObjects = "UpdateWellboreObjects",
   UpdateWell = "UpdateWell",
   UpdateWellbore = "UpdateWellbore",
+  UpdateWellborePartial = "UpdateWellborePartial",
   UpdateWells = "UpdateWells"
 }
 

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationAction.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationAction.tsx
@@ -11,12 +11,14 @@ import {
   UpdateWellboreAction,
   UpdateWellboreLogAction,
   UpdateWellboreObjectsAction,
+  UpdateWellborePartialAction,
   UpdateWellboreTrajectoryAction,
   UpdateWellboreTubularAction,
   UpdateWellboreWbGeometryAction,
   UpdateWellsAction
 } from "./modificationActions";
 import {
+  CollapseTreeNodeChildrenAction,
   SelectJobsAction,
   SelectLogCurveInfoAction,
   SelectLogTypeAction,
@@ -28,8 +30,7 @@ import {
   SelectWellboreAction,
   SetCurveThresholdAction,
   SetFilterAction,
-  ToggleTreeNodeAction,
-  ToggleTreeNodeChildrenAction
+  ToggleTreeNodeAction
 } from "./navigationActions";
 
 export type NavigationAction =
@@ -44,13 +45,14 @@ export type NavigationAction =
   | UpdateWellAction
   | UpdateWellsAction
   | UpdateWellboreAction
+  | UpdateWellborePartialAction
   | UpdateWellboreLogAction
   | UpdateWellboreTrajectoryAction
   | UpdateWellboreTubularAction
   | UpdateWellboreWbGeometryAction
   | UpdateWellboreObjectsAction
   | ToggleTreeNodeAction
-  | ToggleTreeNodeChildrenAction
+  | CollapseTreeNodeChildrenAction
   | SelectJobsAction
   | SelectLogTypeAction
   | SelectLogCurveInfoAction

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationAction.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationAction.tsx
@@ -28,7 +28,8 @@ import {
   SelectWellboreAction,
   SetCurveThresholdAction,
   SetFilterAction,
-  ToggleTreeNodeAction
+  ToggleTreeNodeAction,
+  ToggleTreeNodeChildrenAction
 } from "./navigationActions";
 
 export type NavigationAction =
@@ -49,6 +50,7 @@ export type NavigationAction =
   | UpdateWellboreWbGeometryAction
   | UpdateWellboreObjectsAction
   | ToggleTreeNodeAction
+  | ToggleTreeNodeChildrenAction
   | SelectJobsAction
   | SelectLogTypeAction
   | SelectLogCurveInfoAction

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
@@ -22,8 +22,8 @@ export interface ToggleTreeNodeAction extends Action {
   payload: { nodeId: string };
 }
 
-export interface ToggleTreeNodeChildrenAction extends Action {
-  type: NavigationType.ToggleTreeNodeChildren;
+export interface CollapseTreeNodeChildrenAction extends Action {
+  type: NavigationType.CollapseTreeNodeChildren;
   payload: { nodeId: string };
 }
 

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
@@ -41,7 +41,7 @@ export interface SelectJobsAction extends Action {
 
 export interface SelectObjectGroupAction extends Action {
   type: NavigationType.SelectObjectGroup;
-  payload: { well: Well; wellbore: Wellbore; objectType: ObjectType; objects: ObjectOnWellbore[] | null };
+  payload: { wellUid: string; wellboreUid: string; objectType: ObjectType; objects: ObjectOnWellbore[] | null };
 }
 
 export interface SelectLogTypeAction extends Action {

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
@@ -1,18 +1,6 @@
-import BhaRun from "../models/bhaRun";
-import ChangeLog from "../models/changeLog";
-import FluidsReport from "../models/fluidsReport";
-import FormationMarker from "../models/formationMarker";
-import LogObject from "../models/logObject";
-import MessageObject from "../models/messageObject";
-import MudLog from "../models/mudLog";
 import ObjectOnWellbore from "../models/objectOnWellbore";
 import { ObjectType } from "../models/objectType";
-import Rig from "../models/rig";
-import RiskObject from "../models/riskObject";
 import { Server } from "../models/server";
-import Trajectory from "../models/trajectory";
-import Tubular from "../models/tubular";
-import WbGeometryObject from "../models/wbGeometry";
 import Well from "../models/well";
 import Wellbore from "../models/wellbore";
 import CurveThreshold from "./curveThreshold";
@@ -36,7 +24,7 @@ export interface ToggleTreeNodeAction extends Action {
 
 export interface SelectWellAction extends Action {
   type: NavigationType.SelectWell;
-  payload: { well: Well; wellbores: Wellbore[] };
+  payload: { well: Well };
 }
 
 export interface SelectWellboreAction extends Action {
@@ -44,18 +32,6 @@ export interface SelectWellboreAction extends Action {
   payload: {
     well: Well;
     wellbore: Wellbore;
-    bhaRuns: BhaRun[];
-    changeLogs: ChangeLog[];
-    fluidsReports: FluidsReport[];
-    formationMarkers: FormationMarker[];
-    logs: LogObject[];
-    rigs: Rig[];
-    trajectories: Trajectory[];
-    messages: MessageObject[];
-    mudLogs: MudLog[];
-    risks: RiskObject[];
-    tubulars: Tubular[];
-    wbGeometries: WbGeometryObject[];
   };
 }
 
@@ -65,7 +41,7 @@ export interface SelectJobsAction extends Action {
 
 export interface SelectObjectGroupAction extends Action {
   type: NavigationType.SelectObjectGroup;
-  payload: { well: Well; wellbore: Wellbore; objectType: ObjectType };
+  payload: { well: Well; wellbore: Wellbore; objectType: ObjectType; objects: ObjectOnWellbore[] | null };
 }
 
 export interface SelectLogTypeAction extends Action {

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationActions.tsx
@@ -22,6 +22,11 @@ export interface ToggleTreeNodeAction extends Action {
   payload: { nodeId: string };
 }
 
+export interface ToggleTreeNodeChildrenAction extends Action {
+  type: NavigationType.ToggleTreeNodeChildren;
+  payload: { nodeId: string };
+}
+
 export interface SelectWellAction extends Action {
   type: NavigationType.SelectWell;
   payload: { well: Well };

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -17,6 +17,7 @@ import { performModificationAction } from "./modificationStateReducer";
 import ModificationType from "./modificationType";
 import {
   Action,
+  CollapseTreeNodeChildrenAction,
   SelectLogCurveInfoAction,
   SelectLogTypeAction,
   SelectObjectAction,
@@ -26,8 +27,7 @@ import {
   SelectWellboreAction,
   SetCurveThresholdAction,
   SetFilterAction,
-  ToggleTreeNodeAction,
-  ToggleTreeNodeChildrenAction
+  ToggleTreeNodeAction
 } from "./navigationActions";
 import { EMPTY_NAVIGATION_STATE, NavigationState, allDeselected, selectedJobsFlag, selectedServerManagerFlag } from "./navigationContext";
 import NavigationType from "./navigationType";
@@ -50,8 +50,8 @@ const performNavigationAction = (state: NavigationState, action: Action): Naviga
   switch (action.type) {
     case NavigationType.ToggleTreeNode:
       return selectToggleTreeNode(state, action);
-    case NavigationType.ToggleTreeNodeChildren:
-      return selectToggleTreeNodeChildren(state, action);
+    case NavigationType.CollapseTreeNodeChildren:
+      return collapseTreeNodeChildren(state, action);
     case NavigationType.SelectServer:
       return selectServer(state, action);
     case NavigationType.SelectWell:
@@ -86,7 +86,7 @@ const selectToggleTreeNode = (state: NavigationState, { payload }: ToggleTreeNod
   };
 };
 
-const selectToggleTreeNodeChildren = (state: NavigationState, { payload }: ToggleTreeNodeChildrenAction): NavigationState => {
+const collapseTreeNodeChildren = (state: NavigationState, { payload }: CollapseTreeNodeChildrenAction): NavigationState => {
   const { nodeId } = payload;
   if (!treeNodeIsExpanded(state.expandedTreeNodes, nodeId)) {
     return state;

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -148,14 +148,18 @@ const selectServerManager = (state: NavigationState): NavigationState => {
 };
 
 const selectObjectGroup = (state: NavigationState, { payload }: SelectObjectGroupAction): NavigationState => {
-  const { well, wellbore, objectType, objects } = payload;
+  const { wellUid, wellboreUid, objectType, objects } = payload;
+  // find the well and wellbore in state instead of passing them through payload
+  // to avoid updating stale wellbores when multiple object groups are opened before objects are fetched
+  const wellIndex = state.wells.findIndex((w) => w.uid === wellUid);
+  const well = state.wells[wellIndex];
+  const wellboreIndex = well.wellbores.findIndex((w) => w.uid === wellboreUid);
+  const wellbore = well.wellbores[wellboreIndex];
   let wellAndWellboreState: Partial<NavigationState> = { selectedWell: well, selectedWellbore: wellbore };
   if (objects != null) {
     const namedObjects: Partial<Record<keyof WellboreObjects, ObjectOnWellbore[]>> = {};
     namedObjects[objectTypeToWellboreObjects(objectType)] = objects;
     const updatedWellbore: Wellbore = { ...wellbore, ...(namedObjects as Partial<WellboreObjects>) };
-    const wellIndex = state.wells.findIndex((w) => w.uid === well.uid);
-    const wellboreIndex = well.wellbores.findIndex((w) => w.uid === wellbore.uid);
     const updatedWell = { ...well };
     updatedWell.wellbores.splice(wellboreIndex, 1, updatedWellbore);
     const freshWells = [...state.wells];

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -1,9 +1,16 @@
 import { Dispatch, useReducer } from "react";
 import LogObject from "../models/logObject";
-import { getObjectOnWellboreProperties } from "../models/objectOnWellbore";
+import ObjectOnWellbore, { getObjectOnWellboreProperties } from "../models/objectOnWellbore";
 import { ObjectType } from "../models/objectType";
 import { getWellProperties } from "../models/well";
-import { calculateLogTypeId, calculateObjectGroupId, calculateWellboreNodeId, getWellboreProperties } from "../models/wellbore";
+import Wellbore, {
+  WellboreObjects,
+  calculateLogTypeId,
+  calculateObjectGroupId,
+  calculateWellboreNodeId,
+  getWellboreProperties,
+  objectTypeToWellboreObjects
+} from "../models/wellbore";
 import AuthorizationService from "../services/authorizationService";
 import { filterWells } from "./filter";
 import { performModificationAction } from "./modificationStateReducer";
@@ -93,52 +100,30 @@ const selectServer = (state: NavigationState, { payload }: SelectServerAction): 
 };
 
 const selectWell = (state: NavigationState, { payload }: SelectWellAction): NavigationState => {
-  const { well, wellbores } = payload;
+  const { well } = payload;
   const shouldExpandNode = !treeNodeIsExpanded(state.expandedTreeNodes, well.uid);
   const expandedTreeNodes = shouldExpandNode ? toggleTreeNode(state.expandedTreeNodes, well.uid) : state.expandedTreeNodes;
-  if (state.selectedWell === well) {
-    return {
-      ...state,
-      ...allDeselected,
-      selectedServer: state.selectedServer,
-      selectedWell: well,
-      currentSelected: well,
-      expandedTreeNodes: expandedTreeNodes,
-      currentProperties: getWellProperties(well)
-    };
-  } else {
-    const wellWithWellbores = { ...well, wellbores };
-    const updatedWells = state.wells.map((w) => (w.uid === wellWithWellbores.uid ? wellWithWellbores : w));
-    return {
-      ...state,
-      ...allDeselected,
-      selectedServer: state.selectedServer,
-      selectedWell: wellWithWellbores,
-      currentSelected: wellWithWellbores,
-      expandedTreeNodes: expandedTreeNodes,
-      wells: updatedWells,
-      filteredWells: filterWells(updatedWells, state.selectedFilter),
-      currentProperties: getWellProperties(well)
-    };
-  }
-};
-
-const selectWellbore = (state: NavigationState, { payload }: SelectWellboreAction): NavigationState => {
-  const { well, wellbore, bhaRuns, changeLogs, fluidsReports, formationMarkers, logs, rigs, trajectories, messages, mudLogs, risks, tubulars, wbGeometries } = payload;
-  const shouldExpandNode = shouldExpand(state.expandedTreeNodes, calculateWellboreNodeId(wellbore), well.uid);
-  const wellboreWithProperties = { ...wellbore, bhaRuns, changeLogs, fluidsReports, formationMarkers, logs, rigs, trajectories, messages, mudLogs, risks, tubulars, wbGeometries };
-  const updatedWellbores = well.wellbores.map((wB) => (wB.uid === wellboreWithProperties.uid ? wellboreWithProperties : wB));
-  const updatedWell = { ...well, wellbores: updatedWellbores };
-  const updatedWells = state.wells.map((w) => (w.uid === updatedWell.uid ? updatedWell : w));
   return {
     ...state,
     ...allDeselected,
     selectedServer: state.selectedServer,
-    selectedWell: updatedWell,
-    selectedWellbore: wellboreWithProperties,
-    wells: updatedWells,
-    filteredWells: filterWells(updatedWells, state.selectedFilter),
-    currentSelected: wellboreWithProperties,
+    selectedWell: well,
+    currentSelected: well,
+    expandedTreeNodes: expandedTreeNodes,
+    currentProperties: getWellProperties(well)
+  };
+};
+
+const selectWellbore = (state: NavigationState, { payload }: SelectWellboreAction): NavigationState => {
+  const { well, wellbore } = payload;
+  const shouldExpandNode = shouldExpand(state.expandedTreeNodes, calculateWellboreNodeId(wellbore), well.uid);
+  return {
+    ...state,
+    ...allDeselected,
+    selectedServer: state.selectedServer,
+    selectedWell: well,
+    selectedWellbore: wellbore,
+    currentSelected: wellbore,
     expandedTreeNodes: shouldExpandNode ? toggleTreeNode(state.expandedTreeNodes, calculateWellboreNodeId(wellbore)) : state.expandedTreeNodes,
     currentProperties: getWellboreProperties(wellbore)
   };
@@ -163,15 +148,32 @@ const selectServerManager = (state: NavigationState): NavigationState => {
 };
 
 const selectObjectGroup = (state: NavigationState, { payload }: SelectObjectGroupAction): NavigationState => {
-  const { well, wellbore, objectType } = payload;
+  const { well, wellbore, objectType, objects } = payload;
+  let wellAndWellboreState: Partial<NavigationState> = { selectedWell: well, selectedWellbore: wellbore };
+  if (objects != null) {
+    const namedObjects: Partial<Record<keyof WellboreObjects, ObjectOnWellbore[]>> = {};
+    namedObjects[objectTypeToWellboreObjects(objectType)] = objects;
+    const updatedWellbore: Wellbore = { ...wellbore, ...(namedObjects as Partial<WellboreObjects>) };
+    const wellIndex = state.wells.findIndex((w) => w.uid === well.uid);
+    const wellboreIndex = well.wellbores.findIndex((w) => w.uid === wellbore.uid);
+    const updatedWell = { ...well };
+    updatedWell.wellbores.splice(wellboreIndex, 1, updatedWellbore);
+    const freshWells = [...state.wells];
+    freshWells.splice(wellIndex, 1, updatedWell);
+    wellAndWellboreState = {
+      selectedWell: updatedWell,
+      selectedWellbore: updatedWellbore,
+      wells: freshWells,
+      filteredWells: filterWells(freshWells, state.selectedFilter)
+    };
+  }
   const groupId = calculateObjectGroupId(wellbore, objectType);
   const shouldExpandNode = shouldExpand(state.expandedTreeNodes, groupId, calculateWellboreNodeId(wellbore));
   return {
     ...state,
     ...allDeselected,
     selectedServer: state.selectedServer,
-    selectedWell: well,
-    selectedWellbore: wellbore,
+    ...wellAndWellboreState,
     selectedObjectGroup: objectType,
     currentSelected: objectType,
     expandedTreeNodes: shouldExpandNode ? toggleTreeNode(state.expandedTreeNodes, groupId) : state.expandedTreeNodes,

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -26,7 +26,8 @@ import {
   SelectWellboreAction,
   SetCurveThresholdAction,
   SetFilterAction,
-  ToggleTreeNodeAction
+  ToggleTreeNodeAction,
+  ToggleTreeNodeChildrenAction
 } from "./navigationActions";
 import { EMPTY_NAVIGATION_STATE, NavigationState, allDeselected, selectedJobsFlag, selectedServerManagerFlag } from "./navigationContext";
 import NavigationType from "./navigationType";
@@ -49,6 +50,8 @@ const performNavigationAction = (state: NavigationState, action: Action): Naviga
   switch (action.type) {
     case NavigationType.ToggleTreeNode:
       return selectToggleTreeNode(state, action);
+    case NavigationType.ToggleTreeNodeChildren:
+      return selectToggleTreeNodeChildren(state, action);
     case NavigationType.SelectServer:
       return selectServer(state, action);
     case NavigationType.SelectWell:
@@ -80,6 +83,17 @@ const selectToggleTreeNode = (state: NavigationState, { payload }: ToggleTreeNod
   return {
     ...state,
     expandedTreeNodes: toggleTreeNode(state.expandedTreeNodes, payload.nodeId)
+  };
+};
+
+const selectToggleTreeNodeChildren = (state: NavigationState, { payload }: ToggleTreeNodeChildrenAction): NavigationState => {
+  const { nodeId } = payload;
+  if (!treeNodeIsExpanded(state.expandedTreeNodes, nodeId)) {
+    return state;
+  }
+  return {
+    ...state,
+    expandedTreeNodes: toggleTreeNode(toggleTreeNode(state.expandedTreeNodes, nodeId), nodeId)
   };
 };
 

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationStateReducer.tsx
@@ -206,8 +206,8 @@ const selectObject = (state: NavigationState, { payload }: SelectObjectAction): 
   let expandedTreeNodes = state.expandedTreeNodes;
 
   const objectGroup = calculateObjectGroupId(wellbore, objectType);
-  const shouldExpandLogGroup = shouldExpand(expandedTreeNodes, objectGroup, calculateWellboreNodeId(wellbore));
-  expandedTreeNodes = shouldExpandLogGroup ? toggleTreeNode(expandedTreeNodes, objectGroup) : expandedTreeNodes;
+  const shouldExpandGroup = shouldExpand(expandedTreeNodes, objectGroup, calculateWellboreNodeId(wellbore));
+  expandedTreeNodes = shouldExpandGroup ? toggleTreeNode(expandedTreeNodes, objectGroup) : expandedTreeNodes;
   let logTypeGroup = null;
   if (objectType == ObjectType.Log) {
     logTypeGroup = calculateLogTypeId(wellbore, (object as LogObject).indexType);

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationType.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationType.ts
@@ -1,6 +1,6 @@
 enum NavigationType {
   ToggleTreeNode = "ToggleTreeNode",
-  ToggleTreeNodeChildren = "ToggleTreeNodeChildren",
+  CollapseTreeNodeChildren = "CollapseTreeNodeChildren",
   SelectServer = "SelectServer",
   SelectWell = "SelectWell",
   SelectWellbore = "SelectWellbore",

--- a/Src/WitsmlExplorer.Frontend/contexts/navigationType.ts
+++ b/Src/WitsmlExplorer.Frontend/contexts/navigationType.ts
@@ -1,5 +1,6 @@
 enum NavigationType {
   ToggleTreeNode = "ToggleTreeNode",
+  ToggleTreeNodeChildren = "ToggleTreeNodeChildren",
   SelectServer = "SelectServer",
   SelectWell = "SelectWell",
   SelectWellbore = "SelectWellbore",

--- a/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
@@ -43,6 +43,7 @@ export interface WellboreProperties {
   dateTimeLastChange?: string;
   itemState?: string;
   comments?: string;
+  objectCount: ExpandableObjectsCount;
 }
 
 export interface WellboreObjects {
@@ -59,6 +60,8 @@ export interface WellboreObjects {
   risks?: RiskObject[];
   wbGeometries?: WbGeometryObject[];
 }
+
+export type ExpandableObjectsCount = Partial<Record<ObjectType, number>>;
 
 export default interface Wellbore extends WellboreProperties, WellboreObjects {}
 
@@ -88,7 +91,8 @@ export function emptyWellbore(): Wellbore {
     messages: [],
     mudLogs: [],
     risks: [],
-    wbGeometries: []
+    wbGeometries: [],
+    objectCount: null
   };
 }
 

--- a/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/wellbore.tsx
@@ -43,7 +43,7 @@ export interface WellboreProperties {
   dateTimeLastChange?: string;
   itemState?: string;
   comments?: string;
-  objectCount: ExpandableObjectsCount;
+  objectCount?: ExpandableObjectsCount;
 }
 
 export interface WellboreObjects {

--- a/Src/WitsmlExplorer.Frontend/services/objectService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/objectService.tsx
@@ -1,7 +1,7 @@
 import ObjectOnWellbore from "../models/objectOnWellbore";
 import { ObjectType, ObjectTypeToModel, pluralizeObjectType } from "../models/objectType";
 import { Server } from "../models/server";
-import Wellbore, { getObjectsFromWellbore } from "../models/wellbore";
+import Wellbore, { ExpandableObjectsCount, getObjectsFromWellbore } from "../models/wellbore";
 import { ApiClient } from "./apiClient";
 
 export default class ObjectService {
@@ -85,5 +85,14 @@ export default class ObjectService {
       return await ObjectService.getObjects(wellbore.wellUid, wellbore.uid, objectType, abortSignal);
     }
     return null;
+  }
+
+  public static async getExpandableObjectsCount(wellbore: Wellbore, abortSignal?: AbortSignal): Promise<ExpandableObjectsCount> {
+    const response = await ApiClient.get(`/api/wells/${wellbore.wellUid}/wellbores/${wellbore.uid}/countexpandable`, abortSignal);
+    if (response.ok) {
+      return response.json();
+    } else {
+      return null;
+    }
   }
 }

--- a/Src/WitsmlExplorer.Frontend/services/objectService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/objectService.tsx
@@ -1,6 +1,7 @@
 import ObjectOnWellbore from "../models/objectOnWellbore";
 import { ObjectType, ObjectTypeToModel, pluralizeObjectType } from "../models/objectType";
 import { Server } from "../models/server";
+import Wellbore, { getObjectsFromWellbore } from "../models/wellbore";
 import { ApiClient } from "./apiClient";
 
 export default class ObjectService {
@@ -76,5 +77,13 @@ export default class ObjectService {
     } else {
       return null;
     }
+  }
+
+  public static async getObjectsIfMissing<Key extends ObjectType>(wellbore: Wellbore, objectType: Key, abortSignal?: AbortSignal): Promise<ObjectTypeToModel[Key][] | null> {
+    const objects = getObjectsFromWellbore(wellbore, objectType);
+    if (objects == null || objects.length == 0) {
+      return await ObjectService.getObjects(wellbore.wellUid, wellbore.uid, objectType, abortSignal);
+    }
+    return null;
   }
 }

--- a/Src/WitsmlExplorer.Frontend/services/wellboreService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/wellboreService.tsx
@@ -1,13 +1,6 @@
-import { ObjectType } from "../models/objectType";
 import { Server } from "../models/server";
-import Wellbore, { emptyWellbore, WellboreObjects } from "../models/wellbore";
+import Wellbore, { emptyWellbore } from "../models/wellbore";
 import { ApiClient } from "./apiClient";
-import ObjectService from "./objectService";
-
-// Removes 'optional' attributes from a type's properties
-type Concrete<Type> = {
-  [Property in keyof Type]-?: Type[Property];
-};
 
 export default class WellboreService {
   public static async getWellbore(wellUid: string, wellboreUid: string, abortSignal?: AbortSignal): Promise<Wellbore> {
@@ -31,43 +24,5 @@ export default class WellboreService {
     } else {
       return emptyWellbore();
     }
-  }
-
-  public static async getCompleteWellbore(wellUid: string, wellboreUid: string): Promise<Wellbore> {
-    const getWellbore = WellboreService.getWellbore(wellUid, wellboreUid);
-    const getObjects = WellboreService.getWellboreObjects(wellUid, wellboreUid);
-    const [wellbore, wellboreObjects] = await Promise.all([getWellbore, getObjects]);
-
-    return { ...wellbore, ...wellboreObjects };
-  }
-
-  public static async getWellboreObjects(wellUid: string, wellboreUid: string): Promise<Concrete<WellboreObjects>> {
-    const getBhaRuns = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.BhaRun);
-    const getChangeLogs = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.ChangeLog);
-    const getFluidsReports = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.FluidsReport);
-    const getFormationMarkers = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.FormationMarker);
-    const getLogs = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.Log);
-    const getMessages = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.Message);
-    const getMudLogs = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.MudLog);
-    const getRigs = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.Rig);
-    const getRisks = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.Risk);
-    const getTrajectories = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.Trajectory);
-    const getTubulars = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.Tubular);
-    const getWbGeometries = ObjectService.getObjects(wellUid, wellboreUid, ObjectType.WbGeometry);
-    const [bhaRuns, changeLogs, fluidsReports, formationMarkers, logs, messages, mudLogs, rigs, risks, trajectories, tubulars, wbGeometries] = await Promise.all([
-      getBhaRuns,
-      getChangeLogs,
-      getFluidsReports,
-      getFormationMarkers,
-      getLogs,
-      getMessages,
-      getMudLogs,
-      getRigs,
-      getRisks,
-      getTrajectories,
-      getTubulars,
-      getWbGeometries
-    ]);
-    return { bhaRuns, changeLogs, fluidsReports, formationMarkers, logs, messages, mudLogs, rigs, risks, trajectories, tubulars, wbGeometries };
   }
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #1928 and fixes #298

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Fetch wellbore objects on opening their group view instead of on opening the wellbore
* Asynchronously fetch the count of "expandable" objects to update the sidebar to show which object groups are expandable
* Rework refresh wellbore to not load in all wellbore objects and instead flush the loaded in objects so that they can be loaded in anew when selecting object groups.
* Rework ObjectGroupItem to work with Logs.
* Remove wellbores from SelectWellAction as they did not make a difference.
* Fix #298 by reworking SelectObjectGroupAction to use uids instead of Well and Wellbore to avoid updating stale wellbores when multiple object groups are opened before fetching finishes.
* Fix fetching isActive when refreshing a wellbore.
* Make create and modify object workers use RefreshObjects instead of RefreshWellbore.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [X] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [X] Frontend
* [X] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


