### PR TITLE
Download all as selected popup - wrong color in dark mod #2258

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -473,7 +473,9 @@ export const CurveValuesView = (): React.ReactElement => {
         heading={"Download"}
         content={
           <>
-            <span>Choose download option?</span>
+            <span>
+              <Typography>Choose download option?</Typography>
+            </span>
 
             <label style={alignLayout}>
               <Radio
@@ -483,7 +485,7 @@ export const CurveValuesView = (): React.ReactElement => {
                 onChange={onChangeDownloadOption}
                 defaultChecked
               />
-              Download shown interval
+              <Typography>Download shown interval</Typography>
             </label>
             <label style={alignLayout}>
               <Radio
@@ -493,7 +495,7 @@ export const CurveValuesView = (): React.ReactElement => {
                 onChange={onChangeDownloadOption}
                 disabled={!selectedRows.length}
               />
-              Download selected
+              <Typography>Download selected</Typography>
             </label>
             <label style={alignLayout}>
               <Radio
@@ -502,7 +504,7 @@ export const CurveValuesView = (): React.ReactElement => {
                 value={DownloadOptions.All}
                 onChange={onChangeDownloadOption}
               />
-              Download all data
+              <Typography>Download all data</Typography>
             </label>
           </>
         }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes
 This pull request fixes https://github.com/equinor/witsml-explorer/issues/2258

## Description
- fix of download options popup in dark view 

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


