### PR TITLE
FIX-2282 splice logs - direction should default to increasing

### DIFF
--- a/Src/WitsmlExplorer.Api/Workers/SpliceLogsWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/SpliceLogsWorker.cs
@@ -82,8 +82,8 @@ namespace WitsmlExplorer.Api.Workers
         private static void VerifyLogHeaders(WitsmlLogs logHeaders)
         {
             if (logHeaders.Logs.IsNullOrEmpty()) throw new ArgumentException("Log headers could not be fetched");
-            var direction = logHeaders.Logs.FirstOrDefault().Direction;
-            if (logHeaders.Logs.Any(log => log.Direction != direction)) throw new ArgumentException("Direction must match for all logs");
+            var isIncreasing = logHeaders.Logs.FirstOrDefault().IsIncreasing();
+            if (logHeaders.Logs.Any(log => log.IsIncreasing() != isIncreasing)) throw new ArgumentException("Direction must match for all logs");
             var indexType = logHeaders.Logs.FirstOrDefault().IndexType;
             if (logHeaders.Logs.Any(log => log.IndexType != indexType)) throw new ArgumentException("Index type must match for all logs");
         }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2282 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

If the Direction of a log is null, it will be treated as though it is increasing.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [x] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


