### PR TITLE
FIX-2295 Content view panel style

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -1,4 +1,9 @@
-import { Radio, Switch, Typography } from "@equinor/eds-core-react";
+import {
+  EdsProvider,
+  Radio,
+  Switch,
+  Typography
+} from "@equinor/eds-core-react";
 import { CSSProperties } from "@material-ui/core/styles/withStyles";
 import {
   MILLIS_IN_SECOND,
@@ -27,7 +32,7 @@ import ProgressSpinner from "components/ProgressSpinner";
 import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationContext from "contexts/operationContext";
-import { DispatchOperation } from "contexts/operationStateReducer";
+import { DispatchOperation, UserTheme } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
@@ -609,8 +614,16 @@ export const CurveValuesView = (): React.ReactElement => {
             overrideEndIndex={autoRefresh ? getCurrentMaxIndex() : null}
             onClickRefresh={() => refreshData()}
           />
-          <Switch checked={showPlot} onChange={() => setShowPlot(!showPlot)} />
-          <Typography>Show Plot</Typography>
+          <EdsProvider density={theme}>
+            <Switch
+              checked={showPlot}
+              onChange={() => setShowPlot(!showPlot)}
+              size={theme === UserTheme.Compact ? "small" : "default"}
+            />
+            <Typography style={{ minWidth: "max-content" }}>
+              Show Plot
+            </Typography>
+          </EdsProvider>
           {log?.objectGrowing && (
             <>
               <Switch checked={autoRefresh} onChange={onClickAutoRefresh} />

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/EditSelectedLogCurveInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/EditSelectedLogCurveInfo.tsx
@@ -3,8 +3,7 @@ import {
   EdsProvider,
   Icon,
   Label,
-  TextField,
-  Typography
+  TextField
 } from "@equinor/eds-core-react";
 import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
@@ -156,16 +155,8 @@ const EditSelectedLogCurveInfo = (
     selectedMnemonics && (
       <EdsProvider density={theme}>
         <Layout colors={colors}>
-          <Typography
-            style={{
-              color: `${colors.interactive.primaryResting}`
-            }}
-            variant="h3"
-          >
-            Curve Values
-          </Typography>
           <StartEndIndex>
-            <StyledLabel label="Start Index" />
+            <StyledLabel label="Start Index:" colors={colors} />
             <StyledTextField
               disabled={disabled}
               id="startIndex"
@@ -179,7 +170,7 @@ const EditSelectedLogCurveInfo = (
             />
           </StartEndIndex>
           <StartEndIndex>
-            <StyledLabel label="End Index" />
+            <StyledLabel label="End Index:" colors={colors} />
             <StyledTextField
               disabled={disabled}
               id="endIndex"
@@ -193,8 +184,8 @@ const EditSelectedLogCurveInfo = (
             />
           </StartEndIndex>
           <StartEndIndex>
-            <StyledLabel label="Mnemonics" />
-            <Autocomplete
+            <StyledLabel label="Mnemonics:" colors={colors} />
+            <StyledAutocomplete
               id={"mnemonics"}
               disabled={disabled || isFetching}
               label={""}
@@ -211,10 +202,11 @@ const EditSelectedLogCurveInfo = (
                 } as CSSProperties
               }
               dropdownHeight={600}
+              colors={colors}
             />
           </StartEndIndex>
           <Button
-            variant={"ghost"}
+            variant={"ghost_icon"}
             onClick={submitLogCurveInfo}
             disabled={
               disabled ||
@@ -245,6 +237,12 @@ const getParsedValue = (input: string, isTimeLog: boolean) => {
     : input;
 };
 
+const StyledAutocomplete = styled(Autocomplete)<{ colors: Colors }>`
+  button {
+    color: ${(props) => props.colors.infographic.primaryMossGreen};
+  }
+`;
+
 const Layout = styled.div<{ colors: Colors }>`
   display: flex;
   gap: 0.25rem;
@@ -258,7 +256,8 @@ const StartEndIndex = styled.div`
   display: flex;
 `;
 
-const StyledLabel = styled(Label)`
+const StyledLabel = styled(Label)<{ colors: Colors }>`
+  color: ${(props) => props.colors.infographic.primaryMossGreen};
   white-space: nowrap;
   align-items: center;
   font-style: italic;


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2295 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

This PR will update the styling of the curve values view panel to match the other views. The original plan was to relocate the refresh button closer to the content table panel, where the filter and download buttons are. However, since the button is used in other parts of the curve values view, it is hard to move it.

How it looks now:
![image](https://github.com/equinor/witsml-explorer/assets/48485965/d115ca5c-8070-4cd5-b63e-8d7fcd226350)

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


