### PR TITLE
Job view crashes for jobs with many report items #2311

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -100,5 +100,11 @@ namespace WitsmlExplorer.Api.HttpHandlers
             }
             return TypedResults.NotFound();
         }
+
+        [Produces(typeof(IEnumerable<object>))]
+        public static IResult GetReportItems(string jobId, IJobCache jobCache)
+        {
+            return TypedResults.Ok(jobCache.GetReportItems(jobId));
+        }
     }
 }

--- a/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/JobHandler.cs
@@ -3,8 +3,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Amazon.Runtime;
-
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -119,7 +117,7 @@ namespace WitsmlExplorer.Api.HttpHandlers
             {
                 return TypedResults.Forbid();
             }
-            return TypedResults.Ok(jobCache.GetReportByJobId(jobId));
+            return TypedResults.Ok(job.Report);
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
@@ -49,6 +49,7 @@ namespace WitsmlExplorer.Api.Jobs
 
         public double Progress { get; set; }
 
+        [JsonIgnore]
         public BaseReport Report { get; set; }
 
         public bool IsCancelable { get; internal set; } = false;
@@ -73,6 +74,17 @@ namespace WitsmlExplorer.Api.Jobs
             }
         }
 
+        public string LinkType
+        {
+            get
+            {
+                if (Report?.DownloadImmediately == true)
+                {
+                    return "Donwload file";
+                }
+                return "Report";
+            }
+        }
     }
 
     public enum JobStatus

--- a/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/JobInfo.cs
@@ -74,15 +74,16 @@ namespace WitsmlExplorer.Api.Jobs
             }
         }
 
-        public string LinkType
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public ReportType ReportType
         {
             get
             {
                 if (Report?.DownloadImmediately == true)
                 {
-                    return "Donwload file";
+                    return ReportType.File;
                 }
-                return "Report";
+                return ReportType.Report;
             }
         }
     }
@@ -93,5 +94,11 @@ namespace WitsmlExplorer.Api.Jobs
         Finished,
         Failed,
         Cancelled
+    }
+
+    public enum ReportType
+    {
+        File,
+        Report
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/Reports/BaseReport.cs
+++ b/Src/WitsmlExplorer.Api/Models/Reports/BaseReport.cs
@@ -9,6 +9,6 @@ namespace WitsmlExplorer.Api.Models.Reports
         public IEnumerable<object> ReportItems { get; init; }
         public string WarningMessage { get; init; }
         public bool DownloadImmediately { get; init; } = false;
-        public string ReportHeader { get; init; } = null;
+        public string ReportHeader { get; init; }
     }
 }

--- a/Src/WitsmlExplorer.Api/Models/Reports/BaseReport.cs
+++ b/Src/WitsmlExplorer.Api/Models/Reports/BaseReport.cs
@@ -9,5 +9,6 @@ namespace WitsmlExplorer.Api.Models.Reports
         public IEnumerable<object> ReportItems { get; init; }
         public string WarningMessage { get; init; }
         public bool DownloadImmediately { get; init; } = false;
+        public string ReportHeader { get; init; } = null;
     }
 }

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -95,7 +95,7 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/userjobinfo/{jobId}", JobHandler.GetUserJobInfo, useOAuth2);
             app.MapGet("/jobs/alljobinfos", JobHandler.GetAllJobInfos, useOAuth2, AuthorizationPolicyRoles.ADMINORDEVELOPER);
             app.MapPost("/jobs/cancel/{jobId}", JobHandler.CancelJob, useOAuth2);
-            app.MapGet("/jobs/getreportitems/{jobId}", JobHandler.GetReportItems, useOAuth2);
+            app.MapGet("/jobs/getreport/{jobId}", JobHandler.GetReport, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -95,6 +95,7 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/userjobinfo/{jobId}", JobHandler.GetUserJobInfo, useOAuth2);
             app.MapGet("/jobs/alljobinfos", JobHandler.GetAllJobInfos, useOAuth2, AuthorizationPolicyRoles.ADMINORDEVELOPER);
             app.MapPost("/jobs/cancel/{jobId}", JobHandler.CancelJob, useOAuth2);
+            app.MapGet("/jobs/getreportitems/{jobId}", JobHandler.GetReportItems, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);

--- a/Src/WitsmlExplorer.Api/Routes.cs
+++ b/Src/WitsmlExplorer.Api/Routes.cs
@@ -95,7 +95,7 @@ namespace WitsmlExplorer.Api
             app.MapGet("/jobs/userjobinfo/{jobId}", JobHandler.GetUserJobInfo, useOAuth2);
             app.MapGet("/jobs/alljobinfos", JobHandler.GetAllJobInfos, useOAuth2, AuthorizationPolicyRoles.ADMINORDEVELOPER);
             app.MapPost("/jobs/cancel/{jobId}", JobHandler.CancelJob, useOAuth2);
-            app.MapGet("/jobs/getreport/{jobId}", JobHandler.GetReport, useOAuth2);
+            app.MapGet("/jobs/report/{jobId}", JobHandler.GetReport, useOAuth2);
 
             app.MapGet("/credentials/authorize", AuthorizeHandler.Authorize, useOAuth2);
             app.MapGet("/credentials/deauthorize", AuthorizeHandler.Deauthorize, useOAuth2);

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -68,7 +68,7 @@ namespace WitsmlExplorer.Api.Services
             return HandleBigData(allJobs);
         }
 
-        public IEnumerable<object> GetReportItems (string jobId)
+        public IEnumerable<object> GetReportItems(string jobId)
         {
             var job = _jobs[jobId];
             if (job != null)
@@ -108,7 +108,7 @@ namespace WitsmlExplorer.Api.Services
             var resultJobs = new List<JobInfo>();
             foreach (var job in allJobs)
             {
-                if (job.Report!= null && job.Report.DownloadImmediately)
+                if (job.Report != null && job.Report.DownloadImmediately)
                 {
                     var copyJob = job with { Report = new BaseReport() { Title = job.Report?.Title, ReportHeader = job.Report?.ReportHeader, DownloadImmediately = true } };
                     resultJobs.Add(copyJob);

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -19,7 +19,6 @@ namespace WitsmlExplorer.Api.Services
         ICollection<JobInfo> GetJobInfosByUser(string username);
         JobInfo GetJobInfoById(string jobId);
         ICollection<JobInfo> GetAllJobInfos();
-        BaseReport GetReportByJobId(string jobId);
     }
 
     public class JobCache : IJobCache
@@ -64,16 +63,6 @@ namespace WitsmlExplorer.Api.Services
         public ICollection<JobInfo> GetAllJobInfos()
         {
             return _jobs.Values.ToList();
-        }
-
-        public BaseReport GetReportByJobId(string jobId)
-        {
-            var job = _jobs[jobId];
-            if (job != null)
-            {
-                return job.Report;
-            }
-            return null;
         }
 
         private void Cleanup()

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -4,12 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-using DnsClient.Protocol.Options;
-
 using Microsoft.Extensions.Logging;
 
 using WitsmlExplorer.Api.Jobs;
-using WitsmlExplorer.Api.Models.Reports;
 
 namespace WitsmlExplorer.Api.Services
 {
@@ -62,7 +59,7 @@ namespace WitsmlExplorer.Api.Services
 
         public ICollection<JobInfo> GetAllJobInfos()
         {
-            return _jobs.Values.ToList();
+            return _jobs.Values;
         }
 
         private void Cleanup()

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -19,7 +19,7 @@ namespace WitsmlExplorer.Api.Services
         ICollection<JobInfo> GetJobInfosByUser(string username);
         JobInfo GetJobInfoById(string jobId);
         ICollection<JobInfo> GetAllJobInfos();
-        IEnumerable<object> GetReportItems(string jobId);
+        BaseReport GetReportByJobId(string jobId);
     }
 
     public class JobCache : IJobCache
@@ -53,8 +53,7 @@ namespace WitsmlExplorer.Api.Services
 
         public ICollection<JobInfo> GetJobInfosByUser(string username)
         {
-            var allJobs = _jobs.Values.Where(job => job.Username == username).ToList();
-            return HandleBigData(allJobs);
+            return _jobs.Values.Where(job => job.Username == username).ToList();
         }
 
         public JobInfo GetJobInfoById(string jobId)
@@ -64,17 +63,15 @@ namespace WitsmlExplorer.Api.Services
 
         public ICollection<JobInfo> GetAllJobInfos()
         {
-            var allJobs = _jobs.Values.ToList();
-            return HandleBigData(allJobs);
+            return _jobs.Values.ToList();
         }
 
-        public IEnumerable<object> GetReportItems(string jobId)
+        public BaseReport GetReportByJobId(string jobId)
         {
             var job = _jobs[jobId];
             if (job != null)
             {
-                var reportItems = job.Report?.ReportItems;
-                return reportItems;
+               return job.Report;
             }
             return null;
         }
@@ -101,21 +98,6 @@ namespace WitsmlExplorer.Api.Services
                 }
             }
             _logger.LogInformation("JobCache cleanup finished, deleted: {deleted}, failed: {failed}, remaining: {remaining}", deleted, failed, _jobs.Count);
-        }
-
-        private static ICollection<JobInfo> HandleBigData(ICollection<JobInfo> allJobs)
-        {
-            var resultJobs = new List<JobInfo>();
-            foreach (var job in allJobs)
-            {
-                if (job.Report != null && job.Report.DownloadImmediately)
-                {
-                    var copyJob = job with { Report = new BaseReport() { Title = job.Report?.Title, ReportHeader = job.Report?.ReportHeader, DownloadImmediately = true } };
-                    resultJobs.Add(copyJob);
-                }
-                else { resultJobs.Add(job); }
-            }
-            return resultJobs;
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/JobCache.cs
+++ b/Src/WitsmlExplorer.Api/Services/JobCache.cs
@@ -71,7 +71,7 @@ namespace WitsmlExplorer.Api.Services
             var job = _jobs[jobId];
             if (job != null)
             {
-               return job.Report;
+                return job.Report;
             }
             return null;
         }

--- a/Src/WitsmlExplorer.Api/Workers/DownloadAllLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DownloadAllLogDataWorker.cs
@@ -64,14 +64,14 @@ public class DownloadAllLogDataWorker : BaseWorker<DownloadAllLogDataJob>, IWork
             LogReference = logReference,
             ReportItems = reportItems,
             DownloadImmediately = true,
-            ReportHeader= reportHeader
+            ReportHeader = reportHeader
         };
     }
 
-    private string GetReportHeader (ICollection<CurveSpecification> curveSpecifications)   
+    private string GetReportHeader(ICollection<CurveSpecification> curveSpecifications)
     {
         var listOfHeaders = new List<string>();
-        foreach(CurveSpecification curveSpec in curveSpecifications)
+        foreach (CurveSpecification curveSpec in curveSpecifications)
         {
             listOfHeaders.Add($"{curveSpec.Mnemonic}[{curveSpec.Unit}]");
         }

--- a/Src/WitsmlExplorer.Api/Workers/DownloadAllLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DownloadAllLogDataWorker.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/Src/WitsmlExplorer.Api/Workers/DownloadAllLogDataWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/DownloadAllLogDataWorker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -43,18 +44,18 @@ public class DownloadAllLogDataWorker : BaseWorker<DownloadAllLogDataJob>, IWork
             if (job.JobInfo != null) job.JobInfo.Progress = progress;
         });
         var logData = await _logObjectService.ReadLogData(job.LogReference.WellUid, job.LogReference.WellboreUid, job.LogReference.Uid, job.Mnemonics.ToList(), job.StartIndexIsInclusive, job.LogReference.StartIndex, job.LogReference.EndIndex, true, cancellationToken, progressReporter);
-        return DownloadAllLogDataResult(job, logData.Data, job.LogReference.Uid);
+        return DownloadAllLogDataResult(job, logData.Data, logData.CurveSpecifications);
     }
 
-    private (WorkerResult, RefreshAction) DownloadAllLogDataResult(DownloadAllLogDataJob job, ICollection<Dictionary<string, LogDataValue>> reportItems, string logUid)
+    private (WorkerResult, RefreshAction) DownloadAllLogDataResult(DownloadAllLogDataJob job, ICollection<Dictionary<string, LogDataValue>> reportItems, ICollection<CurveSpecification> curveSpecifications)
     {
         Logger.LogInformation("Download of all data is done. {jobDescription}", job.Description());
-        job.JobInfo.Report = DownloadAllLogDataReport(reportItems, job.LogReference);
+        job.JobInfo.Report = DownloadAllLogDataReport(reportItems, job.LogReference, GetReportHeader(curveSpecifications));
         WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Download of all data is ready, jobId: ", jobId: job.JobInfo.Id);
         return (workerResult, null);
     }
 
-    private DownloadAllLogDataReport DownloadAllLogDataReport(ICollection<Dictionary<string, LogDataValue>> reportItems, LogObject logReference)
+    private DownloadAllLogDataReport DownloadAllLogDataReport(ICollection<Dictionary<string, LogDataValue>> reportItems, LogObject logReference, string reportHeader)
     {
         return new DownloadAllLogDataReport
         {
@@ -62,7 +63,18 @@ public class DownloadAllLogDataWorker : BaseWorker<DownloadAllLogDataJob>, IWork
             Summary = "You can download the report as csv file",
             LogReference = logReference,
             ReportItems = reportItems,
-            DownloadImmediately = true
+            DownloadImmediately = true,
+            ReportHeader= reportHeader
         };
+    }
+
+    private string GetReportHeader (ICollection<CurveSpecification> curveSpecifications)   
+    {
+        var listOfHeaders = new List<string>();
+        foreach(CurveSpecification curveSpec in curveSpecifications)
+        {
+            listOfHeaders.Add($"{curveSpec.Mnemonic}[{curveSpec.Unit}]");
+        }
+        return string.Join(',', listOfHeaders);
     }
 }

--- a/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
@@ -34,6 +34,7 @@ import ObjectOnWellbore from "models/objectOnWellbore";
 import ObjectSearchResult from "models/objectSearchResult";
 import { ObjectType, ObjectTypeToModel } from "models/objectType";
 import RefNameString from "models/refNameString";
+import BaseReport from "models/reports/BaseReport";
 import Rig from "models/rig";
 import RiskObject from "models/riskObject";
 import { Server } from "models/server";
@@ -196,6 +197,17 @@ export function getJobInfo(overrides?: Partial<JobInfo>): JobInfo {
     isCancelable: false,
     linkType: "",
     ...overrides
+  };
+}
+
+export function getReport(): BaseReport {
+  return {
+    title: "testTitle",
+    summary: "testSummary",
+    reportItems: [],
+    warningMessage: "",
+    downloadImmediately: false,
+    reportHeader: ""
   };
 }
 

--- a/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
@@ -192,7 +192,6 @@ export function getJobInfo(overrides?: Partial<JobInfo>): JobInfo {
     killTime: "",
     status: null,
     failedReason: "",
-    report: null,
     progress: 0,
     isCancelable: false,
     reportType: null,

--- a/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
@@ -194,6 +194,7 @@ export function getJobInfo(overrides?: Partial<JobInfo>): JobInfo {
     report: null,
     progress: 0,
     isCancelable: false,
+    linkType: "",
     ...overrides
   };
 }

--- a/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
@@ -195,7 +195,7 @@ export function getJobInfo(overrides?: Partial<JobInfo>): JobInfo {
     report: null,
     progress: 0,
     isCancelable: false,
-    linkType: "",
+    reportType: null,
     ...overrides
   };
 }

--- a/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/__testUtils__/testUtils.tsx
@@ -190,7 +190,7 @@ export function getJobInfo(overrides?: Partial<JobInfo>): JobInfo {
     startTime: "",
     endTime: "",
     killTime: "",
-    status: "",
+    status: null,
     failedReason: "",
     report: null,
     progress: 0,
@@ -200,14 +200,15 @@ export function getJobInfo(overrides?: Partial<JobInfo>): JobInfo {
   };
 }
 
-export function getReport(): BaseReport {
+export function getReport(overrides?: Partial<BaseReport>): BaseReport {
   return {
     title: "testTitle",
     summary: "testSummary",
     reportItems: [],
     warningMessage: "",
     downloadImmediately: false,
-    reportHeader: ""
+    reportHeader: "",
+    ...overrides
   };
 }
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -19,6 +19,7 @@ import { refreshJobInfoQuery } from "hooks/query/queryRefreshHelpers";
 import { useGetJobInfo } from "hooks/query/useGetJobInfo";
 import { useGetServers } from "hooks/query/useGetServers";
 import useExport from "hooks/useExport";
+import JobStatus from "models/jobStatus";
 import { Server } from "models/server";
 import {
   adminRole,
@@ -132,6 +133,10 @@ export const JobsView = (): React.ReactElement => {
             wellName: jobInfo.wellName,
             wellboreName: jobInfo.wellboreName,
             objectName: jobInfo.objectName,
+            status:
+              jobInfo.progress && jobInfo.status === JobStatus.Started
+                ? `${Math.round(jobInfo.progress * 100)}%`
+                : jobInfo.status,
             startTime: formatDateString(
               jobInfo.startTime,
               timeZone,
@@ -145,7 +150,7 @@ export const JobsView = (): React.ReactElement => {
             targetServer: serverUrlToName(servers, jobInfo.targetServer),
             sourceServer: serverUrlToName(servers, jobInfo.sourceServer),
             report:
-              jobInfo.status === "Finished" ? (
+              jobInfo.status === JobStatus.Finished ? (
                 <ReportButton onClick={() => onClickReport(jobInfo.id)}>
                   {jobInfo.linkType}
                 </ReportButton>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -152,7 +152,7 @@ export const JobsView = (): React.ReactElement => {
             report:
               jobInfo.status === JobStatus.Finished ? (
                 <ReportButton onClick={() => onClickReport(jobInfo.id)}>
-                  {jobInfo.linkType}
+                  {jobInfo.reportType}
                 </ReportButton>
               ) : null,
             jobInfo: jobInfo

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -19,7 +19,6 @@ import { refreshJobInfoQuery } from "hooks/query/queryRefreshHelpers";
 import { useGetJobInfo } from "hooks/query/useGetJobInfo";
 import { useGetServers } from "hooks/query/useGetServers";
 import useExport from "hooks/useExport";
-import BaseReport from "models/reports/BaseReport";
 import { Server } from "models/server";
 import {
   adminRole,
@@ -67,10 +66,13 @@ export const JobsView = (): React.ReactElement => {
     });
   };
 
-  const onClickReport = async (report: BaseReport, jobId: string) => {
+  const onClickReport = async (jobId: string) => {
+    const report = await JobService.getReport(jobId);
     if (report.downloadImmediately === true) {
-      const reportItems = await JobService.getReportItems(jobId);
-      const reportProperties = generateReport(reportItems, report.reportHeader);
+      const reportProperties = generateReport(
+        report.reportItems,
+        report.reportHeader
+      );
       exportData(
         report.title,
         reportProperties.exportColumns,
@@ -130,10 +132,6 @@ export const JobsView = (): React.ReactElement => {
             wellName: jobInfo.wellName,
             wellboreName: jobInfo.wellboreName,
             objectName: jobInfo.objectName,
-            status:
-              jobInfo.progress && jobInfo.status === "Started"
-                ? `${Math.round(jobInfo.progress * 100)}%`
-                : jobInfo.status,
             startTime: formatDateString(
               jobInfo.startTime,
               timeZone,
@@ -146,15 +144,12 @@ export const JobsView = (): React.ReactElement => {
             ),
             targetServer: serverUrlToName(servers, jobInfo.targetServer),
             sourceServer: serverUrlToName(servers, jobInfo.sourceServer),
-            report: jobInfo.report ? (
-              <ReportButton
-                onClick={() => onClickReport(jobInfo.report, jobInfo.id)}
-              >
-                {jobInfo.report.downloadImmediately === true
-                  ? "Donwload file"
-                  : "Report"}
-              </ReportButton>
-            ) : null,
+            report:
+              jobInfo.status === "Finished" ? (
+                <ReportButton onClick={() => onClickReport(jobInfo.id)}>
+                  {jobInfo.linkType}
+                </ReportButton>
+              ) : null,
             jobInfo: jobInfo
           };
         })

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -20,6 +20,7 @@ import { useGetJobInfo } from "hooks/query/useGetJobInfo";
 import { useGetServers } from "hooks/query/useGetServers";
 import useExport from "hooks/useExport";
 import JobStatus from "models/jobStatus";
+import ReportType from "models/reportType";
 import { Server } from "models/server";
 import {
   adminRole,
@@ -152,7 +153,9 @@ export const JobsView = (): React.ReactElement => {
             report:
               jobInfo.status === JobStatus.Finished ? (
                 <ReportButton onClick={() => onClickReport(jobInfo.id)}>
-                  {jobInfo.reportType}
+                  {jobInfo.reportType === ReportType.File
+                    ? "Download File"
+                    : "Report"}
                 </ReportButton>
               ) : null,
             jobInfo: jobInfo

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/JobInfoContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/JobInfoContextMenu.tsx
@@ -10,6 +10,7 @@ import {
 } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { refreshJobInfoQuery } from "hooks/query/queryRefreshHelpers";
+import JobStatus from "models/jobStatus";
 import JobInfo from "models/jobs/jobInfo";
 import React from "react";
 import JobService from "services/jobService";
@@ -61,7 +62,8 @@ const JobInfoContextMenu = (
         <MenuItem
           key={"cancelaction"}
           disabled={
-            jobInfo.isCancelable === false || jobInfo.status !== "Started"
+            jobInfo.isCancelable === false ||
+            jobInfo.status !== JobStatus.Started
           }
           onClick={onClickCancelAction}
         >

--- a/Src/WitsmlExplorer.Frontend/components/Modals/JobInfoPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/JobInfoPropertiesModal.tsx
@@ -1,5 +1,6 @@
 import { TextField } from "@material-ui/core";
 import ModalDialog from "components/Modals/ModalDialog";
+import JobStatus from "models/jobStatus";
 import JobInfo from "models/jobs/jobInfo";
 import React from "react";
 
@@ -39,7 +40,7 @@ const JobInfoPropertiesModal = (
               defaultValue={jobInfo.status}
               fullWidth
             />
-            {jobInfo.status == "Failed" && (
+            {jobInfo.status == JobStatus.Failed && (
               <TextField
                 InputProps={{ readOnly: true }}
                 multiline

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
@@ -179,14 +179,15 @@ export const useGetReportOnJobFinished = (jobId: string): BaseReport => {
                 )
               );
             } else {
-              setReport(jobInfo.report);
-              if (jobInfo.report.downloadImmediately === true) {
+              const report = await JobService.getReport(jobId);
+              setReport(report);
+              if (report.downloadImmediately === true) {
                 const reportProperties = generateReport(
-                  jobInfo.report.reportItems,
-                  jobInfo.report.reportHeader
+                  report.reportItems,
+                  report.reportHeader
                 );
                 exportData(
-                  jobInfo.report.title,
+                  report.title,
                   reportProperties.exportColumns,
                   reportProperties.data
                 );

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
@@ -175,7 +175,7 @@ export const useGetReportOnJobFinished = (jobId: string): BaseReport => {
             if (!report) {
               setReport(
                 createReport(
-                  `The job has finished, but could not find job info for job ${jobId}`
+                  `The job has finished, but could not find a report for job ${jobId}`
                 )
               );
             } else {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
@@ -171,15 +171,14 @@ export const useGetReportOnJobFinished = (jobId: string): BaseReport => {
       NotificationService.Instance.snackbarDispatcherAsEvent.subscribe(
         async (notification) => {
           if (notification.jobId === jobId) {
-            const jobInfo = await JobService.getUserJobInfo(notification.jobId);
-            if (!jobInfo) {
+            const report = await JobService.getReport(jobId);
+            if (!report) {
               setReport(
                 createReport(
                   `The job has finished, but could not find job info for job ${jobId}`
                 )
               );
             } else {
-              const report = await JobService.getReport(jobId);
               setReport(report);
               if (report.downloadImmediately === true) {
                 const reportProperties = generateReport(

--- a/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/ReportModal.test.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/ReportModal.test.tsx
@@ -6,6 +6,7 @@ import {
   deferred,
   getJobInfo,
   getNotification,
+  getReport,
   renderWithContexts
 } from "__testUtils__/testUtils";
 import { ReportModal } from "components/Modals/ReportModal";
@@ -20,7 +21,8 @@ jest.mock("@equinor/eds-core-react", () => mockEdsCoreReact());
 
 jest.mock("services/jobService", () => {
   return {
-    getUserJobInfo: () => MOCK_JOB_INFO
+    getUserJobInfo: () => MOCK_JOB_INFO,
+    getReport: () => MOCK_REPORT
   };
 });
 
@@ -130,3 +132,4 @@ const REPORT = createReport("testTitle", "testSummary", REPORT_ITEMS);
 const EMPTY_REPORT = createReport("emptyReportTitle", "emptyReportSummary");
 const MOCK_JOB_INFO = getJobInfo({ report: REPORT, id: "testJobId" });
 const NOTIFICATION = getNotification({ jobId: "testJobId" });
+const MOCK_REPORT = getReport();

--- a/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/ReportModal.test.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/__tests__/ReportModal.test.tsx
@@ -96,7 +96,7 @@ describe("Report Modal", () => {
 
       // A notification that the job has finished has been received. It should still display loading until the job is fetched.
       expect(screen.getByText(/loading report/i)).toBeInTheDocument();
-      expect(JobService.getUserJobInfo).toHaveBeenCalledTimes(2);
+      expect(JobService.getUserJobInfo).toHaveBeenCalledTimes(1);
 
       // Resolve and return from the mocked getUserJobInfo
       await act(async () => {
@@ -130,6 +130,6 @@ const REPORT_ITEMS = [
 
 const REPORT = createReport("testTitle", "testSummary", REPORT_ITEMS);
 const EMPTY_REPORT = createReport("emptyReportTitle", "emptyReportSummary");
-const MOCK_JOB_INFO = getJobInfo({ report: REPORT, id: "testJobId" });
+const MOCK_JOB_INFO = getJobInfo({ id: "testJobId" });
 const NOTIFICATION = getNotification({ jobId: "testJobId" });
 const MOCK_REPORT = getReport();

--- a/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
@@ -6,26 +6,22 @@ export interface ReportProperties {
   data: string;
 }
 
-export const generateReport = (
-  reportItems: object[],
-  reportHeader: string
-) => {
-
+export const generateReport = (reportItems: object[], reportHeader: string) => {
   const columns: ContentTableColumn[] =
     reportItems.length > 0
       ? Object.keys(reportItems[0]).map((key) => ({
-        property: key,
-        label: key,
-        type: ContentType.String
-      }))
+          property: key,
+          label: key,
+          type: ContentType.String
+        }))
       : [];
 
   const exportColumns =
     reportHeader !== null
       ? reportHeader
       : columns
-        .map((column) => `${column.property}`)
-        .join(defaultExportProperties.separator);
+          .map((column) => `${column.property}`)
+          .join(defaultExportProperties.separator);
 
   const data = reportItems
     .map((row) =>
@@ -35,5 +31,5 @@ export const generateReport = (
     )
     .join(defaultExportProperties.newLineCharacter);
 
-  return ({ exportColumns: exportColumns, data: data })
-}
+  return { exportColumns: exportColumns, data: data };
+};

--- a/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
@@ -1,0 +1,39 @@
+import { ContentTableColumn, ContentType } from "./ContentViews/table";
+import { defaultExportProperties } from "models/exportProperties";
+
+export interface ReportProperties {
+  columns: string;
+  data: string;
+}
+
+export const generateReport = (
+  reportItems: object[],
+  reportHeader: string
+) => {
+
+  const columns: ContentTableColumn[] =
+    reportItems.length > 0
+      ? Object.keys(reportItems[0]).map((key) => ({
+        property: key,
+        label: key,
+        type: ContentType.String
+      }))
+      : [];
+
+  const exportColumns =
+    reportHeader !== null
+      ? reportHeader
+      : columns
+        .map((column) => `${column.property}`)
+        .join(defaultExportProperties.separator);
+
+  const data = reportItems
+    .map((row) =>
+      columns
+        .map((col) => row[col.property] as string)
+        .join(defaultExportProperties.separator)
+    )
+    .join(defaultExportProperties.newLineCharacter);
+
+  return ({ exportColumns: exportColumns, data: data })
+}

--- a/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
@@ -6,7 +6,7 @@ export interface ReportProperties {
   data: string;
 }
 
-export const generateReport = (reportItems: any, reportHeader: string) => {
+export const generateReport = (reportItems: any[], reportHeader: string) => {
   const columns: ContentTableColumn[] =
     reportItems.length > 0
       ? Object.keys(reportItems[0]).map((key) => ({

--- a/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
@@ -6,7 +6,7 @@ export interface ReportProperties {
   data: string;
 }
 
-export const generateReport = (reportItems: object[], reportHeader: string) => {
+export const generateReport = (reportItems: any, reportHeader: string) => {
   const columns: ContentTableColumn[] =
     reportItems.length > 0
       ? Object.keys(reportItems[0]).map((key) => ({
@@ -26,7 +26,7 @@ export const generateReport = (reportItems: object[], reportHeader: string) => {
   const data = reportItems
     .map((row) =>
       columns
-        .map((col) => row[col.property])
+        .map((col) => row[col.property] as string)
         .join(defaultExportProperties.separator)
     )
     .join(defaultExportProperties.newLineCharacter);

--- a/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ReportCreationHelper.ts
@@ -26,7 +26,7 @@ export const generateReport = (reportItems: object[], reportHeader: string) => {
   const data = reportItems
     .map((row) =>
       columns
-        .map((col) => row[col.property] as string)
+        .map((col) => row[col.property])
         .join(defaultExportProperties.separator)
     )
     .join(defaultExportProperties.newLineCharacter);

--- a/Src/WitsmlExplorer.Frontend/hooks/useExport.ts
+++ b/Src/WitsmlExplorer.Frontend/hooks/useExport.ts
@@ -1,22 +1,8 @@
+import {
+  ExportProperties,
+  defaultExportProperties
+} from "models/exportProperties";
 import { useCallback, useMemo } from "react";
-
-export interface ExportProperties {
-  outputMimeType: string;
-  fileExtension: string;
-  separator: string;
-  newLineCharacter: string;
-  omitSpecialCharactersFromFilename?: boolean;
-  appendDateTime?: boolean;
-}
-
-const defaultExportProperties = {
-  fileExtension: ".csv",
-  newLineCharacter: "\n",
-  outputMimeType: "text/csv",
-  separator: ",",
-  omitSpecialCharactersFromFilename: true,
-  appendDateTime: true
-};
 
 interface ExportObject {
   exportData: (fileName: string, header: string, data: string) => void;

--- a/Src/WitsmlExplorer.Frontend/models/exportProperties.ts
+++ b/Src/WitsmlExplorer.Frontend/models/exportProperties.ts
@@ -1,17 +1,17 @@
 export interface ExportProperties {
-    outputMimeType: string;
-    fileExtension: string;
-    separator: string;
-    newLineCharacter: string;
-    omitSpecialCharactersFromFilename?: boolean;
-    appendDateTime?: boolean;
+  outputMimeType: string;
+  fileExtension: string;
+  separator: string;
+  newLineCharacter: string;
+  omitSpecialCharactersFromFilename?: boolean;
+  appendDateTime?: boolean;
 }
 
 export const defaultExportProperties = {
-    fileExtension: ".csv",
-    newLineCharacter: "\n",
-    outputMimeType: "text/csv",
-    separator: ",",
-    omitSpecialCharactersFromFilename: true,
-    appendDateTime: true
+  fileExtension: ".csv",
+  newLineCharacter: "\n",
+  outputMimeType: "text/csv",
+  separator: ",",
+  omitSpecialCharactersFromFilename: true,
+  appendDateTime: true
 };

--- a/Src/WitsmlExplorer.Frontend/models/exportProperties.ts
+++ b/Src/WitsmlExplorer.Frontend/models/exportProperties.ts
@@ -1,0 +1,17 @@
+export interface ExportProperties {
+    outputMimeType: string;
+    fileExtension: string;
+    separator: string;
+    newLineCharacter: string;
+    omitSpecialCharactersFromFilename?: boolean;
+    appendDateTime?: boolean;
+}
+
+export const defaultExportProperties = {
+    fileExtension: ".csv",
+    newLineCharacter: "\n",
+    outputMimeType: "text/csv",
+    separator: ",",
+    omitSpecialCharactersFromFilename: true,
+    appendDateTime: true
+};

--- a/Src/WitsmlExplorer.Frontend/models/jobStatus.ts
+++ b/Src/WitsmlExplorer.Frontend/models/jobStatus.ts
@@ -1,0 +1,8 @@
+enum JobStatus {
+  Started = "Started",
+  Finished = "Finished",
+  Failed = "Failed",
+  Cancelled = "Cancelled"
+}
+
+export default JobStatus;

--- a/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
@@ -20,4 +20,5 @@ export default interface JobInfo {
   report: BaseReport;
   progress: number;
   isCancelable: boolean;
+  linkType: string;
 }

--- a/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
@@ -1,3 +1,4 @@
+import JobStatus from "models/jobStatus";
 import BaseReport from "models/reports/BaseReport";
 
 export default interface JobInfo {
@@ -15,7 +16,7 @@ export default interface JobInfo {
   startTime: string;
   endTime: string;
   killTime: string;
-  status: string;
+  status: JobStatus;
   failedReason: string;
   report: BaseReport;
   progress: number;

--- a/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
@@ -1,4 +1,5 @@
 import JobStatus from "models/jobStatus";
+import ReportType from "models/reportType";
 import BaseReport from "models/reports/BaseReport";
 
 export default interface JobInfo {
@@ -21,5 +22,5 @@ export default interface JobInfo {
   report: BaseReport;
   progress: number;
   isCancelable: boolean;
-  linkType: string;
+  reportType: ReportType;
 }

--- a/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/jobInfo.tsx
@@ -19,7 +19,6 @@ export default interface JobInfo {
   killTime: string;
   status: JobStatus;
   failedReason: string;
-  report: BaseReport;
   progress: number;
   isCancelable: boolean;
   reportType: ReportType;

--- a/Src/WitsmlExplorer.Frontend/models/reportType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/reportType.ts
@@ -1,6 +1,6 @@
 enum ReportType {
-    Report = "Report",
-    File = "Download file",
-  }
-  
-  export default ReportType;
+  Report = "Report",
+  File = "Download file"
+}
+
+export default ReportType;

--- a/Src/WitsmlExplorer.Frontend/models/reportType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/reportType.ts
@@ -1,6 +1,6 @@
 enum ReportType {
   Report = "Report",
-  File = "Download file"
+  File = "File"
 }
 
 export default ReportType;

--- a/Src/WitsmlExplorer.Frontend/models/reportType.ts
+++ b/Src/WitsmlExplorer.Frontend/models/reportType.ts
@@ -1,0 +1,6 @@
+enum ReportType {
+    Report = "Report",
+    File = "Download file",
+  }
+  
+  export default ReportType;

--- a/Src/WitsmlExplorer.Frontend/models/reports/BaseReport.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/reports/BaseReport.tsx
@@ -4,6 +4,7 @@ export default interface BaseReport {
   reportItems: any[];
   warningMessage?: string;
   downloadImmediately?: boolean;
+  reportHeader?: string;
 }
 
 export const createReport = (
@@ -11,13 +12,15 @@ export const createReport = (
   summary = "",
   reportItems: any[] = [],
   warningMessage: string = null,
-  downloadImmediately: boolean = null
+  downloadImmediately: boolean = null,
+  reportHeader: string = null
 ): BaseReport => {
   return {
     title,
     summary,
     reportItems,
     warningMessage,
-    downloadImmediately
+    downloadImmediately,
+    reportHeader
   };
 };

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -1,4 +1,5 @@
 import JobInfo from "models/jobs/jobInfo";
+import BaseReport from "models/reports/BaseReport";
 import { Server } from "models/server";
 import { ApiClient, throwError } from "services/apiClient";
 import AuthorizationService from "services/authorizationService";
@@ -108,12 +109,12 @@ export default class JobService {
     }
   }
 
-  public static async getReportItems(
+  public static async getReport(
     jobId: string,
     abortSignal?: AbortSignal
-  ): Promise<object[]> {
+  ): Promise<BaseReport> {
     const response = await ApiClient.get(
-      `/api/jobs/getreportitems/${jobId}`,
+      `/api/jobs/getreport/${jobId}`,
       abortSignal
     );
     if (response.ok) {

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -107,6 +107,21 @@ export default class JobService {
       throwError(response.status, response.statusText);
     }
   }
+
+  public static async getReportItems(
+    jobId: string,
+    abortSignal?: AbortSignal
+  ): Promise<object[]> {
+    const response = await ApiClient.get(
+      `/api/jobs/getreportitems/${jobId}`,
+      abortSignal
+    );
+    if (response.ok) {
+      return response.json();
+    } else {
+      return null;
+    }
+  }
 }
 
 export enum JobType {

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -114,7 +114,7 @@ export default class JobService {
     abortSignal?: AbortSignal
   ): Promise<BaseReport> {
     const response = await ApiClient.get(
-      `/api/jobs/getreport/${jobId}`,
+      `/api/jobs/report/${jobId}`,
       abortSignal
     );
     if (response.ok) {


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes
 This pull request fixes https://github.com/equinor/witsml-explorer/issues/2311

## Description
- job view does not crash while displaying big reports
- data of big reports are downloading directly by clicking "Download file" link in jobs view
- a new api function for fetching report data created
-  report data removed from job view for big reports 

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)



## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [ ] WITSML
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


