### PR TITLE
Added support for including a client certificate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Test
         run: dotnet test ./Tests/Witsml.Tests/Witsml.Tests.csproj --configuration Release
       - name: Package
-        run: dotnet pack --configuration Release Src/Witsml -p:Version=2.7.${GITHUB_RUN_NUMBER}
+        run: dotnet pack --configuration Release Src/Witsml -p:Version=2.8.${GITHUB_RUN_NUMBER}
       - name: Publish
-        run: dotnet nuget push --api-key ${{secrets.NUGET_PUBLISH_KEY}} --source https://api.nuget.org/v3/index.json Src/Witsml/bin/Release/WitsmlClient.2.7.${GITHUB_RUN_NUMBER}.nupkg
+        run: dotnet nuget push --api-key ${{secrets.NUGET_PUBLISH_KEY}} --source https://api.nuget.org/v3/index.json Src/Witsml/bin/Release/WitsmlClient.2.8.${GITHUB_RUN_NUMBER}.nupkg

--- a/Src/Witsml/QueryLogger.cs
+++ b/Src/Witsml/QueryLogger.cs
@@ -1,0 +1,33 @@
+using Serilog;
+using Serilog.Core;
+
+namespace Witsml;
+
+public interface IQueryLogger
+{
+    void LogQuery(string querySent, bool isSuccessful, string xmlReceived = null);
+}
+
+public class DefaultQueryLogger : IQueryLogger
+{
+    private readonly Logger _queryLogger;
+
+    public DefaultQueryLogger()
+    {
+        _queryLogger = new LoggerConfiguration()
+            .WriteTo.File("queries.log", rollOnFileSizeLimit: true, retainedFileCountLimit: 1, fileSizeLimitBytes: 50000000)
+            .CreateLogger();
+    }
+
+    public void LogQuery(string querySent, bool isSuccessful, string xmlReceived = null)
+    {
+        if (xmlReceived != null)
+        {
+            _queryLogger.Information("Query: \n{Query}\nReceived: \n{Response}\nIsSuccessful: {IsSuccessful}", querySent, xmlReceived, isSuccessful);
+        }
+        else
+        {
+            _queryLogger.Information("Query: \n{Query}\nIsSuccessful: {IsSuccessful}", querySent, isSuccessful);
+        }
+    }
+}

--- a/Src/Witsml/QueryResult.cs
+++ b/Src/Witsml/QueryResult.cs
@@ -1,0 +1,13 @@
+namespace Witsml;
+
+public class QueryResult
+{
+    public bool IsSuccessful { get; }
+    public string Reason { get; }
+
+    public QueryResult(bool isSuccessful, string reason = null)
+    {
+        IsSuccessful = isSuccessful;
+        Reason = reason;
+    }
+}

--- a/Src/Witsml/WitsmlClientBase.cs
+++ b/Src/Witsml/WitsmlClientBase.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Net;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+
+using Serilog;
+
+using Witsml.ServiceReference;
+
+namespace Witsml;
+
+public abstract class WitsmlClientBase
+{
+    internal static StoreSoapPortClient CreateSoapClient(WitsmlClientOptions options)
+    {
+        EndpointAddress endpointAddress = new(options.Hostname);
+
+        Binding serviceBinding = options.ClientCertificate == null
+            ? CreateBasicBinding(options.RequestTimeOut)
+            : CreateCertificateAndBasicBinding();
+
+        var client = new StoreSoapPortClient(serviceBinding, endpointAddress);
+        client.ClientCredentials.UserName.UserName = options.Credentials.Username;
+        client.ClientCredentials.UserName.Password = options.Credentials.Password;
+
+        if (options.ClientCertificate != null)
+        {
+            client.ClientCredentials.ClientCertificate.Certificate = options.ClientCertificate;
+            Log.Information($"Configured client to use client certificate. CN={options.ClientCertificate.SubjectName.Name}");
+            if (!options.ClientCertificate.HasPrivateKey)
+                Log.Warning("Configured client certificate does not contain a private key");
+        }
+
+        client.Endpoint.EndpointBehaviors.Add(new EndpointBehavior());
+
+        return client;
+    }
+
+    private static BasicHttpsBinding CreateBasicBinding(TimeSpan requestTimeout)
+    {
+        return new BasicHttpsBinding
+        {
+            Security =
+            {
+                Mode = BasicHttpsSecurityMode.Transport,
+                Transport =
+                {
+                    ClientCredentialType = HttpClientCredentialType.Basic
+                }
+            },
+            MaxReceivedMessageSize = int.MaxValue,
+            SendTimeout = requestTimeout
+        };
+    }
+
+    private static CustomBinding CreateCertificateAndBasicBinding()
+    {
+        return new CustomBinding
+        {
+            Elements =
+            {
+                new TextMessageEncodingBindingElement
+                {
+                    MessageVersion = MessageVersion.Soap11
+                },
+                new HttpsTransportBindingElement
+                {
+                    RequireClientCertificate = true,
+                    AuthenticationScheme = AuthenticationSchemes.Basic,
+                    MaxReceivedMessageSize = int.MaxValue
+                }
+            }
+        };
+    }
+}

--- a/Src/Witsml/WitsmlClientOptions.cs
+++ b/Src/Witsml/WitsmlClientOptions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+using Witsml.Data;
+
+namespace Witsml;
+
+public class WitsmlClientOptions
+{
+    /// <summary>
+    /// Hostname of the WITSML server to connect to
+    /// </summary>
+    public string Hostname { get; init; }
+
+    /// <summary>
+    /// Client credentials to be used for basic authentication with the WITSML server
+    /// </summary>
+    public WitsmlCredentials Credentials { get; init; }
+
+    /// <summary>
+    /// Client certificate to present while connecting to the WITSML server. The certificate should contain the private key.
+    /// </summary>
+    public X509Certificate2 ClientCertificate { get; init; }
+
+    /// <summary>
+    /// The client capabilities to present to the WITSML server
+    /// <see cref="WitsmlClientCapabilities" />
+    /// </summary>
+    public WitsmlClientCapabilities ClientCapabilities { get; init; } = new();
+
+    /// <summary>
+    /// The timeout interval to be used when communicating with the WITSML server. Default is 00:01:00 minutes
+    /// </summary>
+    public TimeSpan RequestTimeOut { get; init; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Enable logging all queries to a file (queries.log) in the current directory
+    /// </summary>
+    public bool LogQueries { get; init; }
+}
+
+public record WitsmlCredentials(string Username, string Password);

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -69,7 +69,12 @@ namespace WitsmlExplorer.Api.Services
                 cacheId = httpContext.CreateWitsmlExplorerCookie();
             }
 
-            WitsmlClient witsmlClient = new(creds.Host.ToString(), creds.UserId, creds.Password, _clientCapabilities);
+            var witsmlClient = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = creds.Host.ToString(),
+                Credentials = new WitsmlCredentials(creds.UserId, creds.Password),
+                ClientCapabilities = _clientCapabilities
+            });
             await witsmlClient.TestConnectionAsync();
 
             double ttl = keep ? 24.0 : 1.0; // hours

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -49,7 +49,13 @@ namespace WitsmlExplorer.Api.Services
         internal WitsmlClientProvider(IConfiguration configuration)
         {
             (string serverUrl, string username, string password) = GetCredentialsFromConfiguration(configuration);
-            _witsmlClient = new WitsmlClient(serverUrl, username, password, new WitsmlClientCapabilities(), null, true);
+            _witsmlClient = new WitsmlClient(
+                new WitsmlClientOptions
+                {
+                    Hostname = serverUrl,
+                    Credentials = new WitsmlCredentials(username, password),
+                    LogQueries = true
+                });
         }
 
         private static (string, string, string) GetCredentialsFromConfiguration(IConfiguration configuration)
@@ -67,7 +73,13 @@ namespace WitsmlExplorer.Api.Services
             {
                 _targetCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
                 _witsmlClient = (_targetCreds != null && !_targetCreds.IsCredsNullOrEmpty())
-                    ? new WitsmlClient(_targetCreds.Host.ToString(), _targetCreds.UserId, _targetCreds.Password, _clientCapabilities, null, _logQueries)
+                    ? new WitsmlClient(new WitsmlClientOptions
+                    {
+                        Hostname = _targetCreds.Host.ToString(),
+                        Credentials = new WitsmlCredentials(_targetCreds.UserId, _targetCreds.Password),
+                        ClientCapabilities = _clientCapabilities,
+                        LogQueries = _logQueries
+                    })
                     : null;
             }
             return _witsmlClient;
@@ -79,7 +91,13 @@ namespace WitsmlExplorer.Api.Services
             {
                 _sourceCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
                 _witsmlSourceClient = (_sourceCreds != null && !_sourceCreds.IsCredsNullOrEmpty())
-                    ? new WitsmlClient(_sourceCreds.Host.ToString(), _sourceCreds.UserId, _sourceCreds.Password, _clientCapabilities, null, _logQueries)
+                    ? new WitsmlClient(new WitsmlClientOptions
+                    {
+                        Hostname = _sourceCreds.Host.ToString(),
+                        Credentials = new WitsmlCredentials(_sourceCreds.UserId, _sourceCreds.Password),
+                        ClientCapabilities = _clientCapabilities,
+                        LogQueries = _logQueries
+                    })
                     : null;
             }
             return _witsmlSourceClient;

--- a/Src/WitsmlExplorer.Console/WitsmlClient/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Console/WitsmlClient/WitsmlClientProvider.cs
@@ -33,7 +33,12 @@ namespace WitsmlExplorer.Console.WitsmlClient
             try
             {
                 (string serverUrl, string username, string password) = GetCredentialsFromConfiguration();
-                _witsmlClient = new Witsml.WitsmlClient(serverUrl, username, password, _clientCapabilities);
+                _witsmlClient = new Witsml.WitsmlClient(new WitsmlClientOptions
+                {
+                    Hostname = serverUrl,
+                    Credentials = new WitsmlCredentials(username, password),
+                    ClientCapabilities = _clientCapabilities
+                });
             }
             catch (Exception e)
             {

--- a/Tests/Witsml.Tests/ClientCertificateExample.cs
+++ b/Tests/Witsml.Tests/ClientCertificateExample.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Witsml.Tests;
+
+public class ClientCertificateExample
+{
+    /// <summary>
+    /// This is just a sample of how to create a X509Certificate client certificate that can be provided to the WitsmlClient
+    /// </summary>
+    public void CreateCertificate()
+    {
+        var clientCertificateString = "---BEGIN CERTIFICATE--- <certificate> ---END CERTIFICATE---";
+        var privateKey = "<certificate key>"; // note that ---BEGIN PRIVATE KEY--- / ---END PRIVATE KEY--- is not included
+
+        var clientCertificate = X509Certificate2.CreateFromPem(clientCertificateString);
+
+        var key = RSA.Create();
+        key.ImportPkcs8PrivateKey(Convert.FromBase64String(privateKey), out _);
+
+        clientCertificate = clientCertificate.CopyWithPrivateKey(key);
+    }
+}

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/LogObjectTests.cs
@@ -20,13 +20,16 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.AddToStore
     {
         private readonly ITestOutputHelper _output;
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public LogObjectTests(ITestOutputHelper output)
         {
             _output = output;
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/TrajectoryTests.cs
@@ -22,13 +22,16 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.AddToStore
     {
         private readonly ITestOutputHelper _output;
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public TrajectoryTests(ITestOutputHelper output)
         {
             _output = output;
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
@@ -14,12 +14,15 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public partial class BhaRunTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public BhaRunTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FluidsReportTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FluidsReportTests.cs
@@ -12,12 +12,15 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public partial class FluidsReportTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public FluidsReportTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FormationMarkersTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FormationMarkersTests.cs
@@ -12,7 +12,6 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public class FormationMarkersTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         private const string UidWell = "94f01089-84d3-4cec-9448-303c508ddb9e";
         private const string UidWellbore = "c4ef4f85-5692-4f62-91b2-f26dce721501";
@@ -20,7 +19,11 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public FormationMarkersTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
@@ -16,7 +16,6 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public class LogObjectTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
         private const string IsoPattern = "yyyy-MM-ddTHH:mm:ss.fffZ";
 
         private const string UidWell = "bbd34996-a1f6-4767-8b02-5e3b46a990e8";
@@ -30,7 +29,11 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public LogObjectTests()
         {
             var config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MessageTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MessageTests.cs
@@ -18,7 +18,11 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public MessageTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, new WitsmlClientCapabilities());
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MudLogTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MudLogTests.cs
@@ -15,12 +15,15 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public partial class MudLogTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public MudLogTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
@@ -15,12 +15,15 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public partial class RigTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public RigTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
@@ -14,12 +14,15 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public partial class TrajectoryTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public TrajectoryTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 
 using Witsml;
-using Witsml.Data;
 using Witsml.Data.Tubular;
 using Witsml.ServiceReference;
 using Witsml.Xml;
@@ -15,12 +14,15 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
     public partial class TubularTests
     {
         private readonly WitsmlClient _client;
-        private readonly WitsmlClientCapabilities _clientCapabilities = new();
 
         public TubularTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(config.Hostname, config.Username, config.Password, _clientCapabilities);
+            _client = new WitsmlClient(new WitsmlClientOptions
+            {
+                Hostname = config.Hostname,
+                Credentials = new WitsmlCredentials(config.Username, config.Password)
+            });
         }
 
         [Fact(Skip = "Should only be run manually")]


### PR DESCRIPTION
## Fixes

This pull request fixes #1971 

## Description

This PR includes an extension of the WitsmlClient that accepts a X509Certificate client certificate for certificate validation when communicating with a WITSML server.

Due to the added arguments to the WitsmlClient constructor, I've refactored it to accept a WitsmlClientOptions object instead. ~The previous constructor has been marked as obsolete to move usage over to the new constructor~ (I removed the Obsolete attribute since it broke the build which seem to be set up to break on warnings)

I've also refactored the WitsmlClient file a bit and extracted some of the content to their own files.


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [ ] API
* [x] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


