### PR TITLE
FIX-2404 Use requested instead of headerOnly to avoid timeout

### DIFF
--- a/Src/WitsmlExplorer.Api/Query/LogQueries.cs
+++ b/Src/WitsmlExplorer.Api/Query/LogQueries.cs
@@ -25,14 +25,24 @@ namespace WitsmlExplorer.Api.Query
                     IndexType = "",
                     RunNumber = "",
                     ObjectGrowing = "",
+                    ServiceCompany = "",
                     StartIndex = new WitsmlIndex(),
                     EndIndex = new WitsmlIndex(),
                     StartDateTimeIndex = "",
                     EndDateTimeIndex = "",
+                    IndexCurve = new WitsmlIndexCurve(),
+                    Direction = "",
                     CommonData = new WitsmlCommonData()
                     {
                         DTimCreation = "",
                         DTimLastChange = ""
+                    },
+                    LogCurveInfo = new List<WitsmlLogCurveInfo>()
+                    {
+                        new WitsmlLogCurveInfo()
+                        {
+                            Mnemonic = ""
+                        }
                     }
                 }.AsItemInList()
             };

--- a/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
+++ b/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
@@ -40,7 +40,7 @@ namespace WitsmlExplorer.Api.Services
         public async Task<ICollection<LogObject>> GetLogs(string wellUid, string wellboreUid)
         {
             WitsmlLogs witsmlLog = LogQueries.GetWitsmlLogsByWellbore(wellUid, wellboreUid);
-            WitsmlLogs result = await _witsmlClient.GetFromStoreAsync(witsmlLog, new OptionsIn(ReturnElements.HeaderOnly));
+            WitsmlLogs result = await _witsmlClient.GetFromStoreAsync(witsmlLog, new OptionsIn(ReturnElements.Requested));
 
             return result.Logs.Select(log =>
                 new LogObject


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2404 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Changed returnElements to requested to only fetch what we need. Had to add a few parameters aswell. As we are counting th enumber of mnemonics, I also added the bare minimum needed to return the logCurveInfo object.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [x] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


