### PR TITLE
FIX-2204 Filter out indexCurve when deleting log curves

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
@@ -57,6 +57,10 @@ const LogCurveInfoContextMenu = (
     selectedServer,
     servers
   } = props;
+  const checkedLogCurveInfoRowsWithoutIndexCurve =
+    checkedLogCurveInfoRows.filter(
+      (lc) => lc.mnemonic !== selectedLog.indexCurve
+    );
 
   const onClickOpen = () => {
     dispatchOperation({ type: OperationType.HideContextMenu });
@@ -111,10 +115,11 @@ const LogCurveInfoContextMenu = (
   };
 
   const toDelete = createComponentReferences(
-    checkedLogCurveInfoRows.map((lc) => lc.mnemonic),
+    checkedLogCurveInfoRowsWithoutIndexCurve.map((lc) => lc.mnemonic),
     selectedLog,
     ComponentType.Mnemonic
   );
+
   return (
     <ContextMenu
       menuItems={[
@@ -177,7 +182,7 @@ const LogCurveInfoContextMenu = (
               JobType.DeleteComponents
             )
           }
-          disabled={checkedLogCurveInfoRows.length === 0}
+          disabled={checkedLogCurveInfoRowsWithoutIndexCurve.length === 0}
         >
           <StyledIcon
             name="deleteToTrash"
@@ -187,7 +192,7 @@ const LogCurveInfoContextMenu = (
             {menuItemText(
               "delete",
               ComponentType.Mnemonic,
-              checkedLogCurveInfoRows
+              checkedLogCurveInfoRowsWithoutIndexCurve
             )}
           </Typography>
         </MenuItem>,
@@ -210,9 +215,8 @@ const LogCurveInfoContextMenu = (
         </NestedMenuItem>,
         <MenuItem
           key={"analyzeGaps"}
-          onClick={
-            onClickAnalyzeGaps
-          } /*disabled={checkedLogCurveInfoRows.length !== 1}*/
+          onClick={onClickAnalyzeGaps}
+          disabled={checkedLogCurveInfoRowsWithoutIndexCurve.length === 0}
         >
           <StyledIcon name="beat" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Analyze gaps</Typography>


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2204 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

When trying to delete a log curve, the indexCurve is filtered out. We cannot delete the index curve of a log without deleting the whole log as a log is required to have an indexCurve.
![image](https://github.com/equinor/witsml-explorer/assets/70512270/3cee8060-24b5-4d2d-8a22-a5d9e798899c)


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


