### PR TITLE
No error message shows when using wrong/expired cached credentials #2181

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -12,7 +12,6 @@ using Microsoft.IdentityModel.Tokens;
 
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Services;
-using WitsmlExplorer.Api.Middleware;
 
 namespace WitsmlExplorer.Api.HttpHandlers
 {
@@ -64,7 +63,6 @@ namespace WitsmlExplorer.Api.HttpHandlers
         public static IResult VerifyUserIsLoggedIn(string serverUrl, string userName, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpContext?.Request);
-            
             var creds = credentialsService.GetCredentials(eh, WebUtility.UrlDecode(serverUrl), userName);
             if (creds == null)
             {

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,6 +12,7 @@ using Microsoft.IdentityModel.Tokens;
 
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Middleware;
 
 namespace WitsmlExplorer.Api.HttpHandlers
 {
@@ -57,6 +59,18 @@ namespace WitsmlExplorer.Api.HttpHandlers
                 expires: DateTime.Now.AddDays(1),
                 signingCredentials: credentials);
             return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+        
+        public static IResult VerifyUserIsLoggedIn(string serverUrl, string userName, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
+        {
+            EssentialHeaders eh = new(httpContext?.Request);
+            
+            var creds = credentialsService.GetCredentials(eh, WebUtility.UrlDecode(serverUrl), userName);
+            if (creds == null)
+            {
+                return TypedResults.Unauthorized();
+            }
+            return TypedResults.Ok();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -59,7 +59,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
                 signingCredentials: credentials);
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
-        
+
         public static IResult VerifyUserIsLoggedIn(string serverUrl, string userName, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpContext?.Request);

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -96,6 +96,7 @@ namespace WitsmlExplorer.Api
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);
+            app.MapGet("/credentials/verifyuserisloggedin/{serverUrl}/{userName}", AuthorizeHandler.VerifyUserIsLoggedIn, useOAuth2);
             if (useOAuth2)
             {
                 app.MapGet("/credentials/token", AuthorizeHandler.GenerateToken, useOAuth2);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -134,7 +134,19 @@ const UserCredentialsModal = (
                 }}
               />
               <Button
-                onClick={() => props.onConnectionVerified(selectedUsername)}
+                onClick={async () => {
+                  try {
+                    await AuthorizationService.verifyuserisloggedin(
+                      server.url,
+                      selectedUsername
+                    );
+                    props.onConnectionVerified(selectedUsername);
+                  } catch {
+                    setErrorMessage(
+                      "Not able to authenticate to WITSML server with given credentials"
+                    );
+                  }
+                }}
               >
                 Switch user
               </Button>

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -156,9 +156,15 @@ class AuthorizationService {
     }
   }
 
-  public async verifyuserisloggedin(serverUrl: string, userName: string, abortSignal?: AbortSignal): Promise<any> {
+  public async verifyuserisloggedin(
+    serverUrl: string,
+    userName: string,
+    abortSignal?: AbortSignal
+  ): Promise<any> {
     const response = await ApiClient.get(
-      `/api/credentials/verifyuserisloggedin/${encodeURIComponent(serverUrl)}/${userName}`,
+      `/api/credentials/verifyuserisloggedin/${encodeURIComponent(
+        serverUrl
+      )}/${userName}`,
       abortSignal
     );
     if (!response.ok) {

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -156,6 +156,17 @@ class AuthorizationService {
     }
   }
 
+  public async verifyuserisloggedin(serverUrl: string, userName: string, abortSignal?: AbortSignal): Promise<any> {
+    const response = await ApiClient.get(
+      `/api/credentials/verifyuserisloggedin/${encodeURIComponent(serverUrl)}/${userName}`,
+      abortSignal
+    );
+    if (!response.ok) {
+      const { message }: ErrorDetails = await response.json();
+      throwError(response.status, message);
+    }
+  }
+
   public onAuthorizationChangeDispatch(authorizationState: AuthorizationState) {
     return this._onAuthorizationChange.dispatch(authorizationState);
   }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes
 This pull request fixes https://github.com/equinor/witsml-explorer/issues/2034

## Description
- display error message is shown when cached credentials are no longer valid

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [x] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


