### PR TITLE
Grouping of Edit disabled with subitem enabled #2159

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -150,7 +150,7 @@ const LogObjectContextMenu = (props: ObjectContextMenuProps): React.ReactElement
         <StyledIcon name="paste" color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>{menuItemText("paste", "log curve", logCurvesReference?.componentUids)}</Typography>
       </MenuItem>,
-      <NestedMenuItem key={"editlognestedmenu"} label={"Edit"} disabled={checkedObjects.length === 0} icon="edit">
+      <NestedMenuItem key={"editlognestedmenu"} label={"Edit"} icon="edit">
         {[
           <MenuItem key={"trimlogobject"} onClick={onClickTrimLogObject} disabled={checkedObjects.length !== 1}>
             <StyledIcon name="formatLine" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -150,7 +150,7 @@ const LogObjectContextMenu = (props: ObjectContextMenuProps): React.ReactElement
         <StyledIcon name="paste" color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>{menuItemText("paste", "log curve", logCurvesReference?.componentUids)}</Typography>
       </MenuItem>,
-      <NestedMenuItem key={"editlognestedmenu"} label={"Edit"} disabled={checkedObjects.length !== 1} icon="edit">
+      <NestedMenuItem key={"editlognestedmenu"} label={"Edit"} disabled={checkedObjects.length !== 1 && checkedObjects.length < 2} icon="edit">
         {[
           <MenuItem key={"trimlogobject"} onClick={onClickTrimLogObject} disabled={checkedObjects.length !== 1}>
             <StyledIcon name="formatLine" color={colors.interactive.primaryResting} />

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -150,7 +150,7 @@ const LogObjectContextMenu = (props: ObjectContextMenuProps): React.ReactElement
         <StyledIcon name="paste" color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>{menuItemText("paste", "log curve", logCurvesReference?.componentUids)}</Typography>
       </MenuItem>,
-      <NestedMenuItem key={"editlognestedmenu"} label={"Edit"} disabled={checkedObjects.length !== 1 && checkedObjects.length < 2} icon="edit">
+      <NestedMenuItem key={"editlognestedmenu"} label={"Edit"} disabled={checkedObjects.length === 0} icon="edit">
         {[
           <MenuItem key={"trimlogobject"} onClick={onClickTrimLogObject} disabled={checkedObjects.length !== 1}>
             <StyledIcon name="formatLine" color={colors.interactive.primaryResting} />


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes
 This pull request fixes #2159

## Description
- edit group disabled only when all sub-items disabled

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


