### PR TITLE
No error message shows when using wrong/expired cached credentials #2…

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -65,7 +65,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
         public static IResult VerifyUserIsLoggedIn(ConnectionInformation connectionInfo, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpContext?.Request);
-            var creds = credentialsService.GetCredentials(eh, connectionInfo.Url.ToString(), connectionInfo.UserName);
+            var creds = credentialsService.GetCredentials(eh, connectionInfo.ServerUrl.ToString(), connectionInfo.UserName);
             if (creds == null)
             {
                 return TypedResults.Unauthorized();

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Text;
@@ -61,10 +62,10 @@ namespace WitsmlExplorer.Api.HttpHandlers
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
 
-        public static IResult VerifyUserIsLoggedIn(Server server, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
+        public static IResult VerifyUserIsLoggedIn(ConnectionInformation connectionInfo, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpContext?.Request);
-            var creds = credentialsService.GetCredentials(eh, server.Url.ToString(), server.CurrentUserName);
+            var creds = credentialsService.GetCredentials(eh, connectionInfo.Url.ToString(), connectionInfo.UserName);
             if (creds == null)
             {
                 return TypedResults.Unauthorized();

--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Tokens;
 
 using WitsmlExplorer.Api.Configuration;
+using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Services;
 
 namespace WitsmlExplorer.Api.HttpHandlers
@@ -60,10 +61,10 @@ namespace WitsmlExplorer.Api.HttpHandlers
             return new JwtSecurityTokenHandler().WriteToken(token);
         }
 
-        public static IResult VerifyUserIsLoggedIn(string serverUrl, string userName, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
+        public static IResult VerifyUserIsLoggedIn(Server server, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpContext?.Request);
-            var creds = credentialsService.GetCredentials(eh, WebUtility.UrlDecode(serverUrl), userName);
+            var creds = credentialsService.GetCredentials(eh, server.Url.ToString(), server.CurrentUserName);
             if (creds == null)
             {
                 return TypedResults.Unauthorized();

--- a/Src/WitsmlExplorer.Api/Models/ConnectionInformation.cs
+++ b/Src/WitsmlExplorer.Api/Models/ConnectionInformation.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WitsmlExplorer.Api.Models
+{
+    public class ConnectionInformation
+    {
+        [JsonPropertyName("url")]
+        public Uri Url { get; init; }
+        [JsonPropertyName("userName")]
+        public string UserName { get; init; }
+
+        public override string ToString()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Models/ConnectionInformation.cs
+++ b/Src/WitsmlExplorer.Api/Models/ConnectionInformation.cs
@@ -6,8 +6,8 @@ namespace WitsmlExplorer.Api.Models
 {
     public class ConnectionInformation
     {
-        [JsonPropertyName("url")]
-        public Uri Url { get; init; }
+        [JsonPropertyName("serverUrl")]
+        public Uri ServerUrl { get; init; }
         [JsonPropertyName("userName")]
         public string UserName { get; init; }
 

--- a/Src/WitsmlExplorer.Api/Models/Server.cs
+++ b/Src/WitsmlExplorer.Api/Models/Server.cs
@@ -25,6 +25,8 @@ namespace WitsmlExplorer.Api.Models
         public IList<string> CredentialIds { get; init; }
         [JsonPropertyName("depthLogDecimals")]
         public int DepthLogDecimals { get; init; }
+        [JsonPropertyName("currentUserName")]
+        public string CurrentUserName { get; init; }
 
         public override string ToString()
         {

--- a/Src/WitsmlExplorer.Api/Models/Server.cs
+++ b/Src/WitsmlExplorer.Api/Models/Server.cs
@@ -25,8 +25,6 @@ namespace WitsmlExplorer.Api.Models
         public IList<string> CredentialIds { get; init; }
         [JsonPropertyName("depthLogDecimals")]
         public int DepthLogDecimals { get; init; }
-        [JsonPropertyName("currentUserName")]
-        public string CurrentUserName { get; init; }
 
         public override string ToString()
         {

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -96,7 +96,7 @@ namespace WitsmlExplorer.Api
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);
-            app.MapGet("/credentials/verifyuserisloggedin/{serverUrl}/{userName}", AuthorizeHandler.VerifyUserIsLoggedIn, useOAuth2);
+            app.MapPost("/credentials/verifyuserisloggedin", AuthorizeHandler.VerifyUserIsLoggedIn, useOAuth2);
             if (useOAuth2)
             {
                 app.MapGet("/credentials/token", AuthorizeHandler.GenerateToken, useOAuth2);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -138,7 +138,7 @@ const UserCredentialsModal = (
                 onClick={async () => {
                   try {
                     const connectionInfo: ConnectionInformation = {
-                      url: server.url,
+                      serverUrl: server.url,
                       userName: selectedUsername
                     };
                     await AuthorizationService.verifyuserisloggedin(

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -13,7 +13,8 @@ import { Server } from "models/server";
 import React, { ChangeEvent, useContext, useEffect, useState } from "react";
 import AuthorizationService, {
   AuthorizationStatus,
-  BasicServerCredentials
+  BasicServerCredentials,
+  ConnectionInformation
 } from "services/authorizationService";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
@@ -136,9 +137,12 @@ const UserCredentialsModal = (
               <Button
                 onClick={async () => {
                   try {
+                    const connectionInfo: ConnectionInformation = {
+                      url: server.url,
+                      userName: selectedUsername
+                    };
                     await AuthorizationService.verifyuserisloggedin(
-                      server,
-                      selectedUsername
+                      connectionInfo
                     );
                     props.onConnectionVerified(selectedUsername);
                   } catch {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -137,7 +137,7 @@ const UserCredentialsModal = (
                 onClick={async () => {
                   try {
                     await AuthorizationService.verifyuserisloggedin(
-                      server.url,
+                      server,
                       selectedUsername
                     );
                     props.onConnectionVerified(selectedUsername);

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -157,14 +157,14 @@ class AuthorizationService {
   }
 
   public async verifyuserisloggedin(
-    serverUrl: string,
-    userName: string,
+    server: Server,
+    selectedUsername: string,
     abortSignal?: AbortSignal
   ): Promise<any> {
-    const response = await ApiClient.get(
-      `/api/credentials/verifyuserisloggedin/${encodeURIComponent(
-        serverUrl
-      )}/${userName}`,
+    server.currentUsername = selectedUsername;
+    const response = await ApiClient.post(
+      `/api/credentials/verifyuserisloggedin`,
+      JSON.stringify(server),
       abortSignal
     );
     if (!response.ok) {

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -30,7 +30,7 @@ export interface AuthorizationState {
 }
 
 export interface ConnectionInformation {
-  url: string;
+  serverUrl: string;
   userName: string;
 }
 

--- a/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
+++ b/Src/WitsmlExplorer.Frontend/services/authorizationService.ts
@@ -29,6 +29,11 @@ export interface AuthorizationState {
   status: AuthorizationStatus;
 }
 
+export interface ConnectionInformation {
+  url: string;
+  userName: string;
+}
+
 class AuthorizationService {
   private static _instance: AuthorizationService;
   private _onAuthorizationChange =
@@ -157,14 +162,12 @@ class AuthorizationService {
   }
 
   public async verifyuserisloggedin(
-    server: Server,
-    selectedUsername: string,
+    connectionInfo: ConnectionInformation,
     abortSignal?: AbortSignal
   ): Promise<any> {
-    server.currentUsername = selectedUsername;
     const response = await ApiClient.post(
       `/api/credentials/verifyuserisloggedin`,
-      JSON.stringify(server),
+      JSON.stringify(connectionInfo),
       abortSignal
     );
     if (!response.ok) {


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes
 This pull request fixes https://github.com/equinor/witsml-explorer/issues/2181

## Description
-  display error message is shown when cached credentials are no longer valid
-  replace api method to POST

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


