### PR TITLE
Fix dark mode for textarea in job properties

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
@@ -122,7 +122,7 @@ const GlobalStyles = createGlobalStyle<{ colors: Colors }>`
       color:${(props) => props.colors.text.staticIconsDefault};
     }
   }
-  input[type=text],input[type=password],input[type=number],textarea {
+  input[type=text],input[type=password],input[type=number],textarea,textarea.MuiInputBase-input {
     color:${(props) => props.colors.text.staticIconsDefault} ;
   }
 


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Fix textarea in job properties having wrong text color in dark mode.
![image](https://github.com/equinor/witsml-explorer/assets/66632214/86c08d49-9422-465d-9cc9-86868dddf090)


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


