### PR TITLE
FIX-2141 Wrong login error message on some servers

### DIFF
--- a/Src/Witsml/WitsmlRemoteServerRequestCrashedException.cs
+++ b/Src/Witsml/WitsmlRemoteServerRequestCrashedException.cs
@@ -1,0 +1,11 @@
+using System.ServiceModel;
+
+namespace Witsml;
+
+/// <summary>
+/// This class represents a custom exception for cases where a WITSML remote server request crash.
+/// </summary>
+public class WitsmlRemoteServerRequestCrashedException : CommunicationException
+{
+    public WitsmlRemoteServerRequestCrashedException(string message) : base(message) { }
+}

--- a/Src/WitsmlExplorer.Api/Middleware/ExceptionMiddleware.cs
+++ b/Src/WitsmlExplorer.Api/Middleware/ExceptionMiddleware.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Http;
 
 using Serilog;
 
+using Witsml;
+
 using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.HttpHandlers;
@@ -48,6 +50,16 @@ namespace WitsmlExplorer.Api.Middleware
                 {
                     StatusCode = (int)HttpStatusCode.BadGateway,
                     Message = "Remote endpoint sent not WITSML server response"
+                };
+                await HandleExceptionAsync(httpContext, errorDetails);
+            }
+            catch (WitsmlRemoteServerRequestCrashedException ex)
+            {
+                Log.Error($"Invalid response from server: {ex}");
+                ErrorDetails errorDetails = new()
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError,
+                    Message = "WITSML remote request failed on the server."
                 };
                 await HandleExceptionAsync(httpContext, errorDetails);
             }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2141 

## Description
When a user enters incorrect login credentials on Petrolink servers, it currently returns an HTTP response status of 500(internal server error), but it should return an HTTP response status of 401(unauthorized). It should be change on Petrolink servers.
It added a new WitsmlRemoteServerRequestCrashedException, which will handle this "internal server error" and merge HTTP response statuses 401 and 403 into one MessageSecurityException.

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [X] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [X] API
* [X] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [X] I have self-reviewed my code
* [X] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


