### PR TITLE
FIX-2109 Add icon to open self-closing tags in QueryView

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/QueryEditor.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/QueryEditor.tsx
@@ -9,6 +9,7 @@ import styled from "styled-components";
 import OperationContext from "../contexts/operationContext";
 import { Colors, dark } from "../styles/Colors";
 import { customCommands, customCompleter } from "./QueryEditorUtils";
+import { updateLinesWithWidgets } from "./QueryEditorWidgetUtils";
 
 export interface QueryEditorProps {
   value: string;
@@ -29,6 +30,7 @@ export const QueryEditor = (props: QueryEditorProps) => {
       editor.renderer.$cursorLayer.element.style.display = "none";
     } else {
       editor.completers = [customCompleter];
+      editor.renderer.on("afterRender", (_: any, renderer: any) => updateLinesWithWidgets(editor, renderer));
     }
   };
 

--- a/Src/WitsmlExplorer.Frontend/components/QueryEditorUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/QueryEditorUtils.tsx
@@ -56,7 +56,7 @@ export const customCompleter = {
  * @param str - The input XML string.
  * @returns The tag found in the input string.
  */
-const getTag = (str: string): string => {
+export const getTag = (str: string): string => {
   return str.match(/<\/*(\w+)[^>]*>/)?.[1];
 };
 
@@ -68,7 +68,7 @@ const getTag = (str: string): string => {
  */
 const getTemplateObject = (rows: string[]): TemplateObjects | null => {
   for (const row of rows) {
-    const tag = getTag(row).slice(0, -1);
+    const tag = getTag(row)?.slice(0, -1);
     if (tag && Object.values(TemplateObjects).includes(tag as TemplateObjects)) {
       return tag as TemplateObjects;
     }

--- a/Src/WitsmlExplorer.Frontend/components/QueryEditorWidgetUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/QueryEditorWidgetUtils.tsx
@@ -52,19 +52,19 @@ const updateWidgets = (editor: any, renderer: any) => {
   const config = textLayer.config;
   const session = textLayer.session;
 
-  const first = config.firstRow;
-  const last = config.lastRow;
+  const firstRow = config.firstRow;
+  const lastRow = config.lastRow;
 
   const lineElements = textLayer.element.childNodes;
   let lineElementsIdx = 0;
 
-  let row = first;
+  let row = firstRow;
   let foldLine = session.getNextFoldLine(row);
   let foldStart = foldLine ? foldLine.start.row : Infinity;
 
   const useGroups = textLayer.$useLineGroups();
 
-  while (row <= last) {
+  while (row <= lastRow) {
     if (row > foldStart) {
       row = foldLine.end.row + 1;
       foldLine = textLayer.session.getNextFoldLine(row, foldLine);

--- a/Src/WitsmlExplorer.Frontend/components/QueryEditorWidgetUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/QueryEditorWidgetUtils.tsx
@@ -1,0 +1,113 @@
+import { Icon } from "@equinor/eds-core-react";
+import { createRoot } from "react-dom/client";
+import styled from "styled-components";
+import { getTag } from "./QueryEditorUtils";
+
+/**
+ * Handles the click event for opening a tag in the QueryEditor.
+ * Replaces the self-closing tag with an opening and closing tag and moves the cursor between the tags.
+ * @param editor The Ace editor instance.
+ * @param row The row number of the tag to open.
+ */
+const onClickOpenTag = (editor: any, row: number) => {
+  const session = editor.getSession();
+  const lineText = session.getLine(row);
+  const tag = getTag(lineText);
+  const newText = `${lineText.replace(/(\s*)\/>/, ">")}</${tag ?? ""}>`;
+  session.replace({ start: { row, column: 0 }, end: { row, column: lineText.length } }, newText);
+  editor.execCommand({
+    exec: () => {
+      editor.selection.moveCursorBy(0, -(tag?.length ?? 0) - 3);
+      editor.selection.clearSelection();
+    }
+  });
+};
+
+let updateTimeout: NodeJS.Timeout | null = null;
+
+/**
+ * Uses a deferred call to updateWidgets to avoid adding multiple icons to the same line when scrolling fast.
+ * @param editor The Ace editor instance.
+ * @param renderer The Ace renderer instance.
+ */
+export const updateLinesWithWidgets = (editor: any, renderer: any) => {
+  // updateWidgets sometimes adds multiple widgets to the same line when scrolling fast, so we need to debounce it slightly.
+  if (updateTimeout) {
+    clearTimeout(updateTimeout);
+  }
+  updateTimeout = setTimeout(() => {
+    updateWidgets(editor, renderer);
+    updateTimeout = null;
+  }, 10);
+};
+
+/**
+ * Updates the widgets for opening tag icons in the QueryEditor.
+ * Adds a widget container with an opening tag icon to each line that contains a self-closing tag.
+ * @param editor The Ace editor instance.
+ * @param renderer The Ace renderer instance.
+ */
+const updateWidgets = (editor: any, renderer: any) => {
+  const textLayer = renderer.$textLayer;
+  const config = textLayer.config;
+  const session = textLayer.session;
+
+  const first = config.firstRow;
+  const last = config.lastRow;
+
+  const lineElements = textLayer.element.childNodes;
+  let lineElementsIdx = 0;
+
+  let row = first;
+  let foldLine = session.getNextFoldLine(row);
+  let foldStart = foldLine ? foldLine.start.row : Infinity;
+
+  const useGroups = textLayer.$useLineGroups();
+
+  while (row <= last) {
+    if (row > foldStart) {
+      row = foldLine.end.row + 1;
+      foldLine = textLayer.session.getNextFoldLine(row, foldLine);
+      foldStart = foldLine ? foldLine.start.row : Infinity;
+    }
+
+    let lineElement = lineElements[lineElementsIdx++];
+    if (lineElement) {
+      if (useGroups) lineElement = lineElement.lastChild;
+      const lineText = session.getLine(row);
+      if (lineText.match(/<.*\/>/) && !lineElement.querySelector("svg")) {
+        const widget = (
+          <StyledEditIcon
+            name="edit"
+            size={16}
+            onClick={(
+              (currentRow) => () =>
+                onClickOpenTag(editor, currentRow)
+            )(row)}
+          />
+        );
+
+        const widgetContainer = document.createElement("span");
+        widgetContainer.className = "widget";
+        widgetContainer.style.marginTop = "-2px";
+        widgetContainer.style.boxSizing = "border-box";
+        widgetContainer.style.display = "inline-block";
+        widgetContainer.style.verticalAlign = "middle";
+        widgetContainer.style.pointerEvents = "auto";
+
+        createRoot(widgetContainer).render(widget);
+
+        lineElement.appendChild(widgetContainer);
+      }
+    }
+    row++;
+  }
+};
+
+const StyledEditIcon = styled(Icon)`
+  display: inline-block;
+  vertical-align: middle;
+  transform: scale(0.75);
+  cursor: pointer;
+  opacity: 0.7;
+`;


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2109 

## Description

Added a icon on lines with a self-closing tag. Clicking the icon expands the tag and places the cursor between the opening and closing tag.



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


