### PR TITLE
FIX-2135 Move fonts to global.css

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,9 +265,8 @@ Verify successful deployment by accessing the url in browser or postman; Expect 
 		https://localhost/witsmlexplorerbackend/api/witsml-servers
 		
 #### Deploy Frontend
-Edit .env.local file in WitsmlExplorer.Frontend project and set these values
+Edit .env.local file in WitsmlExplorer.Frontend project and set this value
 ```
-	NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL=https://localhost/witsmlexplorer
 	NEXT_PUBLIC_WITSMLEXPLORER_API_URL=https://localhost/witsmlexplorerbackend
 ```
 

--- a/Src/WitsmlExplorer.Frontend/components/AssetsLoader.ts
+++ b/Src/WitsmlExplorer.Frontend/components/AssetsLoader.ts
@@ -1,6 +1,0 @@
-export class AssetsLoader {
-  static getAssetsRoot(): string {
-    const wePath = process.env.NEXT_PUBLIC_WITSMLEXPLORER_FRONTEND_URL;
-    return wePath && wePath.length > 0 ? new URL(wePath).pathname : "";
-  }
-}

--- a/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
@@ -1,33 +1,7 @@
-import { AssetsLoader } from "components/AssetsLoader";
 import { createGlobalStyle } from "styled-components";
 import { Colors } from "styles/Colors";
 
 const GlobalStyles = createGlobalStyle<{ colors: Colors }>`
-  @font-face {
-    font-family: "Equinor";
-    src: url("${AssetsLoader.getAssetsRoot()}/assets/fonts/Equinor-Regular.woff2");
-    font-weight: normal;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: "EquinorRegular";
-    src: url("${AssetsLoader.getAssetsRoot()}/assets/fonts/Equinor-Regular.woff2");
-    font-weight: normal;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: "EquinorBold";
-    src: url("${AssetsLoader.getAssetsRoot()}/assets/fonts/Equinor-Bold.woff2");
-    font-weight: normal;
-    font-style: normal;
-  }
-  @font-face {
-    font-family: "EquinorMedium";
-    src: url("${AssetsLoader.getAssetsRoot()}/assets/fonts/Equinor-Medium.woff2");
-    font-weight: normal;
-    font-style: normal;
-  }
-
 *,
 *:before,
 *:after {

--- a/Src/WitsmlExplorer.Frontend/pages/_app.tsx
+++ b/Src/WitsmlExplorer.Frontend/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { AppProps } from "next/app";
 import { useEffect, useState } from "react";
+import "styles/global.css";
 
 export default function App({ Component, pageProps }: AppProps) {
   const [render, setRender] = useState(false);

--- a/Src/WitsmlExplorer.Frontend/routes/Root.tsx
+++ b/Src/WitsmlExplorer.Frontend/routes/Root.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from "@material-ui/core";
 import Head from "next/head";
 import { SnackbarProvider } from "notistack";
 import { useEffect } from "react";
-import { AssetsLoader } from "../components/AssetsLoader";
 import ContextMenuPresenter from "../components/ContextMenus/ContextMenuPresenter";
 import GlobalStyles from "../components/GlobalStyles";
 import ModalPresenter from "../components/Modals/ModalPresenter";
@@ -110,7 +109,7 @@ export default function Root() {
     <>
       <Head>
         <title>WITSML Explorer</title>
-        <link rel="icon" href={AssetsLoader.getAssetsRoot() + "/favicon.ico"} />
+        <link rel="icon" href={"/favicon.ico"} />
       </Head>
       <MsalProvider instance={msalInstance}>
         {msalEnabled && (

--- a/Src/WitsmlExplorer.Frontend/styles/global.css
+++ b/Src/WitsmlExplorer.Frontend/styles/global.css
@@ -1,0 +1,24 @@
+@font-face {
+  font-family: "Equinor";
+  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/assets/font/Equinor-Regular.woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: "EquinorRegular";
+  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/font/Equinor-Regular.woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: "EquinorBold";
+  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/font/Equinor-Bold.woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+@font-face {
+  font-family: "EquinorMedium";
+  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/font/Equinor-Medium.woff2");
+  font-weight: normal;
+  font-style: normal;
+}

--- a/Src/WitsmlExplorer.Frontend/styles/global.css
+++ b/Src/WitsmlExplorer.Frontend/styles/global.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Equinor";
-  src:  url(//cdn.eds.equinor.com/font/Equinor-Regular.woff2) format('woff2');
+  src:  url("/assets/fonts/Equinor-Regular.woff2");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorRegular";
-  src:  url(//cdn.eds.equinor.com/font/Equinor-Regular.woff2) format('woff2');
+  src:  url("/assets/fonts/Equinor-Regular.woff2");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorBold";
-  src:  url(//cdn.eds.equinor.com/font/Equinor-Bold.woff2) format('woff2');
+  src:  url("/assets/fonts/Equinor-Bold.woff2");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorMedium";
-  src:  url(//cdn.eds.equinor.com/font/Equinor-Medium.woff2) format('woff2');
+  src:  url("/assets/fonts/Equinor-Medium.woff2");
   font-weight: normal;
   font-style: normal;
 }

--- a/Src/WitsmlExplorer.Frontend/styles/global.css
+++ b/Src/WitsmlExplorer.Frontend/styles/global.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Equinor";
-  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/assets/font/Equinor-Regular.woff2");
+  src:  url(//cdn.eds.equinor.com/font/Equinor-Regular.woff2) format('woff2');
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorRegular";
-  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/font/Equinor-Regular.woff2");
+  src:  url(//cdn.eds.equinor.com/font/Equinor-Regular.woff2) format('woff2');
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorBold";
-  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/font/Equinor-Bold.woff2");
+  src:  url(//cdn.eds.equinor.com/font/Equinor-Bold.woff2) format('woff2');
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorMedium";
-  src: url("https://s478-cdne-edsartefacts-prod.azureedge.net/font/Equinor-Medium.woff2");
+  src:  url(//cdn.eds.equinor.com/font/Equinor-Medium.woff2) format('woff2');
   font-weight: normal;
   font-style: normal;
 }

--- a/Src/WitsmlExplorer.Frontend/styles/global.css
+++ b/Src/WitsmlExplorer.Frontend/styles/global.css
@@ -1,24 +1,24 @@
 @font-face {
   font-family: "Equinor";
-  src:  url("/assets/fonts/Equinor-Regular.woff2");
+  src: url("/assets/fonts/Equinor-Regular.woff2");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorRegular";
-  src:  url("/assets/fonts/Equinor-Regular.woff2");
+  src: url("/assets/fonts/Equinor-Regular.woff2");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorBold";
-  src:  url("/assets/fonts/Equinor-Bold.woff2");
+  src: url("/assets/fonts/Equinor-Bold.woff2");
   font-weight: normal;
   font-style: normal;
 }
 @font-face {
   font-family: "EquinorMedium";
-  src:  url("/assets/fonts/Equinor-Medium.woff2");
+  src: url("/assets/fonts/Equinor-Medium.woff2");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2135 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

This PR moves fonts from `GlobalStyle.tsx` to `global.css`, allowing for one-time loading.


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


