### PR TITLE
FIX-2411 Handle timeZone in curveValuesView

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -330,7 +330,7 @@ export const CurveValuesView = (): React.ReactElement => {
         columnOf: curveSpecification,
         property: curveSpecification.mnemonic,
         label: `${curveSpecification.mnemonic} (${curveSpecification.unit})`,
-        type: getColumnType(curveSpecification)
+        type: getColumnType(curveSpecification, log)
       };
     });
     const prevMnemonics = columns.map((column) => column.property);
@@ -742,7 +742,17 @@ const getComparatorByColumn = (
   return [comparator, column.property];
 };
 
-const getColumnType = (curveSpecification: CurveSpecification) => {
+const getColumnType = (
+  curveSpecification: CurveSpecification,
+  log: LogObject
+) => {
+  const isTimeLog = log.indexType === WITSML_INDEX_TYPE_DATE_TIME;
+  if (
+    isTimeLog &&
+    curveSpecification.mnemonic.toLowerCase() === log.indexCurve.toLowerCase()
+  ) {
+    return ContentType.DateTime;
+  }
   const isTimeMnemonic = (mnemonic: string) =>
     ["time", "datetime", "date time"].indexOf(mnemonic.toLowerCase()) >= 0;
   if (isTimeMnemonic(curveSpecification.mnemonic)) {

--- a/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
+++ b/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
@@ -22,6 +22,8 @@ function formatDateString(
     }
     if (dateTimeFormatString == DateTimeFormat.Natural) {
       dateTimeFormat = naturalDateTimeFormat;
+    } else if (dateTimeFormatString == DateTimeFormat.RawNoOffset) {
+      dateTimeFormat = dateTimeFormatNoOffset;
     } else if (dateTimeFormatString == DateTimeFormat.Raw) {
       dateTimeFormat = rawDateTimeFormat;
     }

--- a/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
+++ b/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
@@ -6,6 +6,7 @@ const naturalDateTimeFormat = "dd.MM.yyyy HH:mm:ss.SSS";
 const rawDateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
 let dateTimeFormat = rawDateTimeFormat;
 export const dateTimeFormatNoOffset = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+export const dateTimeFormatTextField = "yyyy-MM-dd'T'HH:mm:ss";
 
 // Minus character U+2212 is preferred by ISO 8601 over hyphen minus '-' so we check both
 // date-fns-tz behaves weirdly with minus so we replace it

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
@@ -101,8 +101,7 @@ export const LogHeaderDateTimeField = (
           onChange={onTextFieldChange}
           style={{
             paddingTop: "16px",
-            fontFeatureSettings: '"tnum"',
-            paddingBottom: validate(value) ? "24px" : 0
+            fontFeatureSettings: '"tnum"'
           }}
         />
       </Horizontal>
@@ -140,5 +139,4 @@ const Layout = styled.div`
 const Horizontal = styled.div`
   display: flex;
   flex-direction: row;
-  justify-items: bottom;
 `;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
@@ -1,31 +1,30 @@
 import { TextField } from "@equinor/eds-core-react";
-import {
-  dateTimeFormatNoOffset,
-  validateIsoDateStringNoOffset
+import formatDateString, {
+  dateTimeFormatTextField,
+  getOffset,
+  getOffsetFromTimeZone
 } from "components/DateFormatter";
-import { formatInTimeZone } from "date-fns-tz";
-import { useEffect, useState } from "react";
+import OperationContext from "contexts/operationContext";
+import { DateTimeFormat, TimeZone } from "contexts/operationStateReducer";
+import { isValid, parse } from "date-fns";
+import { ChangeEvent, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
-import Icon from "styles/Icons";
 
 interface DateTimeFieldProps {
   value: string;
   label: string;
-  updateObject: (dateTime: string, valid: boolean) => void;
-  offset: string;
+  updateObject: (dateTime: string) => void;
   minValue?: string;
   maxValue?: string;
 }
 
 /**
- * A component to edit a date time, taking in a string in the DateFormatter.dateTimeFormatNoOffset.
+ * A component to edit a date time, taking in a string in the DateFormatter.dateTimeFormat.
  * The offset is shown beside the input in a disabled field.
  * One can either write/paste a string manually, or use the native datepicker.
- * This component should be replaced if EDS ever gets a custom datepicker.
  * @param value The current value of the field.
  * @param label Label shown above the field.
  * @param updateObject A lambda to update the value on the object to be modified.
- * @param offset A constant UTC offset to calculate the time properly
  * @param minValue Optional earliest time the value can be.
  * @param maxValue Optional latest time the value can be.
  * @returns
@@ -33,9 +32,15 @@ interface DateTimeFieldProps {
 export const LogHeaderDateTimeField = (
   props: DateTimeFieldProps
 ): React.ReactElement => {
-  const { value, label, updateObject, offset, minValue, maxValue } = props;
+  const { value, label, updateObject, minValue, maxValue } = props;
+  const {
+    operationState: { timeZone }
+  } = useContext(OperationContext);
+  const offset =
+    timeZone === TimeZone.Raw
+      ? getOffset(value)
+      : getOffsetFromTimeZone(timeZone);
   const [initiallyEmpty, setInitiallyEmpty] = useState(false);
-  const isFirefox = navigator.userAgent.includes("Firefox");
 
   useEffect(() => {
     setInitiallyEmpty(value == null || value === "");
@@ -43,12 +48,12 @@ export const LogHeaderDateTimeField = (
 
   const validate = (current: string) => {
     return (
-      (validateIsoDateStringNoOffset(current, offset) &&
-        (!minValue || current >= minValue) &&
+      ((!minValue || current >= minValue) &&
         (!maxValue || current <= maxValue)) ||
       (initiallyEmpty && (current == null || current === ""))
     );
   };
+
   const getHelperText = () => {
     if (!validate(value)) {
       if (!initiallyEmpty && (value == null || value === "")) {
@@ -60,10 +65,19 @@ export const LogHeaderDateTimeField = (
       if (maxValue && value > maxValue) {
         return `Must be sooner than ${maxValue}`;
       }
-      return "The input must be in the yyyy-MM-dd'T'HH:mm:ss.SSS format.";
+      return "The input must be in the yyyy-MM-dd'T'HH:mm:ss format.";
     }
     return "";
   };
+
+  const onTextFieldChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const isMissingSeconds = e.target.value.split(":")?.length === 2;
+    const value = isMissingSeconds ? `${e.target.value}:00` : e.target.value;
+    if (isValid(parseDate(value))) {
+      updateObject(getUtcValue(value, offset));
+    }
+  };
+
   return (
     <Layout>
       <Horizontal>
@@ -74,56 +88,46 @@ export const LogHeaderDateTimeField = (
           disabled
           style={{
             fontFeatureSettings: '"tnum"',
-            width: "16%"
+            width: "92px"
           }}
         />
         <TextField
           id={label}
-          label={label}
-          value={value}
+          value={getParsedValue(value, timeZone) ?? ""}
           helperText={getHelperText()}
           variant={validate(value) ? undefined : "error"}
-          autoComplete="off"
-          onChange={(
-            e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-          ) => {
-            updateObject(e.target.value, validate(e.target.value));
-          }}
+          type={"datetime-local"}
+          step="1"
+          onChange={onTextFieldChange}
           style={{
+            paddingTop: "16px",
             fontFeatureSettings: '"tnum"',
             paddingBottom: validate(value) ? "24px" : 0
           }}
         />
       </Horizontal>
-      <PickerIcon name="calendar" />
-      <Picker
-        id={label + "picker"}
-        placeholder=""
-        label=""
-        value=""
-        type={isFirefox ? "date" : "datetime-local"}
-        style={{ width: "44px" }}
-        tabIndex={-1} //disable tab focus due to the native datepicker including multiple invisible fields that are not to be used
-        onChange={(
-          e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-        ) => {
-          let toFormat = e.target.value;
-          if (validateIsoDateStringNoOffset(value, offset)) {
-            // preserve the ss.SSS (and also HH:mm for Firefox) part of the original value that the datepicker does not set
-            const slice = isFirefox ? value.slice(10) : value.slice(16);
-            toFormat += slice;
-          }
-          toFormat += offset;
-          const formatted = formatInTimeZone(
-            toFormat,
-            offset,
-            dateTimeFormatNoOffset
-          );
-          updateObject(formatted, validate(formatted));
-        }}
-      />
     </Layout>
   );
+};
+
+const parseDate = (current: string) => {
+  return parse(current, dateTimeFormatTextField, new Date());
+};
+
+const getParsedValue = (input: string, timeZone: TimeZone) => {
+  if (!input) return null;
+  return formatDateString(input, timeZone, DateTimeFormat.RawNoOffset);
+};
+
+const getUtcValue = (input: string, offset: string) => {
+  if (!input) return null;
+  const inputWithZone = input + offset;
+  const utcInput = formatDateString(
+    inputWithZone,
+    TimeZone.Utc,
+    DateTimeFormat.Raw
+  );
+  return utcInput;
 };
 
 const Layout = styled.div`
@@ -136,17 +140,5 @@ const Layout = styled.div`
 const Horizontal = styled.div`
   display: flex;
   flex-direction: row;
-`;
-
-const Picker = styled(TextField)`
-  opacity: 0;
-  position: absolute;
-  right: 0;
-  top: 15px;
-`;
-
-const PickerIcon = styled(Icon)`
-  position: absolute;
-  right: 15px;
-  top: 22px;
+  justify-items: bottom;
 `;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/AdjustDateTimeModal.tsx
@@ -1,12 +1,7 @@
 import { Button } from "@equinor/eds-core-react";
-import {
-  dateTimeFormatNoOffset,
-  getOffset,
-  validateIsoDateStringNoOffset
-} from "components/DateFormatter";
 import { LogHeaderDateTimeField } from "components/Modals/LogHeaderDateTimeField";
 import { addMilliseconds } from "date-fns";
-import { formatInTimeZone, toDate } from "date-fns-tz";
+import { toDate } from "date-fns-tz";
 import React, { useEffect, useState } from "react";
 
 export interface AdjustDateTimeModelProps {
@@ -34,14 +29,8 @@ const AdjustDateTimeModal = (
     onEndDateChanged,
     onValidChange
   } = props;
-  const [startOffset] = useState<string>(getOffset(minDate));
-  const [endOffset] = useState<string>(getOffset(maxDate));
-  const [startIndex, setStartIndex] = useState<string>(
-    formatInTimeZone(minDate, startOffset, dateTimeFormatNoOffset)
-  );
-  const [endIndex, setEndIndex] = useState<string>(
-    formatInTimeZone(maxDate, endOffset, dateTimeFormatNoOffset)
-  );
+  const [startIndex, setStartIndex] = useState<string>(minDate);
+  const [endIndex, setEndIndex] = useState<string>(maxDate);
   const [startIndexInitiallyEmpty] = useState<boolean>(
     startIndex == null || startIndex === ""
   );
@@ -62,35 +51,31 @@ const AdjustDateTimeModal = (
 
   const validate = (
     current: string,
-    offset: string,
     minValue: string,
     maxValue: string,
     initiallyEmpty: boolean
   ) => {
     return (
-      (validateIsoDateStringNoOffset(current, offset) &&
-        (!minValue || current >= minValue) &&
+      ((!minValue || current >= minValue) &&
         (!maxValue || current <= maxValue)) ||
       (initiallyEmpty && (current == null || current === ""))
     );
   };
 
   useEffect(() => {
-    onStartDateChanged(startIndex + startOffset);
-    onEndDateChanged(endIndex + endOffset);
+    onStartDateChanged(startIndex);
+    onEndDateChanged(endIndex);
   }, [startIndex, endIndex]);
 
   useEffect(() => {
     const startIndexIsValid = validate(
       startIndex,
-      startOffset,
       startIndexMinValue,
       startIndexMaxValue,
       startIndexInitiallyEmpty
     );
     const endIndexIsValid = validate(
       endIndex,
-      endOffset,
       endIndexMinValue,
       endIndexMaxValue,
       endIndexInitiallyEmpty
@@ -115,19 +100,11 @@ const AdjustDateTimeModal = (
                 key={"last" + buttonValue.displayText}
                 onClick={() => {
                   const newStartIndex = addMilliseconds(
-                    toDate(endIndex + endOffset),
+                    toDate(endIndex),
                     -buttonValue.timeInMilliseconds
                   );
-                  setStartIndex(
-                    formatInTimeZone(
-                      newStartIndex,
-                      startOffset,
-                      dateTimeFormatNoOffset
-                    )
-                  );
-                  setEndIndex(
-                    formatInTimeZone(maxDate, endOffset, dateTimeFormatNoOffset)
-                  );
+                  setStartIndex(newStartIndex.toISOString());
+                  setEndIndex(maxDate);
                 }}
               >
                 {"Last " + buttonValue.displayText}
@@ -138,12 +115,8 @@ const AdjustDateTimeModal = (
         <Button
           key={"resetRangeValues"}
           onClick={() => {
-            setStartIndex(
-              formatInTimeZone(minDate, startOffset, dateTimeFormatNoOffset)
-            );
-            setEndIndex(
-              formatInTimeZone(maxDate, endOffset, dateTimeFormatNoOffset)
-            );
+            setStartIndex(minDate);
+            setEndIndex(maxDate);
           }}
         >
           Reset
@@ -156,7 +129,6 @@ const AdjustDateTimeModal = (
         updateObject={(dateTime: string) => {
           setStartIndex(dateTime);
         }}
-        offset={startOffset}
         minValue={startIndexMinValue}
         maxValue={startIndexMaxValue}
       />
@@ -166,7 +138,6 @@ const AdjustDateTimeModal = (
         updateObject={(dateTime: string) => {
           setEndIndex(dateTime);
         }}
-        offset={endOffset}
         minValue={endIndexMinValue}
         maxValue={endIndexMaxValue}
       />

--- a/Src/WitsmlExplorer.Frontend/contexts/operationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/operationStateReducer.tsx
@@ -23,7 +23,8 @@ export enum TimeZone {
 
 export enum DateTimeFormat {
   Raw = "raw",
-  Natural = "natural"
+  Natural = "natural",
+  RawNoOffset = "rawNoOffset"
 }
 
 export enum DecimalPreference {


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2402 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

The curveValuesView (both the table and textfield) now uses the timeZone from settings.

Also added an extra check for indexCurve for time logs in case the name does not match the pre-defined "datetime"-names or units. The indexCurve for time logs should always be a datetime.

Also changed (at least some) of the other usages of date-picker to keep it consistent.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


