### PR TITLE
FIX-2100 fix permanently disabling of the view curve value button

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
@@ -38,7 +38,7 @@ export const LogHeaderDateTimeField = (props: DateTimeFieldProps): React.ReactEl
 
   const validate = (current: string) => {
     return (
-      (validateIsoDateStringNoOffset(current, offset) && (!minValue || value >= minValue) && (!maxValue || value <= maxValue)) ||
+      (validateIsoDateStringNoOffset(current, offset) && (!minValue || current >= minValue) && (!maxValue || current <= maxValue)) ||
       (initiallyEmpty && (current == null || current === ""))
     );
   };

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonGroup } from "@material-ui/core";
 import { addMilliseconds } from "date-fns";
 import { formatInTimeZone, toDate } from "date-fns-tz";
 import React, { useEffect, useState } from "react";
-import { dateTimeFormatNoOffset, getOffset } from "../../DateFormatter";
+import { dateTimeFormatNoOffset, getOffset, validateIsoDateStringNoOffset } from "../../DateFormatter";
 import { LogHeaderDateTimeField } from "../LogHeaderDateTimeField";
 
 export interface AdjustDateTimeModelProps {
@@ -21,12 +21,12 @@ interface SetRangeButton {
 
 const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElement => {
   const { minDate, maxDate, isDescending, onStartDateChanged, onEndDateChanged, onValidChange } = props;
-  const [startIndexIsValid, setStartIndexIsValid] = useState<boolean>(true);
-  const [endIndexIsValid, setEndIndexIsValid] = useState<boolean>(true);
   const [startOffset] = useState<string>(getOffset(minDate));
   const [endOffset] = useState<string>(getOffset(maxDate));
   const [startIndex, setStartIndex] = useState<string>(formatInTimeZone(minDate, startOffset, dateTimeFormatNoOffset));
   const [endIndex, setEndIndex] = useState<string>(formatInTimeZone(maxDate, endOffset, dateTimeFormatNoOffset));
+  const [startIndexInitiallyEmpty] = useState<boolean>(startIndex == null || startIndex === "");
+  const [endIndexInitiallyEmpty] = useState<boolean>(endIndex == null || endIndex === "");
   const setRangeButtons: SetRangeButton[] = [
     { timeInMilliseconds: 3600000, displayText: "hour" },
     { timeInMilliseconds: 21600000, displayText: "6 hours" },
@@ -34,6 +34,17 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
     { timeInMilliseconds: 604800000, displayText: "week" }
   ];
   const totalTimeSpan = toDate(maxDate).getTime() - toDate(minDate).getTime();
+  const startIndexMinValue = isDescending ? endIndex : null;
+  const startIndexMaxValue = isDescending ? null : endIndex;
+  const endIndexMinValue = isDescending ? null : startIndex;
+  const endIndexMaxValue = isDescending ? startIndex : null;
+
+  const validate = (current: string, offset: string, minValue: string, maxValue: string, initiallyEmpty: boolean) => {
+    return (
+      (validateIsoDateStringNoOffset(current, offset) && (!minValue || current >= minValue) && (!maxValue || current <= maxValue)) ||
+      (initiallyEmpty && (current == null || current === ""))
+    );
+  };
 
   useEffect(() => {
     onStartDateChanged(startIndex + startOffset);
@@ -41,8 +52,10 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
   }, [startIndex, endIndex]);
 
   useEffect(() => {
+    const startIndexIsValid = validate(startIndex, startOffset, startIndexMinValue, startIndexMaxValue, startIndexInitiallyEmpty);
+    const endIndexIsValid = validate(endIndex, endOffset, endIndexMinValue, endIndexMaxValue, endIndexInitiallyEmpty);
     onValidChange(startIndexIsValid && endIndexIsValid && (isDescending ? startIndex > endIndex : startIndex < endIndex));
-  }, [startIndexIsValid, endIndexIsValid, startIndex, endIndex]);
+  }, [startIndex, endIndex]);
 
   return (
     <>
@@ -77,24 +90,22 @@ const AdjustDateTimeModal = (props: AdjustDateTimeModelProps): React.ReactElemen
       <LogHeaderDateTimeField
         value={startIndex ?? ""}
         label="Start index"
-        updateObject={(dateTime: string, valid: boolean) => {
+        updateObject={(dateTime: string) => {
           setStartIndex(dateTime);
-          setEndIndexIsValid(valid);
         }}
         offset={startOffset}
-        minValue={isDescending ? endIndex : null}
-        maxValue={isDescending ? null : endIndex}
+        minValue={startIndexMinValue}
+        maxValue={startIndexMaxValue}
       />
       <LogHeaderDateTimeField
         value={endIndex ?? ""}
         label="End index"
-        updateObject={(dateTime: string, valid: boolean) => {
+        updateObject={(dateTime: string) => {
           setEndIndex(dateTime);
-          setStartIndexIsValid(valid);
         }}
         offset={endOffset}
-        minValue={isDescending ? null : startIndex}
-        maxValue={isDescending ? startIndex : null}
+        minValue={endIndexMinValue}
+        maxValue={endIndexMaxValue}
       />
     </>
   );


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2100 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

I changed the validation function in the `LogHeaderDateTimeField` component to use `current` instead of `value`. I did not notice any issues with this change, and I believe `current` is the value we should use here. When reviewing the PR, kindly take an additional look at this. Let's make sure that we don't miss anything important.


