### PR TITLE
Update options/lambda syntax when setting up WitsmlClient

### DIFF
--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -36,28 +36,31 @@ namespace Witsml
         [Obsolete("Use the WitsmlClientOptions based constructor instead")]
         public WitsmlClient(string hostname, string username, string password, WitsmlClientCapabilities clientCapabilities, TimeSpan? requestTimeout = null,
             bool logQueries = false)
-            : this(new WitsmlClientOptions
+            : this(options =>
             {
-                Hostname = hostname,
-                Credentials = new WitsmlCredentials(username, password),
-                ClientCapabilities = clientCapabilities,
-                RequestTimeOut = requestTimeout ?? TimeSpan.FromMinutes(1),
-                LogQueries = logQueries
+                options.Hostname = hostname;
+                options.Credentials = new WitsmlCredentials(username, password);
+                options.ClientCapabilities = clientCapabilities;
+                options.RequestTimeOut = requestTimeout ?? TimeSpan.FromMinutes(1);
+                options.LogQueries = logQueries;
             })
         { }
 
-        public WitsmlClient(WitsmlClientOptions options)
+        public WitsmlClient(Action<WitsmlClientOptions> options)
         {
-            ArgumentNullException.ThrowIfNull(options.Hostname);
-            ArgumentNullException.ThrowIfNull(options.Credentials.Username);
-            ArgumentNullException.ThrowIfNull(options.Credentials.Password);
+            var witsmlClientOptions = new WitsmlClientOptions();
+            options(witsmlClientOptions);
 
-            _clientCapabilities = options.ClientCapabilities.ToXml();
-            _serverUrl = new Uri(options.Hostname);
+            ArgumentNullException.ThrowIfNull(witsmlClientOptions.Hostname);
+            ArgumentNullException.ThrowIfNull(witsmlClientOptions.Credentials.Username);
+            ArgumentNullException.ThrowIfNull(witsmlClientOptions.Credentials.Password);
 
-            _client = CreateSoapClient(options);
+            _clientCapabilities = witsmlClientOptions.ClientCapabilities.ToXml();
+            _serverUrl = new Uri(witsmlClientOptions.Hostname);
 
-            SetupQueryLogging(options.LogQueries);
+            _client = CreateSoapClient(witsmlClientOptions);
+
+            SetupQueryLogging(witsmlClientOptions.LogQueries);
         }
 
         private void SetupQueryLogging(bool logQueries)

--- a/Src/Witsml/WitsmlClientOptions.cs
+++ b/Src/Witsml/WitsmlClientOptions.cs
@@ -10,33 +10,33 @@ public class WitsmlClientOptions
     /// <summary>
     /// Hostname of the WITSML server to connect to
     /// </summary>
-    public string Hostname { get; init; }
+    public string Hostname { get; set; }
 
     /// <summary>
     /// Client credentials to be used for basic authentication with the WITSML server
     /// </summary>
-    public WitsmlCredentials Credentials { get; init; }
+    public WitsmlCredentials Credentials { get; set; }
 
     /// <summary>
-    /// Client certificate to present while connecting to the WITSML server. The certificate should contain the private key.
+    /// Optional. Client certificate to present while connecting to the WITSML server. The certificate should contain the private key.
     /// </summary>
-    public X509Certificate2 ClientCertificate { get; init; }
+    public X509Certificate2 ClientCertificate { get; set; }
 
     /// <summary>
     /// The client capabilities to present to the WITSML server
     /// <see cref="WitsmlClientCapabilities" />
     /// </summary>
-    public WitsmlClientCapabilities ClientCapabilities { get; init; } = new();
+    public WitsmlClientCapabilities ClientCapabilities { get; set; } = new();
 
     /// <summary>
     /// The timeout interval to be used when communicating with the WITSML server. Default is 00:01:00 minutes
     /// </summary>
-    public TimeSpan RequestTimeOut { get; init; } = TimeSpan.FromMinutes(1);
+    public TimeSpan RequestTimeOut { get; set; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
     /// Enable logging all queries to a file (queries.log) in the current directory
     /// </summary>
-    public bool LogQueries { get; init; }
+    public bool LogQueries { get; set; }
 }
 
 public record WitsmlCredentials(string Username, string Password);

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -70,11 +70,11 @@ namespace WitsmlExplorer.Api.Services
                 cacheId = httpContext.CreateWitsmlExplorerCookie();
             }
 
-            var witsmlClient = new WitsmlClient(new WitsmlClientOptions
+            var witsmlClient = new WitsmlClient(options =>
             {
-                Hostname = creds.Host.ToString(),
-                Credentials = new WitsmlCredentials(creds.UserId, creds.Password),
-                ClientCapabilities = _clientCapabilities
+                options.Hostname = creds.Host.ToString();
+                options.Credentials = new WitsmlCredentials(creds.UserId, creds.Password);
+                options.ClientCapabilities = _clientCapabilities;
             });
             await witsmlClient.TestConnectionAsync();
 

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -50,11 +50,11 @@ namespace WitsmlExplorer.Api.Services
         {
             (string serverUrl, string username, string password) = GetCredentialsFromConfiguration(configuration);
             _witsmlClient = new WitsmlClient(
-                new WitsmlClientOptions
+                options =>
                 {
-                    Hostname = serverUrl,
-                    Credentials = new WitsmlCredentials(username, password),
-                    LogQueries = true
+                    options.Hostname = serverUrl;
+                    options.Credentials = new WitsmlCredentials(username, password);
+                    options.LogQueries = true;
                 });
         }
 
@@ -73,12 +73,12 @@ namespace WitsmlExplorer.Api.Services
             {
                 _targetCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
                 _witsmlClient = (_targetCreds != null && !_targetCreds.IsCredsNullOrEmpty())
-                    ? new WitsmlClient(new WitsmlClientOptions
+                    ? new WitsmlClient(options =>
                     {
-                        Hostname = _targetCreds.Host.ToString(),
-                        Credentials = new WitsmlCredentials(_targetCreds.UserId, _targetCreds.Password),
-                        ClientCapabilities = _clientCapabilities,
-                        LogQueries = _logQueries
+                        options.Hostname = _targetCreds.Host.ToString();
+                        options.Credentials = new WitsmlCredentials(_targetCreds.UserId, _targetCreds.Password);
+                        options.ClientCapabilities = _clientCapabilities;
+                        options.LogQueries = _logQueries;
                     })
                     : null;
             }
@@ -91,12 +91,12 @@ namespace WitsmlExplorer.Api.Services
             {
                 _sourceCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
                 _witsmlSourceClient = (_sourceCreds != null && !_sourceCreds.IsCredsNullOrEmpty())
-                    ? new WitsmlClient(new WitsmlClientOptions
+                    ? new WitsmlClient(options =>
                     {
-                        Hostname = _sourceCreds.Host.ToString(),
-                        Credentials = new WitsmlCredentials(_sourceCreds.UserId, _sourceCreds.Password),
-                        ClientCapabilities = _clientCapabilities,
-                        LogQueries = _logQueries
+                        options.Hostname = _sourceCreds.Host.ToString();
+                        options.Credentials = new WitsmlCredentials(_sourceCreds.UserId, _sourceCreds.Password);
+                        options.ClientCapabilities = _clientCapabilities;
+                        options.LogQueries = _logQueries;
                     })
                     : null;
             }

--- a/Src/WitsmlExplorer.Console/WitsmlClient/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Console/WitsmlClient/WitsmlClientProvider.cs
@@ -33,11 +33,11 @@ namespace WitsmlExplorer.Console.WitsmlClient
             try
             {
                 (string serverUrl, string username, string password) = GetCredentialsFromConfiguration();
-                _witsmlClient = new Witsml.WitsmlClient(new WitsmlClientOptions
+                _witsmlClient = new Witsml.WitsmlClient(options =>
                 {
-                    Hostname = serverUrl,
-                    Credentials = new WitsmlCredentials(username, password),
-                    ClientCapabilities = _clientCapabilities
+                    options.Hostname = serverUrl;
+                    options.Credentials = new WitsmlCredentials(username, password);
+                    options.ClientCapabilities = _clientCapabilities;
                 });
             }
             catch (Exception e)

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/LogObjectTests.cs
@@ -25,10 +25,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.AddToStore
         {
             _output = output;
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/AddToStore/TrajectoryTests.cs
@@ -27,10 +27,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.AddToStore
         {
             _output = output;
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/BhaRunTests.cs
@@ -18,10 +18,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public BhaRunTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FluidsReportTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FluidsReportTests.cs
@@ -16,10 +16,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public FluidsReportTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FormationMarkersTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/FormationMarkersTests.cs
@@ -19,10 +19,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public FormationMarkersTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/LogObjectTests.cs
@@ -29,10 +29,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public LogObjectTests()
         {
             var config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 
@@ -101,7 +101,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             };
 
             var result = await _client.GetFromStoreAsync(query, new OptionsIn(ReturnElements.All));
-            var witsmlLog = result.Logs.FirstOrDefault();
+            var witsmlLog = result.Logs.First();
             var data = witsmlLog.LogData.Data;
             data.First().GetRow(); // Test fails if parsing error on GetRow() due to incompatible culture setting.
         }

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MessageTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MessageTests.cs
@@ -18,10 +18,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public MessageTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MudLogTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/MudLogTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 
 using Witsml;
-using Witsml.Data;
 using Witsml.Data.MudLog;
 using Witsml.ServiceReference;
 using Witsml.Xml;
@@ -19,10 +18,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public MudLogTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 
@@ -34,7 +33,7 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
             string wellUid = "8c77de13-4fad-4b2e-ba3d-7e6b0e35a394";
             string wellboreUid = "44e7a064-c2f2-4a3a-9259-5ab92085e110";
             string mudLogUid = "integration_test";
-            WitsmlMudLogs queryExisting = MudLogQueries.QueryById(wellUid, wellboreUid, new string[] { mudLogUid });
+            WitsmlMudLogs queryExisting = MudLogQueries.QueryById(wellUid, wellboreUid, new[] { mudLogUid });
             WitsmlMudLogs serverMudLog = await _client.GetFromStoreAsync(queryExisting, new OptionsIn(ReturnElements.All));
             string responseXml = XmlHelper.Serialize(serverMudLog);
             string serverMudLogXml = TestUtils.CleanResponse(responseXml);

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/RigTests.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 
 using Witsml;
-using Witsml.Data;
 using Witsml.Data.Rig;
 using Witsml.ServiceReference;
 using Witsml.Xml;
@@ -19,10 +18,11 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public RigTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TrajectoryTests.cs
@@ -18,10 +18,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public TrajectoryTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/GetFromStore/TubularTests.cs
@@ -18,10 +18,10 @@ namespace WitsmlExplorer.IntegrationTests.Witsml.GetFromStore
         public TubularTests()
         {
             WitsmlConfiguration config = ConfigurationReader.GetWitsmlConfiguration();
-            _client = new WitsmlClient(new WitsmlClientOptions
+            _client = new WitsmlClient(options =>
             {
-                Hostname = config.Hostname,
-                Credentials = new WitsmlCredentials(config.Username, config.Password)
+                options.Hostname = config.Hostname;
+                options.Credentials = new WitsmlCredentials(config.Username, config.Password);
             });
         }
 


### PR DESCRIPTION
## Description

This was the intended syntax for the previous changes to the WitsmlClient constructor, inspired by the miscellaneous ASP.NET code during setup (f.ex `app.UseEndpoints(options => { ... });`).

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [ ] API
* [x] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests
