### PR TITLE
Fix 2245 compare log data shared index interval

### DIFF
--- a/Src/WitsmlExplorer.Api/Jobs/CompareLogDataJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/CompareLogDataJob.cs
@@ -7,6 +7,7 @@ namespace WitsmlExplorer.Api.Jobs
         public ObjectReference SourceLog { get; init; }
         public ObjectReference TargetLog { get; init; }
         public bool IncludeIndexDuplicates { get; init; }
+        public bool CompareAllIndexes { get; init; }
 
         public override string Description()
         {

--- a/Src/WitsmlExplorer.Api/Workers/CompareLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/CompareLogDataWorker.cs
@@ -34,6 +34,7 @@ namespace WitsmlExplorer.Api.Workers
         private bool _isDecreasing;
         private bool _isDepthLog;
         private bool _includeIndexDuplicates;
+        private bool _compareAllIndexes;
 
         public CompareLogDataWorker(ILogger<CompareLogDataJob> logger, IWitsmlClientProvider witsmlClientProvider, IDocumentRepository<Server, Guid> witsmlServerRepository = null) : base(witsmlClientProvider, logger)
         {
@@ -59,6 +60,7 @@ namespace WitsmlExplorer.Api.Workers
             WitsmlLog sourceLog = await LogWorkerTools.GetLog(GetSourceWitsmlClientOrThrow(), job.SourceLog, ReturnElements.HeaderOnly);
             WitsmlLog targetLog = await LogWorkerTools.GetLog(GetTargetWitsmlClientOrThrow(), job.TargetLog, ReturnElements.HeaderOnly);
             _includeIndexDuplicates = job.IncludeIndexDuplicates;
+            _compareAllIndexes = job.CompareAllIndexes;
 
             try
             {
@@ -69,7 +71,10 @@ namespace WitsmlExplorer.Api.Workers
                 _isDepthLog = sourceLog.IndexType == WitsmlLog.WITSML_INDEX_TYPE_MD;
 
                 // Set the logs shared index interval
-                (sourceLog, targetLog) = SetSharedIndexInterval(sourceLog, targetLog);
+                if (!_compareAllIndexes)
+                {
+                    (sourceLog, targetLog) = SetSharedIndexInterval(sourceLog, targetLog);
+                }
 
                 List<string> sourceLogMnemonics = GetLogMnemonics(sourceLog);
                 List<string> targetLogMnemonics = GetLogMnemonics(targetLog);

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -16,6 +16,7 @@ import { useClipboardComponentReferencesOfType } from "components/ContextMenus/U
 import AnalyzeGapModal, {
   AnalyzeGapModalProps
 } from "components/Modals/AnalyzeGapModal";
+import CompareLogDataModal from "components/Modals/CompareLogDataModal";
 import DeleteEmptyMnemonicsModal, {
   DeleteEmptyMnemonicsModalProps
 } from "components/Modals/DeleteEmptyMnemonicsModal";
@@ -164,12 +165,14 @@ const LogObjectContextMenu = (
     const onPicked = async (
       targetObject: ObjectOnWellbore,
       targetServer: Server,
-      includeIndexDuplicates: boolean
+      includeIndexDuplicates: boolean,
+      compareAllIndexes: boolean
     ) => {
       const compareLogDataJob: CompareLogDataJob = {
         sourceLog: checkedObjects[0],
         targetLog: targetObject,
-        includeIndexDuplicates
+        includeIndexDuplicates,
+        compareAllIndexes
       };
       const jobId = await JobService.orderJobAtServer(
         JobType.CompareLogData,
@@ -185,15 +188,25 @@ const LogObjectContextMenu = (
         });
       }
     };
-    const props: ObjectPickerProps = {
-      sourceObject: checkedObjects[0],
-      objectType: ObjectType.Log,
-      onPicked,
-      includeIndexDuplicatesOption: true
-    };
     if (checkedObjects.length === 2) {
-      onPicked(checkedObjects[1], selectedServer, false);
+      dispatchOperation({
+        type: OperationType.DisplayModal,
+        payload: (
+          <CompareLogDataModal
+            targetObject={checkedObjects[1]}
+            targetServer={selectedServer}
+            onPicked={onPicked}
+          />
+        )
+      });
     } else {
+      const props: ObjectPickerProps = {
+        sourceObject: checkedObjects[0],
+        objectType: ObjectType.Log,
+        onPicked,
+        includeIndexDuplicatesOption: true,
+        includeCompareAllLogIndexesOption: true
+      };
       dispatchOperation({
         type: OperationType.DisplayModal,
         payload: <ObjectPickerModal {...props} />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/CompareLogDataModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/CompareLogDataModal.tsx
@@ -1,0 +1,94 @@
+import { Checkbox } from "@equinor/eds-core-react";
+import ModalDialog, {
+  ModalContentLayout,
+  ModalWidth
+} from "components/Modals/ModalDialog";
+import OperationContext from "contexts/operationContext";
+import OperationType from "contexts/operationType";
+import ObjectOnWellbore from "models/objectOnWellbore";
+import { Server } from "models/server";
+import { ChangeEvent, useContext, useState } from "react";
+import styled from "styled-components";
+import { Colors } from "styles/Colors";
+
+export interface CompareLogDataModalProps {
+  targetObject: ObjectOnWellbore;
+  targetServer: Server;
+  onPicked: (
+    targetObject: ObjectOnWellbore,
+    targetServer: Server,
+    includeIndexDuplicates?: boolean,
+    compareAllLogIndexes?: boolean
+  ) => void;
+}
+
+export default function CompareLogDataModal({
+  targetObject,
+  targetServer,
+  onPicked
+}: CompareLogDataModalProps) {
+  const {
+    operationState: { colors },
+    dispatchOperation
+  } = useContext(OperationContext);
+  const [checkedCompareAllLogIndexes, setCheckedCompareAllLogIndexes] =
+    useState(false);
+  const onSubmit = async () => {
+    dispatchOperation({ type: OperationType.HideModal });
+    onPicked(targetObject, targetServer, false, checkedCompareAllLogIndexes);
+  };
+
+  return (
+    <ModalDialog
+      heading={"Compare log data"}
+      onSubmit={onSubmit}
+      confirmColor={"primary"}
+      confirmText={`Compare`}
+      showCancelButton={true}
+      width={ModalWidth.MEDIUM}
+      isLoading={false}
+      content={
+        <ModalContentLayout>
+          <StyledParagraph colors={colors}>
+            By default, logs are compared within their shared log index
+            interval. Do you want to compare all indexes instead?
+          </StyledParagraph>
+          <ButtonsContainer>
+            <StyledCheckbox
+              colors={colors}
+              label="Compare all log indexes"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setCheckedCompareAllLogIndexes(e.target.checked);
+              }}
+              checked={checkedCompareAllLogIndexes}
+            />
+          </ButtonsContainer>
+        </ModalContentLayout>
+      }
+    />
+  );
+}
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  padding-left: 0.5rem;
+  padding-bottom: 1rem;
+`;
+
+const StyledParagraph = styled.p<{
+  colors: Colors;
+}>`
+  color: ${(props) => props.colors.text.staticIconsDefault};
+`;
+
+const StyledCheckbox = styled(Checkbox)<{ colors: Colors }>`
+  span {
+    color: ${(props) => props.colors.infographic.primaryMossGreen};
+  }
+  span:hover {
+    background: ${(props) => props.colors.interactive.checkBoxHover};
+  }
+`;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ObjectPickerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ObjectPickerModal.tsx
@@ -29,16 +29,19 @@ export interface ObjectPickerProps {
   onPicked: (
     targetObject: ObjectOnWellbore,
     targetServer: Server,
-    includeIndexDuplicates?: boolean
+    includeIndexDuplicates?: boolean,
+    compareAllLogIndexes?: boolean
   ) => void;
   includeIndexDuplicatesOption?: boolean;
+  includeCompareAllLogIndexesOption?: boolean;
 }
 
 const ObjectPickerModal = ({
   sourceObject,
   objectType,
   onPicked,
-  includeIndexDuplicatesOption
+  includeIndexDuplicatesOption,
+  includeCompareAllLogIndexesOption
 }: ObjectPickerProps): React.ReactElement => {
   const {
     navigationState: { servers }
@@ -57,6 +60,8 @@ const ObjectPickerModal = ({
   const [fetchError, setFetchError] = useState("");
   const objectReference = useClipboardReferencesOfType(objectType, 100);
   const [checkedIncludeIndexDuplicates, setCheckedIncludeIndexDuplicates] =
+    useState(false);
+  const [checkedCompareAllLogIndexes, setCheckedCompareAllLogIndexes] =
     useState(false);
 
   const onClear = () => {
@@ -98,8 +103,13 @@ const ObjectPickerModal = ({
       );
       if (targetObject?.uid === objectUid) {
         dispatchOperation({ type: OperationType.HideModal });
-        checkedIncludeIndexDuplicates
-          ? onPicked(targetObject, targetServer, checkedIncludeIndexDuplicates)
+        checkedIncludeIndexDuplicates || checkedCompareAllLogIndexes
+          ? onPicked(
+              targetObject,
+              targetServer,
+              checkedIncludeIndexDuplicates,
+              checkedCompareAllLogIndexes
+            )
           : onPicked(targetObject, targetServer);
       } else {
         setFetchError(`The target ${objectType} was not found`);
@@ -198,16 +208,29 @@ const ObjectPickerModal = ({
             >
               Paste
             </Button>
-            {includeIndexDuplicatesOption && (
-              <StyledCheckbox
-                colors={colors}
-                label="Include index duplicates"
-                onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                  setCheckedIncludeIndexDuplicates(e.target.checked);
-                }}
-                checked={checkedIncludeIndexDuplicates}
-              />
-            )}
+            <>
+              {includeIndexDuplicatesOption && (
+                <StyledCheckbox
+                  colors={colors}
+                  label="Include index duplicates"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    setCheckedIncludeIndexDuplicates(e.target.checked);
+                  }}
+                  checked={checkedIncludeIndexDuplicates}
+                />
+              )}
+              {objectType === ObjectType.Log &&
+                includeCompareAllLogIndexesOption && (
+                  <StyledCheckbox
+                    colors={colors}
+                    label="Compare all log indexes"
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                      setCheckedCompareAllLogIndexes(e.target.checked);
+                    }}
+                    checked={checkedCompareAllLogIndexes}
+                  />
+                )}
+            </>
           </ButtonsContainer>
           {checkedIncludeIndexDuplicates && (
             <StyledBanner colors={colors}>
@@ -221,6 +244,18 @@ const ObjectPickerModal = ({
                 result in unnecessary mismatches. This feature should only be
                 used in special cases that require investigation of anomalies in
                 the index duplicates.
+              </Banner.Message>
+            </StyledBanner>
+          )}
+          {checkedCompareAllLogIndexes && (
+            <StyledBanner colors={colors}>
+              <Banner.Icon variant="warning">
+                <Icon name="infoCircle" />
+              </Banner.Icon>
+              <Banner.Message>
+                Compare all log indexes: By default, logs are compared within
+                their shared log index interval. Comparing logs outside their
+                shared index interval should be unnecessary.
               </Banner.Message>
             </StyledBanner>
           )}

--- a/Src/WitsmlExplorer.Frontend/models/jobs/compareLogData.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/compareLogData.tsx
@@ -4,4 +4,5 @@ export default interface CompareLogDataJob {
   sourceLog: ObjectReference;
   targetLog: ObjectReference;
   includeIndexDuplicates: boolean;
+  compareAllIndexes: boolean;
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes  #2245 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Added default behavior to compare the shared index interval when comparing log data. Also added an option to enable the comparison of the whole index interval. To facilitate this, we have added a compare log data modal. 

Additionally, tests have been included for the compare log data worker.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


