### PR TITLE
FIX-2165 Disable show on server on multiselect

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -1,6 +1,7 @@
 import { Typography } from "@equinor/eds-core-react";
 import { Divider, MenuItem } from "@material-ui/core";
 import React, { useContext } from "react";
+import { v4 as uuid } from "uuid";
 import NavigationContext from "../../contexts/navigationContext";
 import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
@@ -270,7 +271,7 @@ const LogObjectContextMenu = (
         ]}
         ,
       </NestedMenuItem>,
-      <Divider key={"divider1"} />,
+      <Divider key={uuid()} />,
       <NestedMenuItem
         key={"agentslognestedmenu"}
         label={"Agents"}
@@ -348,7 +349,7 @@ const LogObjectContextMenu = (
           </MenuItem>
         ]}
       </NestedMenuItem>,
-      <Divider key={"divider2"} />,
+      <Divider key={uuid()} />,
       <MenuItem
         key={"importlogdata"}
         onClick={onClickImport}
@@ -357,7 +358,7 @@ const LogObjectContextMenu = (
         <StyledIcon name="upload" color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>Import log data from .csv</Typography>
       </MenuItem>,
-      <Divider key={"divider3"} />,
+      <Divider key={uuid()} />,
       <MenuItem
         key={"properties"}
         onClick={onClickProperties}

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -163,7 +163,7 @@ const LogObjectContextMenu = (props: ObjectContextMenuProps): React.ReactElement
         ]}
         ,
       </NestedMenuItem>,
-      <Divider key={"divider"} />,
+      <Divider key={"divider1"} />,
       <NestedMenuItem key={"agentslognestedmenu"} label={"Agents"} disabled={checkedObjects.length !== 1} icon="person">
         {[
           <MenuItem key={"comparelogheader"} onClick={onClickCompareHeader} disabled={checkedObjects.length !== 1}>
@@ -188,12 +188,12 @@ const LogObjectContextMenu = (props: ObjectContextMenuProps): React.ReactElement
           </MenuItem>
         ]}
       </NestedMenuItem>,
-      <Divider key={"divider"} />,
+      <Divider key={"divider2"} />,
       <MenuItem key={"importlogdata"} onClick={onClickImport} disabled={checkedObjects.length === 0}>
         <StyledIcon name="upload" color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>Import log data from .csv</Typography>
       </MenuItem>,
-      <Divider key={"divider"} />,
+      <Divider key={"divider3"} />,
       <MenuItem key={"properties"} onClick={onClickProperties} disabled={checkedObjects.length !== 1}>
         <StyledIcon name="settings" color={colors.interactive.primaryResting} />
         <Typography color={"primary"}>Properties</Typography>

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ObjectMenuItems.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ObjectMenuItems.tsx
@@ -42,7 +42,7 @@ export const ObjectMenuItems = (
       <StyledIcon name="refresh" color={colors.interactive.primaryResting} />
       <Typography color={"primary"}>{menuItemText("Refresh", objectType, null)}</Typography>
     </MenuItem>,
-    <Divider key={"divider"} />,
+    <Divider key={"objectMenuItemsDivider"} />,
     <MenuItem key={"copy"} onClick={() => copyObjectOnWellbore(selectedServer, checkedObjects, dispatchOperation, objectType)} disabled={checkedObjects.length === 0}>
       <StyledIcon name="copy" color={colors.interactive.primaryResting} />
       <Typography color={"primary"}>{menuItemText("copy", objectType, checkedObjects)}</Typography>
@@ -72,7 +72,11 @@ export const ObjectMenuItems = (
     ...extraMenuItems,
     <NestedMenuItem key={"showOnServer"} label={"Show on server"} disabled={checkedObjects.length !== 1}>
       {servers.map((server: Server) => (
-        <MenuItem key={server.name} onClick={() => onClickShowGroupOnServer(dispatchOperation, server, wellbore, objectType, (checkedObjects[0] as LogObject)?.indexType)}>
+        <MenuItem
+          key={server.name}
+          onClick={() => onClickShowGroupOnServer(dispatchOperation, server, wellbore, objectType, (checkedObjects[0] as LogObject)?.indexType)}
+          disabled={checkedObjects.length !== 1}
+        >
           <Typography color={"primary"}>{server.name}</Typography>
         </MenuItem>
       ))}


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2165 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Disabled clicking on a server when you have selected multiple items.
Also changed the key of the dividers to avoid getting a warning for duplicate keys.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


