### PR TITLE
FIX-2299 Fix empty mnemonics not showing

### DIFF
--- a/Src/WitsmlExplorer.Api/Extensions/WitsmLogExtensions.cs
+++ b/Src/WitsmlExplorer.Api/Extensions/WitsmLogExtensions.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+
 using Witsml.Data;
 
 using WitsmlExplorer.Api.Workers;
@@ -14,6 +17,35 @@ namespace WitsmlExplorer.Api.Extensions
                 WellboreName = witsmlLog.NameWellbore,
                 ObjectName = witsmlLog.Name
             };
+        }
+
+        public static void EnsureIndexCurveIsFirst(this WitsmlLogs witsmlLogs)
+        {
+            foreach (var log in witsmlLogs.Logs)
+            {
+                log.EnsureIndexCurveIsFirst();
+            }
+        }
+
+        public static void EnsureIndexCurveIsFirst(this WitsmlLog witsmlLog)
+        {
+            witsmlLog.LogCurveInfo.EnsureIndexCurveIsFirst(witsmlLog.IndexCurve?.Value);
+        }
+
+        public static void EnsureIndexCurveIsFirst(this IList<WitsmlLogCurveInfo> witsmlLogCurveInfos, string indexCurve)
+        {
+            PlaceIndexCurveFirst(witsmlLogCurveInfos, indexCurve);
+        }
+
+        private static void PlaceIndexCurveFirst(IList<WitsmlLogCurveInfo> witsmlLogCurveInfos, string indexCurve)
+        {
+            if (indexCurve == null) return;
+
+            var indexCurveInfo = witsmlLogCurveInfos.FirstOrDefault(lci => lci.Mnemonic == indexCurve);
+            if (indexCurveInfo == null) return;
+
+            witsmlLogCurveInfos.Remove(indexCurveInfo);
+            witsmlLogCurveInfos.Insert(0, indexCurveInfo);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
+++ b/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
@@ -10,6 +10,7 @@ using Witsml.Data;
 using Witsml.Extensions;
 using Witsml.ServiceReference;
 
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Middleware;
 using WitsmlExplorer.Api.Models;
 using WitsmlExplorer.Api.Models.Measure;
@@ -114,6 +115,7 @@ namespace WitsmlExplorer.Api.Services
         {
             WitsmlLogs query = LogQueries.GetWitsmlLogById(wellUid, wellboreUid, logUid);
             WitsmlLogs result = await _witsmlClient.GetFromStoreAsync(query, new OptionsIn(ReturnElements.HeaderOnly));
+            result.EnsureIndexCurveIsFirst();
             return result.Logs.FirstOrDefault();
         }
 
@@ -183,8 +185,10 @@ namespace WitsmlExplorer.Api.Services
                 }
             }
 
-            string[] witsmlLogMnemonics = witsmlLog.LogData.MnemonicList.Split(CommonConstants.DataSeparator);
-            string[] witsmlLogUnits = witsmlLog.LogData.UnitList.Split(CommonConstants.DataSeparator);
+            List<CurveSpecification> curveSpecifications = log.LogCurveInfo
+                .Where(lci => mnemonics.Contains(lci.Mnemonic))
+                .Select(lci => new CurveSpecification { Mnemonic = lci.Mnemonic, Unit = lci.Unit ?? CommonConstants.Unit.Unitless })
+                .ToList();
 
             return new LogData
             {
@@ -192,8 +196,7 @@ namespace WitsmlExplorer.Api.Services
                 Index.Start(witsmlLog).GetValueAsString(),
                 EndIndex = witsmlLog.EndIndex == null ? endIndex.GetValueAsString() :
                 Index.End(witsmlLog).GetValueAsString(),
-                CurveSpecifications = witsmlLogMnemonics.Zip(witsmlLogUnits, (mnemonic, unit) =>
-                    new CurveSpecification { Mnemonic = mnemonic, Unit = unit }).ToList(),
+                CurveSpecifications = curveSpecifications,
                 Data = GetDataDictionary(witsmlLog.LogData)
             };
         }

--- a/Src/WitsmlExplorer.Api/Workers/Tools/LogWorkerTools.cs
+++ b/Src/WitsmlExplorer.Api/Workers/Tools/LogWorkerTools.cs
@@ -9,6 +9,7 @@ using Witsml.Data;
 using Witsml.Extensions;
 using Witsml.ServiceReference;
 
+using WitsmlExplorer.Api.Extensions;
 using WitsmlExplorer.Api.Jobs.Common.Interfaces;
 using WitsmlExplorer.Api.Query;
 using WitsmlExplorer.Api.Services;
@@ -23,11 +24,7 @@ namespace WitsmlExplorer.Api.Workers
             WitsmlLogs result = await client.GetFromStoreAsync(logQuery, new OptionsIn(optionsInReturnElements));
             WitsmlLog log = result.Logs.FirstOrDefault();
 
-            // Make sure the index curve is the first element in logCurveInfo
-            if (log != null)
-            {
-                log.LogCurveInfo = GetLogCurveInfoWithIndexCurveFirst(log);
-            }
+            log?.EnsureIndexCurveIsFirst();
 
             return log;
         }
@@ -37,20 +34,9 @@ namespace WitsmlExplorer.Api.Workers
             WitsmlLogs logQuery = LogQueries.GetWitsmlLogsByIds(wellUid, wellboreUid, logUids);
             WitsmlLogs result = await client.GetFromStoreAsync(logQuery, new OptionsIn(optionsInReturnElements));
 
-            // Make sure the index curve is the first element in logCurveInfo
-            foreach (var log in result.Logs)
-            {
-                log.LogCurveInfo = GetLogCurveInfoWithIndexCurveFirst(log);
-            }
+            result?.EnsureIndexCurveIsFirst();
 
             return result;
-        }
-
-        public static List<WitsmlLogCurveInfo> GetLogCurveInfoWithIndexCurveFirst(WitsmlLog log)
-        {
-            string indexCurve = log.IndexCurve?.Value;
-            if (indexCurve == null || log.LogCurveInfo.FirstOrDefault().Mnemonic == indexCurve) return log.LogCurveInfo;
-            return log.LogCurveInfo.OrderBy(lci => lci.Mnemonic == indexCurve ? 0 : 1).ToList();
         }
 
         public static async Task<WitsmlLogData> GetLogDataForCurve(IWitsmlClient witsmlClient, WitsmlLog log, string mnemonic, ILogger logger)

--- a/Src/WitsmlExplorer.Frontend/hooks/useGetMnemonics.tsx
+++ b/Src/WitsmlExplorer.Frontend/hooks/useGetMnemonics.tsx
@@ -53,7 +53,7 @@ export function useGetMnemonics(
 }
 
 const getExistingMnemonics = (logCurveInfoList: LogCurveInfo[]) => {
-  return logCurveInfoList.slice(1).map((logCurveInfo) => logCurveInfo.mnemonic); // splice(1) to skip index curve
+  return logCurveInfoList.slice(1).map((logCurveInfo) => logCurveInfo.mnemonic); // slice(1) to skip index curve
 };
 
 const getMnemonicsFromSearchParams = (mnemonicsSearchParams: string) => {

--- a/Tests/WitsmlExplorer.Api.Tests/Extensions/WitsmlLogExtensionsTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Extensions/WitsmlLogExtensionsTests.cs
@@ -1,18 +1,19 @@
 using System.Collections.Generic;
+using System.Text.Json;
 
 using Witsml;
 using Witsml.Data;
 
-using WitsmlExplorer.Api.Workers;
+using WitsmlExplorer.Api.Extensions;
 
 using Xunit;
 
-namespace WitsmlExplorer.Api.Tests.Workers
+namespace WitsmlExplorer.Api.Tests.Extensions
 {
-    public class LogWorkerToolsTests
+    public class WitsmlLogExtensionsTests
     {
         [Fact]
-        public void GetLogCurveInfoWithIndexCurveFirst_IndexCurveIsNotFirst_MovesIndexCurveFirst()
+        public void EnsureIndexCurveIsFirst_IndexCurveIsNotFirst_MovesIndexCurveFirst()
         {
             WitsmlLog log = new WitsmlLog()
             {
@@ -46,7 +47,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 }
             };
 
-            List<WitsmlLogCurveInfo> resultLCI = LogWorkerTools.GetLogCurveInfoWithIndexCurveFirst(log);
+            log.EnsureIndexCurveIsFirst();
+            List<WitsmlLogCurveInfo> resultLCI = log.LogCurveInfo;
 
             Assert.Equal("IndexCurve", resultLCI[0].Mnemonic);
             Assert.Equal("Curve3", resultLCI[1].Mnemonic);
@@ -55,7 +57,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         }
 
         [Fact]
-        public void GetLogCurveInfoWithIndexCurveFirst_CorrectLCI_StaysUnchanged()
+        public void EnsureIndexCurveIsFirst_CorrectLCI_StaysUnchanged()
         {
             WitsmlLog log = new WitsmlLog()
             {
@@ -89,9 +91,13 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 }
             };
 
-            List<WitsmlLogCurveInfo> resultLCI = LogWorkerTools.GetLogCurveInfoWithIndexCurveFirst(log);
+            var originalLog = JsonSerializer.Serialize(log, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
 
-            Assert.Equal(log.LogCurveInfo, resultLCI);
+            log.EnsureIndexCurveIsFirst();
+
+            var newLog = JsonSerializer.Serialize(log, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+
+            Assert.Equal(originalLog, newLog);
         }
     }
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2299 

* As some servers do not return mnemonics that does not have data in the LogData object, I take the mnemonics and names from the LCI instead of the mnemonic/unit lists.
* Added extension methods to move the index curve first in the LCI list.

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [x] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


