### PR TITLE
fix for : Right clicking a log in content view should display a conte…

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -180,7 +180,10 @@ export const ContentTable = (contentTableProps: ContentTableProps): React.ReactE
                 <Fragment key={row.id}>
                   <StyledTr
                     selected={row.getIsSelected()}
-                    onContextMenu={(e) => onRowContextMenu(e, row)}
+                    onContextMenu={async (e) => {
+                      await row.toggleSelected(true);
+                      onRowContextMenu(e, row);
+                    }}
                     style={{
                       height: `${calculateRowHeight(row, headCellHeight, cellHeight)}px`,
                       transform: `translateY(${virtualRow.start}px)`

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -181,6 +181,7 @@ export const ContentTable = (contentTableProps: ContentTableProps): React.ReactE
                   <StyledTr
                     selected={row.getIsSelected()}
                     onContextMenu={async (e) => {
+                      // await selection to ensure that the context menu detects that a row has been selected
                       await row.toggleSelected(true);
                       onRowContextMenu(e, row);
                     }}


### PR DESCRIPTION

[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #57
Right clicking a log in content view should display a context menu with clickable items.

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


