### PR TITLE
Add OpenTelemetry library and expose metrics for Witsml requests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,6 +32,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.0" />
     <PackageVersion Include="System.ServiceModel.Http" Version="8.0.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageVersion Include="LiteDB" Version="5.0.19" />
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7">

--- a/Src/Witsml/Metrics/WitsmlMethod.cs
+++ b/Src/Witsml/Metrics/WitsmlMethod.cs
@@ -1,0 +1,10 @@
+namespace Witsml.Metrics;
+
+public enum WitsmlMethod
+{
+    GetFromStore,
+    AddToStore,
+    UpdateInStore,
+    DeleteFromStore,
+    GetCap
+}

--- a/Src/Witsml/Metrics/WitsmlMethod.cs
+++ b/Src/Witsml/Metrics/WitsmlMethod.cs
@@ -6,5 +6,6 @@ public enum WitsmlMethod
     AddToStore,
     UpdateInStore,
     DeleteFromStore,
-    GetCap
+    GetCap,
+    GetVersion
 }

--- a/Src/Witsml/Metrics/WitsmlMetrics.cs
+++ b/Src/Witsml/Metrics/WitsmlMetrics.cs
@@ -40,7 +40,7 @@ internal sealed class WitsmlMetrics
             description: "Number of active requests");
 
     internal async Task<TResponseType> MeasureQuery<TResponseType>(Uri serverUri, WitsmlMethod method, string witsmlType, Task<TResponseType> wmlsTask)
-        where TResponseType:IWitsmlResponse
+        where TResponseType : IWitsmlResponse
     {
         var tagList = new TagList
         {

--- a/Src/Witsml/Metrics/WitsmlMetrics.cs
+++ b/Src/Witsml/Metrics/WitsmlMetrics.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Witsml.ServiceReference;
+
+namespace Witsml.Metrics;
+
+internal sealed class WitsmlMetrics
+{
+    #region Singleton
+    // We still want to collect unified metrics in case there are multiple WitsmlClient instances used
+
+    private static readonly Lazy<WitsmlMetrics> LazyInstance =
+        new(() => new WitsmlMetrics());
+
+    public static WitsmlMetrics Instance { get { return LazyInstance.Value; } }
+
+    private WitsmlMetrics() { }
+
+    #endregion
+
+    private static readonly AssemblyName AssemblyName =
+        typeof(WitsmlMetrics).Assembly.GetName();
+
+    internal static readonly string MeterName = AssemblyName.Name;
+
+    private static readonly Meter MeterInstance = new(MeterName, AssemblyName.Version!.ToString());
+
+    private readonly Histogram<long> _requestDuration = MeterInstance.CreateHistogram<long>(
+        "witsml.requests.duration",
+        unit: "s",
+        description: "Time spent during requests to a Witsml server");
+
+    private readonly UpDownCounter<int> _activeRequests =
+        MeterInstance.CreateUpDownCounter<int>(
+            "witsml.requests.active",
+            description: "Number of active requests");
+
+    internal async Task<TResponseType> MeasureQuery<TResponseType>(Uri serverUri, WitsmlMethod method, string witsmlType, Task<TResponseType> wmlsTask)
+        where TResponseType:IWitsmlResponse
+    {
+        var tagList = new TagList
+        {
+            { "host", serverUri.Host },
+            { "method", Enum.GetName(method) },
+            { "objectType", witsmlType },
+        };
+
+        _activeRequests.Add(1, tagList);
+        var timer = Stopwatch.StartNew();
+        TResponseType response = await wmlsTask;
+        timer.Stop();
+        _activeRequests.Add(-1, tagList);
+
+        tagList.Add("resultCode", response.GetResultCode());
+
+        var elapsedSeconds = timer.ElapsedMilliseconds / 1000;
+        _requestDuration.Record(elapsedSeconds, tagList);
+        return response;
+    }
+}

--- a/Src/Witsml/Metrics/WitsmlMetricsExtensions.cs
+++ b/Src/Witsml/Metrics/WitsmlMetricsExtensions.cs
@@ -1,0 +1,17 @@
+using OpenTelemetry.Metrics;
+
+namespace Witsml.Metrics;
+
+public static class WitsmlMetricsExtensions
+{
+    // ReSharper disable once UnusedMember.Global (For usage by external applications)
+    public static MeterProviderBuilder AddWitsmlInstrumentation(this MeterProviderBuilder builder)
+    {
+        builder.AddMeter(WitsmlMetrics.MeterName);
+        builder.AddView("witsml.requests.duration", new ExplicitBucketHistogramConfiguration()
+        {
+            Boundaries = [0.5, 1, 3, 5, 10, 15, 30, 60]
+        });
+        return builder;
+    }
+}

--- a/Src/Witsml/ServiceReference/WitsmlServiceExtensions.cs
+++ b/Src/Witsml/ServiceReference/WitsmlServiceExtensions.cs
@@ -1,12 +1,39 @@
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable InconsistentNaming
 namespace Witsml.ServiceReference
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
-    // ReSharper disable once InconsistentNaming
-    public partial class WMLS_GetFromStoreResponse
+    internal interface IWitsmlResponse
     {
+        public short GetResultCode();
+    }
+
+    public partial class WMLS_GetFromStoreResponse : IWitsmlResponse
+    {
+        public short GetResultCode() => Result;
+
         public override string ToString()
         {
             return $"Result: {Result}\nXMLout: {XMLout}\nSuppMsgOut: {SuppMsgOut}";
         }
+    }
+
+    public partial class WMLS_AddToStoreResponse : IWitsmlResponse
+    {
+        public short GetResultCode() => Result;
+    }
+
+    public partial class WMLS_UpdateInStoreResponse : IWitsmlResponse
+    {
+        public short GetResultCode() => Result;
+    }
+
+    public partial class WMLS_DeleteFromStoreResponse : IWitsmlResponse
+    {
+        public short GetResultCode() => Result;
+    }
+
+    public partial class WMLS_GetCapResponse : IWitsmlResponse
+    {
+        public short GetResultCode() => Result;
     }
 }

--- a/Src/Witsml/ServiceReference/WitsmlServiceExtensions.cs
+++ b/Src/Witsml/ServiceReference/WitsmlServiceExtensions.cs
@@ -4,12 +4,12 @@ namespace Witsml.ServiceReference
 {
     internal interface IWitsmlResponse
     {
-        public short GetResultCode();
+        public string GetResultCode();
     }
 
     public partial class WMLS_GetFromStoreResponse : IWitsmlResponse
     {
-        public short GetResultCode() => Result;
+        public string GetResultCode() => Result.ToString();
 
         public override string ToString()
         {
@@ -19,21 +19,26 @@ namespace Witsml.ServiceReference
 
     public partial class WMLS_AddToStoreResponse : IWitsmlResponse
     {
-        public short GetResultCode() => Result;
+        public string GetResultCode() => Result.ToString();
     }
 
     public partial class WMLS_UpdateInStoreResponse : IWitsmlResponse
     {
-        public short GetResultCode() => Result;
+        public string GetResultCode() => Result.ToString();
     }
 
     public partial class WMLS_DeleteFromStoreResponse : IWitsmlResponse
     {
-        public short GetResultCode() => Result;
+        public string GetResultCode() => Result.ToString();
     }
 
     public partial class WMLS_GetCapResponse : IWitsmlResponse
     {
-        public short GetResultCode() => Result;
+        public string GetResultCode() => Result.ToString();
+    }
+
+    public partial class WMLS_GetVersionResponse : IWitsmlResponse
+    {
+        public string GetResultCode() => Result;
     }
 }

--- a/Src/Witsml/Witsml.csproj
+++ b/Src/Witsml/Witsml.csproj
@@ -1,7 +1,6 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latestMajor</LangVersion>
     <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
@@ -22,9 +21,6 @@
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="System.ServiceModel.Http" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 </Project>

--- a/Src/Witsml/Witsml.csproj
+++ b/Src/Witsml/Witsml.csproj
@@ -1,6 +1,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latestMajor</LangVersion>
     <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
@@ -21,5 +22,9 @@
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="System.ServiceModel.Http" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
   </ItemGroup>
 </Project>

--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -9,6 +9,7 @@ using Serilog;
 
 using Witsml.Data;
 using Witsml.Extensions;
+using Witsml.Metrics;
 using Witsml.ServiceReference;
 using Witsml.Xml;
 
@@ -37,6 +38,7 @@ namespace Witsml
         private readonly StoreSoapPortClient _client;
         private readonly Uri _serverUrl;
         private IQueryLogger _queryLogger;
+        private readonly WitsmlMetrics _witsmlMetrics;
 
         [Obsolete("Use the WitsmlClientOptions based constructor instead")]
         public WitsmlClient(string hostname, string username, string password, WitsmlClientCapabilities clientCapabilities, TimeSpan? requestTimeout = null,
@@ -65,6 +67,7 @@ namespace Witsml
 
             _client = CreateSoapClient(witsmlClientOptions);
 
+            _witsmlMetrics = WitsmlMetrics.Instance;
             SetupQueryLogging(witsmlClientOptions.LogQueries);
         }
 
@@ -132,7 +135,11 @@ namespace Witsml
                 CapabilitiesIn = _clientCapabilities
             };
 
-            WMLS_GetFromStoreResponse response = await _client.WMLS_GetFromStoreAsync(request);
+            WMLS_GetFromStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                _serverUrl,
+                WitsmlMethod.GetFromStore,
+                query.TypeName,
+                _client.WMLS_GetFromStoreAsync(request));
 
             LogQueriesSentAndReceived(nameof(_client.WMLS_GetFromStoreAsync), this._serverUrl, query, optionsIn, request.QueryIn,
                 response.IsSuccessful(), response.XMLout, response.Result, response.SuppMsgOut);
@@ -164,7 +171,11 @@ namespace Witsml
                     CapabilitiesIn = _clientCapabilities
                 };
 
-                WMLS_GetFromStoreResponse response = await _client.WMLS_GetFromStoreAsync(request);
+                WMLS_GetFromStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                    _serverUrl,
+                    WitsmlMethod.GetFromStore,
+                    query.TypeName,
+                    _client.WMLS_GetFromStoreAsync(request));
 
                 LogQueriesSentAndReceived(nameof(_client.WMLS_GetFromStoreAsync), this._serverUrl, query, optionsIn,
                     request.QueryIn, response.IsSuccessful(), response.XMLout, response.Result, response.SuppMsgOut);
@@ -182,7 +193,7 @@ namespace Witsml
             }
         }
 
-        private string GetQueryType(string query)
+        private static string GetQueryType(string query)
         {
             XmlReaderSettings settings = new()
             {
@@ -213,7 +224,12 @@ namespace Witsml
                 CapabilitiesIn = _clientCapabilities
             };
 
-            WMLS_GetFromStoreResponse response = await _client.WMLS_GetFromStoreAsync(request);
+            WMLS_GetFromStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                _serverUrl,
+                WitsmlMethod.GetFromStore,
+                type,
+                _client.WMLS_GetFromStoreAsync(request));
+
             LogQueriesSentAndReceived<IWitsmlQueryType>(nameof(_client.WMLS_GetFromStoreAsync), _serverUrl, null, optionsIn,
                     query, response.IsSuccessful(), response.XMLout, response.Result, response.SuppMsgOut);
 
@@ -237,7 +253,11 @@ namespace Witsml
                     CapabilitiesIn = _clientCapabilities
                 };
 
-                WMLS_AddToStoreResponse response = await _client.WMLS_AddToStoreAsync(request);
+                WMLS_AddToStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                    _serverUrl,
+                    WitsmlMethod.AddToStore,
+                    query.TypeName,
+                    _client.WMLS_AddToStoreAsync(request));
 
                 LogQueriesSentAndReceived(nameof(_client.WMLS_AddToStoreAsync), this._serverUrl, query, optionsIn,
                     request.XMLin, response.IsSuccessful(), null, response.Result, response.SuppMsgOut);
@@ -268,7 +288,12 @@ namespace Witsml
                 CapabilitiesIn = _clientCapabilities
             };
 
-            WMLS_AddToStoreResponse response = await _client.WMLS_AddToStoreAsync(request);
+            WMLS_AddToStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                _serverUrl,
+                WitsmlMethod.AddToStore,
+                type,
+                _client.WMLS_AddToStoreAsync(request));
+
             LogQueriesSentAndReceived<IWitsmlQueryType>(nameof(_client.WMLS_AddToStoreAsync), _serverUrl, null, optionsIn,
                     query, response.IsSuccessful(), null, response.Result, response.SuppMsgOut);
 
@@ -291,7 +316,11 @@ namespace Witsml
                     CapabilitiesIn = _clientCapabilities
                 };
 
-                WMLS_UpdateInStoreResponse response = await _client.WMLS_UpdateInStoreAsync(request);
+                WMLS_UpdateInStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                    _serverUrl,
+                    WitsmlMethod.UpdateInStore,
+                    query.TypeName,
+                    _client.WMLS_UpdateInStoreAsync(request));
 
                 LogQueriesSentAndReceived(nameof(_client.WMLS_UpdateInStoreAsync), this._serverUrl, query, null,
                     request.XMLin, response.IsSuccessful(), null, response.Result, response.SuppMsgOut);
@@ -322,7 +351,12 @@ namespace Witsml
                 CapabilitiesIn = _clientCapabilities
             };
 
-            WMLS_UpdateInStoreResponse response = await _client.WMLS_UpdateInStoreAsync(request);
+            WMLS_UpdateInStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                _serverUrl,
+                WitsmlMethod.UpdateInStore,
+                type,
+                _client.WMLS_UpdateInStoreAsync(request));
+
             LogQueriesSentAndReceived<IWitsmlQueryType>(nameof(_client.WMLS_UpdateInStoreAsync), _serverUrl, null, optionsIn,
                     query, response.IsSuccessful(), null, response.Result, response.SuppMsgOut);
 
@@ -345,7 +379,11 @@ namespace Witsml
                     CapabilitiesIn = _clientCapabilities
                 };
 
-                WMLS_DeleteFromStoreResponse response = await _client.WMLS_DeleteFromStoreAsync(request);
+                WMLS_DeleteFromStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                    _serverUrl,
+                    WitsmlMethod.DeleteFromStore,
+                    query.TypeName,
+                    _client.WMLS_DeleteFromStoreAsync(request));
 
                 LogQueriesSentAndReceived(nameof(_client.WMLS_DeleteFromStoreAsync), this._serverUrl, query, null,
                     request.QueryIn, response.IsSuccessful(), null, response.Result, response.SuppMsgOut);
@@ -376,7 +414,12 @@ namespace Witsml
                 CapabilitiesIn = _clientCapabilities
             };
 
-            WMLS_DeleteFromStoreResponse response = await _client.WMLS_DeleteFromStoreAsync(request);
+            WMLS_DeleteFromStoreResponse response = await _witsmlMetrics.MeasureQuery(
+                _serverUrl,
+                WitsmlMethod.DeleteFromStore,
+                type,
+                _client.WMLS_DeleteFromStoreAsync(request));
+
             LogQueriesSentAndReceived<IWitsmlQueryType>(nameof(_client.WMLS_DeleteFromStoreAsync), _serverUrl, null, optionsIn,
                     query, response.IsSuccessful(), null, response.Result, response.SuppMsgOut);
 
@@ -405,7 +448,11 @@ namespace Witsml
 
         public async Task<WitsmlCapServers> GetCap()
         {
-            WMLS_GetCapResponse response = await _client.WMLS_GetCapAsync(new WMLS_GetCapRequest("dataVersion=1.4.1.1"));
+            WMLS_GetCapResponse response = await _witsmlMetrics.MeasureQuery(
+                _serverUrl,
+                WitsmlMethod.GetCap,
+                "",
+                _client.WMLS_GetCapAsync(new WMLS_GetCapRequest("dataVersion=1.4.1.1")));
 
             if (response.IsSuccessful())
                 return XmlHelper.Deserialize(response.CapabilitiesOut, new WitsmlCapServers());

--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -435,7 +435,7 @@ namespace Witsml
             WMLS_GetVersionResponse response =
                 await _witsmlMetrics.MeasureQuery(
                     _serverUrl,
-                    WitsmlMethod.GetCap,
+                    WitsmlMethod.GetVersion,
                     "",
                     _client.WMLS_GetVersionAsync());
 

--- a/Src/Witsml/WitsmlClient.cs
+++ b/Src/Witsml/WitsmlClient.cs
@@ -432,11 +432,15 @@ namespace Witsml
 
         public async Task<QueryResult> TestConnectionAsync()
         {
-            WMLS_GetVersionResponse response = await _client.WMLS_GetVersionAsync();
+            WMLS_GetVersionResponse response =
+                await _witsmlMetrics.MeasureQuery(
+                    _serverUrl,
+                    WitsmlMethod.GetCap,
+                    "",
+                    _client.WMLS_GetVersionAsync());
+
             if (string.IsNullOrEmpty(response.Result))
-            {
                 throw new Exception("Error while testing connection: Server failed to return a valid version");
-            }
 
             // Spec requires a comma-seperated list of supported versions without spaces
             var versions = response.Result.Split(CommonConstants.DataSeparator);


### PR DESCRIPTION
## Fixes

#2290 

Implements OpenTelemetry metrics:
- witsml_requests_duration_seconds (histogram)
- witsml_requests_active (counter)

## Description

The histogram has been set up with the following buckets: 0.5, 1, 3, 5, 10, 15, 30 and 60 seconds.

When used in an application using the library, the metrics can be added within the `AddOpenTelemetry` method added by the OpenTelementry SDK:

```
services.AddOpenTelemetry()
            .WithMetrics(builder =>
            {
                builder.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("MyApplication"));
                builder.AddWitsmlInstrumentation();

                builder.AddPrometheusExporter();
            });
```

Example from prometheus export:
```
# TYPE witsml_requests_duration_seconds histogram
# UNIT witsml_requests_duration_seconds seconds
# HELP witsml_requests_duration_seconds Time spent during requests to a Witsml server
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="0.5"} 31251 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="1"} 31691 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="3"} 31911 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="5"} 31941 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="10"} 31943 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="15"} 31944 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="30"} 31944 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="60"} 31944 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1",le="+Inf"} 31945 1710160333618
witsml_requests_duration_seconds_sum{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1"} 1171 1710160333618
witsml_requests_duration_seconds_count{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="1"} 31945 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="0.5"} 27621 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="1"} 27876 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="3"} 27979 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="5"} 27993 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="10"} 27993 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="15"} 27993 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="30"} 27994 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="60"} 27994 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1",le="+Inf"} 27994 1710160333618
witsml_requests_duration_seconds_sum{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1"} 563 1710160333618
witsml_requests_duration_seconds_count{host="witsml.somewhere.com",method="GetFromStore",objectType="risk",resultCode="1"} 27994 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="0.5"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="1"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="3"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="5"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="10"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="15"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="30"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="60"} 2 1710160333618
witsml_requests_duration_seconds_bucket{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2",le="+Inf"} 2 1710160333618
witsml_requests_duration_seconds_sum{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2"} 0 1710160333618
witsml_requests_duration_seconds_count{host="witsml.somewhere.com",method="GetFromStore",objectType="log",resultCode="2"} 2 1710160333618

# TYPE witsml_requests_active gauge
# HELP witsml_requests_active Number of active requests
witsml_requests_active{host="witsml.somewhere.com",method="GetFromStore",objectType="log"} 1 1710160333618
witsml_requests_active{host="witsml.somewhere.com",method="GetFromStore",objectType="risk"} 2 1710160333618
```

All metrics are tagged with host, method and objectType. If available, resultCode is also added as a tag.

Note: This has only been tested in a .NET 8 application.

## Type of change

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [ ] API
* [x] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests