### PR TITLE
Fix logs routing

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Routing.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Routing.tsx
@@ -141,18 +141,21 @@ const Routing = (): React.ReactElement => {
     }
   }, [selectedWell]);
 
+  const [isFetchingObjects, setIsFetchingObjects] = useState(false);
   useEffect(() => {
-    if (isSyncingUrlAndState && selectedWellbore) {
+    if (isSyncingUrlAndState && selectedWellbore && !isFetchingObjects) {
       const group = urlParams?.group as ObjectType;
       const objectUid = urlParams?.objectUid;
       if (group != null && getObjectsFromWellbore(selectedWellbore, group) == null) {
         const fetchAndSelectObjectGroup = async () => {
+          setIsFetchingObjects(true);
           const objects = await ObjectService.getObjects(selectedWell.uid, selectedWellbore.uid, group);
           const action: SelectObjectGroupAction = {
             type: NavigationType.SelectObjectGroup,
             payload: { objectType: group, wellUid: selectedWell.uid, wellboreUid: selectedWellbore.uid, objects }
           };
           dispatchNavigation(action);
+          setIsFetchingObjects(false);
         };
         fetchAndSelectObjectGroup();
         if (urlParams.logType == null && objectUid == null) {


### PR DESCRIPTION
## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Fix routing to logs group when logType is in the url. Previously, the routing went back to LogTypeListView instead of LogsListView due to multiple calls to fetchAndSelectObjectGroup.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


