### PR TITLE
FIX-1948 Offset log curves

### DIFF
--- a/Src/WitsmlExplorer.Api/Jobs/OffsetLogCurveJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/OffsetLogCurveJob.cs
@@ -1,0 +1,34 @@
+using System;
+
+using WitsmlExplorer.Api.Jobs.Common;
+
+namespace WitsmlExplorer.Api.Jobs
+{
+    public record OffsetLogCurveJob : Job
+    {
+        public ComponentReferences LogCurveInfoReferences { get; init; }
+        public double? DepthOffset { get; init; }
+        public long? TimeOffsetMilliseconds { get; set; }
+
+        public override string Description()
+        {
+            TimeSpan timeOffset = TimeSpan.FromMilliseconds(TimeOffsetMilliseconds ?? 0);
+            return $"ToOffset - {LogCurveInfoReferences.Description()}; DepthOffset: {DepthOffset}; TimeOffset: {timeOffset};";
+        }
+
+        public override string GetObjectName()
+        {
+            return LogCurveInfoReferences.GetObjectName();
+        }
+
+        public override string GetWellboreName()
+        {
+            return LogCurveInfoReferences.GetWellboreName();
+        }
+
+        public override string GetWellName()
+        {
+            return LogCurveInfoReferences.GetWellName();
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Jobs/OffsetLogCurveJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/OffsetLogCurveJob.cs
@@ -9,11 +9,13 @@ namespace WitsmlExplorer.Api.Jobs
         public ComponentReferences LogCurveInfoReferences { get; init; }
         public double? DepthOffset { get; init; }
         public long? TimeOffsetMilliseconds { get; set; }
+        public string StartIndex { get; init; }
+        public string EndIndex { get; init; }
 
         public override string Description()
         {
             TimeSpan timeOffset = TimeSpan.FromMilliseconds(TimeOffsetMilliseconds ?? 0);
-            return $"ToOffset - {LogCurveInfoReferences.Description()}; DepthOffset: {DepthOffset}; TimeOffset: {timeOffset};";
+            return $"ToOffset - {LogCurveInfoReferences.Description()}; DepthOffset: {DepthOffset}; TimeOffset: {timeOffset}; StartIndex: {StartIndex}; EndIndex: {EndIndex};";
         }
 
         public override string GetObjectName()

--- a/Src/WitsmlExplorer.Api/Jobs/OffsetLogCurveJob.cs
+++ b/Src/WitsmlExplorer.Api/Jobs/OffsetLogCurveJob.cs
@@ -8,9 +8,10 @@ namespace WitsmlExplorer.Api.Jobs
     {
         public ComponentReferences LogCurveInfoReferences { get; init; }
         public double? DepthOffset { get; init; }
-        public long? TimeOffsetMilliseconds { get; set; }
+        public long? TimeOffsetMilliseconds { get; init; }
         public string StartIndex { get; init; }
         public string EndIndex { get; init; }
+        public bool UseBackup { get; init; }
 
         public override string Description()
         {

--- a/Src/WitsmlExplorer.Api/Models/JobType.cs
+++ b/Src/WitsmlExplorer.Api/Models/JobType.cs
@@ -44,6 +44,7 @@ namespace WitsmlExplorer.Api.Models
         CompareLogData,
         CountLogDataRows,
         BatchModifyLogCurveInfo,
-        DownloadAllLogData
+        DownloadAllLogData,
+        OffsetLogCurves
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Witsml.Data;
+using Witsml.Extensions;
+using Witsml.ServiceReference;
+
+using WitsmlExplorer.Api.Jobs;
+using WitsmlExplorer.Api.Jobs.Common;
+using WitsmlExplorer.Api.Models;
+using WitsmlExplorer.Api.Query;
+using WitsmlExplorer.Api.Services;
+
+using Index = Witsml.Data.Curves.Index;
+
+namespace WitsmlExplorer.Api.Workers
+{
+    public class OffsetLogCurveWorker : BaseWorker<OffsetLogCurveJob>, IWorker
+    {
+        public JobType JobType => JobType.OffsetLogCurves;
+
+        public OffsetLogCurveWorker(ILogger<OffsetLogCurveJob> logger, IWitsmlClientProvider witsmlClientProvider) : base(witsmlClientProvider, logger) { }
+
+        public override async Task<(WorkerResult, RefreshAction)> Execute(OffsetLogCurveJob job, CancellationToken? cancellationToken = null)
+        {
+            ComponentReferences logCurveInfoReferences = job.LogCurveInfoReferences;
+            ObjectReference logReference = logCurveInfoReferences.Parent;
+            double depthOffset = job.DepthOffset ?? 0;
+            TimeSpan timeOffset = TimeSpan.FromMilliseconds(job.TimeOffsetMilliseconds ?? 0);
+
+            Logger.LogInformation("Started {JobType}. {jobDescription}", JobType, job.Description());
+
+            try
+            {
+                WitsmlLog log = await LogWorkerTools.GetLog(GetTargetWitsmlClientOrThrow(), logReference, ReturnElements.HeaderOnly) ?? throw new ArgumentException("Failed to find log");
+                bool isDepthLog = log.IndexType == WitsmlLog.WITSML_INDEX_TYPE_MD;
+                List<WitsmlLogCurveInfo> logCurveInfos = log.LogCurveInfo.Where(lci => logCurveInfoReferences.ComponentUids.Contains(lci.Uid)).ToList();
+
+                foreach (WitsmlLogCurveInfo logCurveInfo in logCurveInfos)
+                {
+                    WitsmlLogData logData = await LogWorkerTools.GetLogDataForCurve(GetTargetWitsmlClientOrThrow(), log, logCurveInfo.Mnemonic, Logger);
+                    WitsmlLogData offsetLogData = OffsetLogData(logData, depthOffset, timeOffset, isDepthLog);
+                    await DeleteLogData(log, logCurveInfo, isDepthLog);
+                    await UpdateLogData(log, logCurveInfo, offsetLogData);
+                }
+            }
+            catch (Exception e)
+            {
+                var message = $"{JobType} failed. Description: {job.Description()}. Error: {e.Message} ";
+                Logger.LogError(message);
+                return (new WorkerResult(GetTargetWitsmlClientOrThrow().GetServerHostname(), false, message, job.JobInfo.Id), null);
+            }
+
+            Logger.LogInformation("Finished {JobType}. {jobDescription}", JobType, job.Description());
+
+            RefreshAction refreshAction = new RefreshObjects(GetTargetWitsmlClientOrThrow().GetServerHostname(), logReference.WellUid, logReference.WellboreUid, EntityType.Log, logReference.Uid);
+            WorkerResult workerResult = new(GetTargetWitsmlClientOrThrow().GetServerHostname(), true, $"Successfully offset curves {string.Join(", ", logCurveInfoReferences.ComponentUids)}", null, null, job.JobInfo.Id);
+
+            return (workerResult, refreshAction);
+        }
+
+        private async Task DeleteLogData(WitsmlLog log, WitsmlLogCurveInfo logCurveInfo, bool isDepthLog)
+        {
+            Index startIndex = Index.Start(log, isDepthLog ? logCurveInfo.MinIndex.Value : logCurveInfo.MinDateTimeIndex);
+            Index endIndex = Index.End(log, isDepthLog ? logCurveInfo.MaxIndex.Value : logCurveInfo.MaxDateTimeIndex);
+
+            var query = LogQueries.DeleteLogCurveContent(log.UidWell, log.UidWellbore, log.Uid, log.IndexType, logCurveInfo.AsItemInList(), startIndex, endIndex);
+            var result = await GetTargetWitsmlClientOrThrow().DeleteFromStoreAsync(query);
+            if (!result.IsSuccessful)
+            {
+                throw new Exception($"Failed to delete log data for mnemonic {logCurveInfo.Mnemonic}");
+            }
+        }
+
+        private async Task UpdateLogData(WitsmlLog log, WitsmlLogCurveInfo logCurveinfo, WitsmlLogData offsetLogData)
+        {
+            var queries = GetUpdateLogDataQueries(log, offsetLogData);
+            foreach (var query in queries)
+            {
+
+                var result = await RequestUtils.WithRetry(async () => await GetTargetWitsmlClientOrThrow().UpdateInStoreAsync(query), Logger);
+                if (!result.IsSuccessful)
+                {
+                    // TODO: Do we want to keep going, or stop on first error?
+                    throw new Exception($"Failed to update log data for mnemonic {logCurveinfo.Mnemonic}");
+                }
+            }
+        }
+
+        private static List<WitsmlLogs> GetUpdateLogDataQueries(WitsmlLog log, WitsmlLogData offsetLogData)
+        {
+            int chunkSize = 1000;
+            List<WitsmlLogs> batchedQueries = offsetLogData.Data.Chunk(chunkSize).Select(chunk =>
+                new WitsmlLogs
+                {
+                    Logs = new WitsmlLog
+                    {
+                        Uid = log.Uid,
+                        UidWell = log.UidWell,
+                        UidWellbore = log.UidWellbore,
+                        LogData = new WitsmlLogData
+                        {
+                            MnemonicList = offsetLogData.MnemonicList,
+                            UnitList = offsetLogData.UnitList,
+                            Data = chunk.ToList(),
+                        }
+                    }.AsItemInList()
+                }
+            ).ToList();
+
+            return batchedQueries;
+        }
+
+        private static WitsmlLogData OffsetLogData(WitsmlLogData logData, double depthOffset, TimeSpan timeOffset, bool isDepthLog)
+        {
+            List<WitsmlData> offsetLogData = new();
+
+            foreach (WitsmlData data in logData.Data)
+            {
+                string stringIndex = data.Data.Split(",").FirstOrDefault() ?? throw new Exception($"Failed to extract index from log data: {data.Data}");
+                string offsetIndex = isDepthLog
+                    ? OffsetDepthIndex(stringIndex, depthOffset)
+                    : OffsetTimeIndex(stringIndex, timeOffset);
+
+                offsetLogData.Add(
+                    new WitsmlData
+                    {
+                        Data = $"{offsetIndex}{data.Data.Substring(stringIndex.Length)}"
+                    }
+                );
+            }
+
+            return new WitsmlLogData()
+            {
+                MnemonicList = logData.MnemonicList,
+                UnitList = logData.UnitList,
+                Data = offsetLogData
+            };
+        }
+
+        private static string OffsetDepthIndex(string stringIndex, double depthOffset)
+        {
+            if (!double.TryParse(stringIndex, NumberStyles.Any, CultureInfo.InvariantCulture, out var index))
+            {
+                throw new Exception($"Failed to parse index to double: {stringIndex}");
+            }
+
+            return $"{index + depthOffset}";
+        }
+
+        private static string OffsetTimeIndex(string stringIndex, TimeSpan timeOffset)
+        {
+            if (!DateTime.TryParse(stringIndex, out DateTime index))
+            {
+                throw new Exception($"Failed to parse index to TimeSpan: {stringIndex}");
+            }
+
+            return $"{index.Add(timeOffset).ToISODateTimeString()}";
+        }
+    }
+}

--- a/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
@@ -246,7 +246,7 @@ namespace WitsmlExplorer.Api.Workers
                 throw new Exception($"Failed to parse index to double: {stringIndex}");
             }
 
-            string offsetIndex = (index + depthOffset).ToString(CultureInfo.InvariantCulture);
+            string offsetIndex = ((decimal)index + (decimal)depthOffset).ToString(CultureInfo.InvariantCulture); // Use decimal for higher precision to reduce floating point errors
 
             return offsetIndex;
         }

--- a/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
@@ -96,7 +96,7 @@ namespace WitsmlExplorer.Api.Workers
                 var result = await RequestUtils.WithRetry(async () => await GetTargetWitsmlClientOrThrow().UpdateInStoreAsync(query), Logger);
                 if (!result.IsSuccessful)
                 {
-                    throw new Exception($"Failed to update log data for mnemonic {logCurveinfo.Mnemonic}");
+                    throw new Exception($"Failed to update log data for mnemonic {logCurveinfo.Mnemonic}. {result.Reason}.");
                 }
             }
         }
@@ -159,7 +159,9 @@ namespace WitsmlExplorer.Api.Workers
                 throw new Exception($"Failed to parse index to double: {stringIndex}");
             }
 
-            return $"{index + depthOffset}";
+            string offsetIndex = (index + depthOffset).ToString(CultureInfo.InvariantCulture);
+
+            return offsetIndex;
         }
 
         private static string OffsetTimeIndex(string stringIndex, TimeSpan timeOffset)
@@ -169,7 +171,7 @@ namespace WitsmlExplorer.Api.Workers
                 throw new Exception($"Failed to parse index to TimeSpan: {stringIndex}");
             }
 
-            return $"{index.Add(timeOffset).ToISODateTimeString()}";
+            return index.Add(timeOffset).ToISODateTimeString();
         }
     }
 }

--- a/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
+++ b/Src/WitsmlExplorer.Api/Workers/OffsetLogCurveWorker.cs
@@ -42,7 +42,7 @@ namespace WitsmlExplorer.Api.Workers
                 bool isDepthLog = log.IndexType == WitsmlLog.WITSML_INDEX_TYPE_MD;
                 Index startIndex = Index.Start(log, job.StartIndex);
                 Index endIndex = Index.End(log, job.EndIndex);
-                List<WitsmlLogCurveInfo> logCurveInfos = log.LogCurveInfo.Where(lci => logCurveInfoReferences.ComponentUids.Contains(lci.Uid)).ToList();
+                List<WitsmlLogCurveInfo> logCurveInfos = log.LogCurveInfo.Where(lci => logCurveInfoReferences.ComponentUids.Contains(lci.Mnemonic)).ToList();
 
                 double totalIterations = logCurveInfos.Count * 2;
                 for (int i = 0; i < logCurveInfos.Count; i++)

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -40,14 +40,10 @@ import useExport from "hooks/useExport";
 import { useGetMnemonics } from "hooks/useGetMnemonics";
 import orderBy from "lodash/orderBy";
 import { ComponentType } from "models/componentType";
-import {
-  DeleteLogCurveValuesJob,
-  IndexRange
-} from "models/jobs/deleteLogCurveValuesJob";
+import { IndexRange } from "models/jobs/deleteLogCurveValuesJob";
 import DownloadAllLogDataJob from "models/jobs/downloadAllLogDataJob";
 import { CurveSpecification, LogData, LogDataRow } from "models/logData";
 import LogObject, { indexToNumber } from "models/logObject";
-import { toObjectReference } from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import React, {
   CSSProperties,
@@ -218,29 +214,6 @@ export const CurveValuesView = (): React.ReactElement => {
     });
   };
 
-  const getDeleteLogCurveValuesJob = useCallback(
-    (
-      mnemonics: string[],
-      checkedContentItems: CurveValueRow[],
-      selectedLog: LogObject,
-      tableData: CurveValueRow[]
-    ) => {
-      const indexRanges = getIndexRanges(
-        checkedContentItems,
-        tableData,
-        selectedLog
-      );
-
-      const deleteLogCurveValuesJob: DeleteLogCurveValuesJob = {
-        logReference: toObjectReference(selectedLog),
-        mnemonics: mnemonics,
-        indexRanges: indexRanges
-      };
-      return deleteLogCurveValuesJob;
-    },
-    [getIndexRanges, toObjectReference]
-  );
-
   const executeExport = () => {
     switch (downloadOptions) {
       case DownloadOptions.All:
@@ -298,13 +271,12 @@ export const CurveValuesView = (): React.ReactElement => {
       const originalTableData = tableData.filter((data) =>
         checkedContentItems.map((c) => c.id).includes(data.id)
       );
-      const deleteLogCurveValuesJob = getDeleteLogCurveValuesJob(
-        mnemonics,
-        originalTableData,
+      const indexRanges = getIndexRanges(originalTableData, tableData, log);
+      const contextMenuProps = {
         log,
-        tableData
-      );
-      const contextMenuProps = { deleteLogCurveValuesJob, dispatchOperation };
+        mnemonics,
+        indexRanges
+      };
       const position = getContextMenuPosition(event);
       dispatchOperation({
         type: OperationType.DisplayContextMenu,
@@ -317,7 +289,7 @@ export const CurveValuesView = (): React.ReactElement => {
     [
       mnemonics,
       log,
-      getDeleteLogCurveValuesJob,
+      getIndexRanges,
       dispatchOperation,
       getContextMenuPosition,
       tableData
@@ -373,7 +345,7 @@ export const CurveValuesView = (): React.ReactElement => {
     setIsLoading(true);
     setAutoRefresh(false);
 
-    if (log && !isFetching && mnemonics) {
+    if (log && !isFetchingLog && mnemonics) {
       getLogData(startIndex, endIndex)
         .catch(truncateAbortHandler)
         .then(() => setIsLoading(false));

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
@@ -170,9 +170,11 @@ const LogCurveInfoContextMenu = (
     dispatchOperation({ type: OperationType.HideContextMenu });
     const offsetLogCurveModalProps: OffsetLogCurveModalProps = {
       selectedLog,
-      logCurveInfos: checkedLogCurveInfoRowsWithoutIndexCurve.map(
-        (lc) => lc.logCurveInfo
-      )
+      mnemonics: checkedLogCurveInfoRowsWithoutIndexCurve.map(
+        (lc) => lc.logCurveInfo.mnemonic
+      ),
+      startIndex: selectedLog.startIndex,
+      endIndex: selectedLog.endIndex
     };
     dispatchOperation({
       type: OperationType.DisplayModal,

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurveInfoContextMenu.tsx
@@ -24,6 +24,10 @@ import {
   LogCurvePriorityModalProps
 } from "components/Modals/LogCurvePriorityModal";
 import { IndexCurve } from "components/Modals/LogPropertiesModal";
+import {
+  OffsetLogCurveModal,
+  OffsetLogCurveModalProps
+} from "components/Modals/OffsetLogCurveModal";
 import SelectIndexToDisplayModal from "components/Modals/SelectIndexToDisplayModal";
 import {
   DisplayModalAction,
@@ -159,6 +163,20 @@ const LogCurveInfoContextMenu = (
     dispatchOperation({
       type: OperationType.DisplayModal,
       payload: <LogCurvePriorityModal {...logCurvePriorityModalProps} />
+    });
+  };
+
+  const onClickOffset = () => {
+    dispatchOperation({ type: OperationType.HideContextMenu });
+    const offsetLogCurveModalProps: OffsetLogCurveModalProps = {
+      selectedLog,
+      logCurveInfos: checkedLogCurveInfoRowsWithoutIndexCurve.map(
+        (lc) => lc.logCurveInfo
+      )
+    };
+    dispatchOperation({
+      type: OperationType.DisplayModal,
+      payload: <OffsetLogCurveModal {...offsetLogCurveModalProps} />
     });
   };
 
@@ -325,6 +343,22 @@ const LogCurveInfoContextMenu = (
         >
           <StyledIcon name="beat" color={colors.interactive.primaryResting} />
           <Typography color={"primary"}>Analyze gaps</Typography>
+        </MenuItem>,
+        <MenuItem
+          key={"offset"}
+          onClick={onClickOffset}
+          disabled={
+            checkedLogCurveInfoRowsWithoutIndexCurve.length === 0 || isMultiLog
+          }
+        >
+          <StyledIcon name="tune" color={colors.interactive.primaryResting} />
+          <Typography color={"primary"}>
+            {menuItemText(
+              "offset",
+              ComponentType.Mnemonic,
+              checkedLogCurveInfoRowsWithoutIndexCurve
+            )}
+          </Typography>
         </MenuItem>,
         <MenuItem
           key={"setPriority"}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
@@ -6,6 +6,7 @@ import {
 import { StyledAccordionHeader } from "components/Modals/LogComparisonModal";
 import AdjustDateTimeModal from "components/Modals/TrimLogObject/AdjustDateTimeModal";
 import AdjustNumberRangeModal from "components/Modals/TrimLogObject/AdjustNumberRangeModal";
+import WarningBar from "components/WarningBar";
 import { ComponentType } from "models/componentType";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { OffsetLogCurveJob } from "models/jobs/offsetLogCurveJob";
@@ -140,6 +141,7 @@ export const OffsetLogCurveModal = (
               />
             </>
           )}
+          <WarningBar message="Data within the specified range will be deleted before attempting to write the new data with the offset. If writing the offset data fails, the original data will be lost!" />
         </Layout>
       }
       onSubmit={onSubmit}

--- a/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
@@ -164,7 +164,7 @@ const ExampleDepthOffset = (): ReactElement => {
       style={{ whiteSpace: "pre-line", fontVariantNumeric: "tabular-nums" }}
     >
       The curves are offset by adding the offset value to the index of each data
-      point for the curve.
+      point for the curve. Data in the target range will be overwritten.
       <br />
       <br />
       Before: <br />
@@ -186,7 +186,7 @@ const ExampleTimeOffset = (): ReactElement => {
       style={{ whiteSpace: "pre-line", fontVariantNumeric: "tabular-nums" }}
     >
       The curves are offset by adding the offset value to the index of each data
-      point for the curve.
+      point for the curve. Data in the target range will be overwritten.
       <br />
       <br />
       Before: <br />

--- a/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
@@ -10,7 +10,6 @@ import WarningBar from "components/WarningBar";
 import { ComponentType } from "models/componentType";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { OffsetLogCurveJob } from "models/jobs/offsetLogCurveJob";
-import LogCurveInfo from "models/logCurveInfo";
 import LogObject from "models/logObject";
 import React, { ChangeEvent, ReactElement, useContext, useState } from "react";
 import JobService, { JobType } from "services/jobService";
@@ -22,22 +21,29 @@ import ModalDialog from "./ModalDialog";
 
 export interface OffsetLogCurveModalProps {
   selectedLog: LogObject;
-  logCurveInfos: LogCurveInfo[];
+  mnemonics: string[];
+  startIndex: string;
+  endIndex: string;
 }
 
 export const OffsetLogCurveModal = (
   props: OffsetLogCurveModalProps
 ): React.ReactElement => {
-  const { selectedLog, logCurveInfos } = props;
+  const {
+    selectedLog,
+    mnemonics,
+    startIndex: initialStartIndex,
+    endIndex: initialEndIndex
+  } = props;
   const { operationState, dispatchOperation } = useContext(OperationContext);
   const { colors } = operationState;
   const isDepthLog = selectedLog.indexType === WITSML_INDEX_TYPE_MD;
   const [isValidInterval, setIsValidInterval] = useState<boolean>();
   const [startIndex, setStartIndex] = useState<string | number>(
-    isDepthLog ? indexToNumber(selectedLog.startIndex) : selectedLog.startIndex
+    isDepthLog ? indexToNumber(initialStartIndex) : initialStartIndex
   );
   const [endIndex, setEndIndex] = useState<string | number>(
-    isDepthLog ? indexToNumber(selectedLog.endIndex) : selectedLog.endIndex
+    isDepthLog ? indexToNumber(initialEndIndex) : initialEndIndex
   );
   const [offset, setOffset] = useState<string>(isDepthLog ? "0" : "00:00:00");
   const isValidOffset = isDepthLog
@@ -52,7 +58,7 @@ export const OffsetLogCurveModal = (
     const depthOffset = isDepthLog ? Number(offset) : null;
     const offsetLogCurveJob: OffsetLogCurveJob = {
       logCurveInfoReferences: createComponentReferences(
-        logCurveInfos.map((lci) => lci.uid),
+        mnemonics,
         selectedLog,
         ComponentType.Mnemonic
       ),
@@ -88,8 +94,8 @@ export const OffsetLogCurveModal = (
           {isDepthLog ? (
             <>
               <AdjustNumberRangeModal
-                minValue={indexToNumber(selectedLog.startIndex)}
-                maxValue={indexToNumber(selectedLog.endIndex)}
+                minValue={indexToNumber(initialStartIndex)}
+                maxValue={indexToNumber(initialEndIndex)}
                 isDescending={
                   selectedLog.direction == WITSML_LOG_ORDERTYPE_DECREASING
                 }
@@ -115,8 +121,8 @@ export const OffsetLogCurveModal = (
           ) : (
             <>
               <AdjustDateTimeModal
-                minDate={selectedLog.startIndex}
-                maxDate={selectedLog.endIndex}
+                minDate={initialStartIndex}
+                maxDate={initialEndIndex}
                 isDescending={
                   selectedLog.direction == WITSML_LOG_ORDERTYPE_DECREASING
                 }

--- a/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
@@ -1,0 +1,185 @@
+import { Accordion, TextField, Typography } from "@equinor/eds-core-react";
+import { WITSML_INDEX_TYPE_MD } from "components/Constants";
+import { StyledAccordionHeader } from "components/Modals/LogComparisonModal";
+import { ComponentType } from "models/componentType";
+import { createComponentReferences } from "models/jobs/componentReferences";
+import { OffsetLogCurveJob } from "models/jobs/offsetLogCurveJob";
+import LogCurveInfo from "models/logCurveInfo";
+import LogObject from "models/logObject";
+import React, { ChangeEvent, ReactElement, useContext, useState } from "react";
+import JobService, { JobType } from "services/jobService";
+import styled from "styled-components";
+import OperationContext from "../../contexts/operationContext";
+import OperationType from "../../contexts/operationType";
+import ModalDialog from "./ModalDialog";
+
+export interface OffsetLogCurveModalProps {
+  selectedLog: LogObject;
+  logCurveInfos: LogCurveInfo[];
+}
+
+export const OffsetLogCurveModal = (
+  props: OffsetLogCurveModalProps
+): React.ReactElement => {
+  const { selectedLog, logCurveInfos } = props;
+  const { operationState, dispatchOperation } = useContext(OperationContext);
+  const { colors } = operationState;
+  const isDepthLog = selectedLog.indexType === WITSML_INDEX_TYPE_MD;
+  const [offset, setOffset] = useState<string>(isDepthLog ? "0" : "00:00:00");
+  const isValidOffset = isDepthLog
+    ? isValidDepthOffset(offset)
+    : isValidTimeOffset(offset);
+
+  const onSubmit = async () => {
+    dispatchOperation({ type: OperationType.HideModal });
+    const timeOffsetMilliseconds = isDepthLog
+      ? null
+      : offsetStringToMilliseconds(offset);
+    const depthOffset = isDepthLog ? Number(offset) : null;
+    const offsetLogCurveJob: OffsetLogCurveJob = {
+      logCurveInfoReferences: createComponentReferences(
+        logCurveInfos.map((lci) => lci.uid),
+        selectedLog,
+        ComponentType.Mnemonic
+      ),
+      timeOffsetMilliseconds: timeOffsetMilliseconds,
+      depthOffset: depthOffset
+    };
+    await JobService.orderJob(JobType.OffsetLogCurves, offsetLogCurveJob);
+  };
+
+  const handleOffsetChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setOffset(event.target.value);
+  };
+
+  return (
+    <ModalDialog
+      heading={`Offset Log Curves`}
+      content={
+        <Layout>
+          <Accordion>
+            <Accordion.Item>
+              <StyledAccordionHeader colors={colors}>
+                How are the curves offset?
+              </StyledAccordionHeader>
+              <Accordion.Panel
+                style={{ backgroundColor: colors.ui.backgroundLight }}
+              >
+                {isDepthLog ? <ExampleDepthOffset /> : <ExampleTimeOffset />}
+              </Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+          {isDepthLog ? (
+            <TextField
+              id={"depthOffset"}
+              label="Offset"
+              type="number"
+              value={offset}
+              onChange={handleOffsetChange}
+              helperText={
+                !isValidOffset
+                  ? "The offset must be a number and must not be 0"
+                  : null
+              }
+            />
+          ) : (
+            <TextField
+              id={"timeOffset"}
+              label="Offset"
+              value={offset}
+              onChange={handleOffsetChange}
+              placeholder="hh:mm:ss"
+              maxLength={9}
+              helperText={
+                !isValidOffset
+                  ? "The offset must be in format +-hh:mm:ss, where hours: 00..23, minutes: 00..59, seconds: 00..59 and must not be 00:00:00"
+                  : null
+              }
+            />
+          )}
+        </Layout>
+      }
+      onSubmit={onSubmit}
+      isLoading={false}
+      confirmText={"Save"}
+      confirmDisabled={!isValidOffset}
+    />
+  );
+};
+
+const ExampleDepthOffset = (): ReactElement => {
+  return (
+    <Typography
+      style={{ whiteSpace: "pre-line", fontVariantNumeric: "tabular-nums" }}
+    >
+      The curves are offset by adding the offset value to the index of each data
+      point for the curve.
+      <br />
+      <br />
+      Before: <br />
+      Depth | Curve1 <br />
+      10.5 | 3.14 <br />
+      10.6 | 2.72 <br />
+      <br />
+      After adding an offset of -1.0: <br />
+      Depth | Curve1 <br />
+      9.5 | 3.14 <br />
+      9.6 | 2.72 <br />
+    </Typography>
+  );
+};
+
+const ExampleTimeOffset = (): ReactElement => {
+  return (
+    <Typography
+      style={{ whiteSpace: "pre-line", fontVariantNumeric: "tabular-nums" }}
+    >
+      The curves are offset by adding the offset value to the index of each data
+      point for the curve.
+      <br />
+      <br />
+      Before: <br />
+      Time | Curve1 <br />
+      2024-01-16T09:21:30.000Z | 3.14 <br />
+      2024-01-16T09:21:45.000Z | 2.72 <br />
+      <br />
+      After adding an offset of 01:00:00 (1 hour): <br />
+      Time | Curve1 <br />
+      2024-01-16T10:21:30.000Z | 3.14 <br />
+      2024-01-16T10:21:45.000Z | 2.72 <br />
+    </Typography>
+  );
+};
+
+const isValidTimeOffset = (offset: string): boolean => {
+  const timePattern = /^[+-]?([0-1]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/;
+  const emptyTimePattern = /^[+-]?00:00:00$/;
+
+  return (
+    new RegExp(timePattern).test(offset) &&
+    !new RegExp(emptyTimePattern).test(offset)
+  );
+};
+
+const isValidDepthOffset = (offset: string): boolean => {
+  const depthPattern = /^[+-]?[0-9]+(\.[0-9]+)?$/;
+  const emptyDepthPattern = /^[+-]?0$/;
+
+  return (
+    new RegExp(depthPattern).test(offset) &&
+    !new RegExp(emptyDepthPattern).test(offset)
+  );
+};
+
+const offsetStringToMilliseconds = (offset: string): number => {
+  const sign = offset.startsWith("-") ? -1 : 1;
+  offset = offset.replace(/[+-]/, "");
+  const [hours, minutes, seconds] = offset.split(":").map(Number);
+  return sign * (hours * 3600 + minutes * 60 + seconds) * 1000;
+};
+
+const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;

--- a/Src/WitsmlExplorer.Frontend/models/jobs/offsetLogCurveJob.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/offsetLogCurveJob.tsx
@@ -1,0 +1,7 @@
+import ComponentReferences from "models/jobs/componentReferences";
+
+export interface OffsetLogCurveJob {
+  logCurveInfoReferences: ComponentReferences;
+  timeOffsetMilliseconds: number;
+  depthOffset: number;
+}

--- a/Src/WitsmlExplorer.Frontend/models/jobs/offsetLogCurveJob.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/offsetLogCurveJob.tsx
@@ -4,4 +4,6 @@ export interface OffsetLogCurveJob {
   logCurveInfoReferences: ComponentReferences;
   timeOffsetMilliseconds: number;
   depthOffset: number;
+  startIndex: string;
+  endIndex: string;
 }

--- a/Src/WitsmlExplorer.Frontend/models/jobs/offsetLogCurveJob.tsx
+++ b/Src/WitsmlExplorer.Frontend/models/jobs/offsetLogCurveJob.tsx
@@ -6,4 +6,5 @@ export interface OffsetLogCurveJob {
   depthOffset: number;
   startIndex: string;
   endIndex: string;
+  useBackup: boolean;
 }

--- a/Src/WitsmlExplorer.Frontend/services/jobService.tsx
+++ b/Src/WitsmlExplorer.Frontend/services/jobService.tsx
@@ -168,5 +168,6 @@ export enum JobType {
   SpliceLogs = "SpliceLogs",
   CompareLogData = "CompareLogData",
   CountLogDataRows = "CountLogDataRows",
-  DownloadAllLogData = "DownloadAllLogData"
+  DownloadAllLogData = "DownloadAllLogData",
+  OffsetLogCurves = "OffsetLogCurves"
 }

--- a/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
+++ b/Src/WitsmlExplorer.Frontend/styles/Icons.tsx
@@ -49,6 +49,7 @@ import {
   settings,
   sync,
   text_field as textField,
+  tune,
   update,
   upload,
   world
@@ -103,6 +104,7 @@ const icons = {
   settings,
   sync,
   textField,
+  tune,
   update,
   upload,
   world

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
@@ -41,7 +41,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddSerilog(Log.Logger);
             ILogger<OffsetLogCurveJob> logger = loggerFactory.CreateLogger<OffsetLogCurveJob>();
-            _worker = new OffsetLogCurveWorker(logger, witsmlClientProvider.Object);
+            _worker = new OffsetLogCurveWorker(logger, witsmlClientProvider.Object, null, null);
         }
 
         [Fact]

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using Serilog;
+
+using Witsml;
+using Witsml.Data;
+using Witsml.Extensions;
+using Witsml.ServiceReference;
+
+using WitsmlExplorer.Api.Jobs;
+using WitsmlExplorer.Api.Jobs.Common;
+using WitsmlExplorer.Api.Services;
+using WitsmlExplorer.Api.Workers;
+
+using Xunit;
+
+namespace WitsmlExplorer.Api.Tests.Workers
+{
+    public class OffsetLogCurveWorkerTests
+    {
+        private const string LogUid = "8cfad887-3e81-40f0-9034-178be642df65";
+        private const string LogName = "Test log";
+        private const string WellUid = "W-5209671";
+        private const string WellName = "Test well";
+        private const string WellboreUid = "B-5209671";
+        private const string WellboreName = "Test wellbore";
+        private readonly Mock<IWitsmlClient> _witsmlClient;
+        private readonly OffsetLogCurveWorker _worker;
+
+        public OffsetLogCurveWorkerTests()
+        {
+            Mock<IWitsmlClientProvider> witsmlClientProvider = new();
+            _witsmlClient = new Mock<IWitsmlClient>();
+            witsmlClientProvider.Setup(provider => provider.GetClient()).Returns(_witsmlClient.Object);
+            ILoggerFactory loggerFactory = new LoggerFactory();
+            loggerFactory.AddSerilog(Log.Logger);
+            ILogger<OffsetLogCurveJob> logger = loggerFactory.CreateLogger<OffsetLogCurveJob>();
+            _worker = new OffsetLogCurveWorker(logger, witsmlClientProvider.Object);
+        }
+
+        [Fact]
+        public async Task Execute_DepthLog_AddsDepth()
+        {
+            /*
+            Initial Data (indexCurve, curve1):
+            [(0,0), (1,1), (2,2), (3,3), (4,4), (5,5)]
+
+            Offset: 10
+
+            Expected Data (indexCurve, curve1):
+            [(10,0), (11,1), (12,2), (13,3), (14,4), (15,5)]
+            */
+
+            var job = CreateJob(depthOffset: 10);
+            SetupClient(_witsmlClient, WitsmlLog.WITSML_INDEX_TYPE_MD);
+            var expectedData = new List<string>
+            {
+                "10,0",
+                "11,1",
+                "12,2",
+                "13,3",
+                "14,4",
+                "15,5"
+            };
+
+            var (result, refreshAction) = await _worker.Execute(job);
+
+            Assert.True(result.IsSuccess);
+            _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Once);
+            _witsmlClient.Verify(client => client.UpdateInStoreAsync(It.Is<WitsmlLogs>(logs => ValidateLogs(logs, expectedData))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Execute_TimeLog_AddsTime()
+        {
+            /*
+            Initial Data (indexCurve, curve1):
+            [(2024-01-16T15:00:00.000Z,0), (2024-01-16T15:15:00.000Z,1), (2024-01-16T15:30:00.000Z,2), (2024-01-16T15:45:00.000Z,3), (2024-01-16T16:00:00.000Z,4)]
+
+            Offset: 1 hour
+
+            Expected Data (indexCurve, curve1):
+            [(2024-01-16T16:00:00.000Z,0), (2024-01-16T16:15:00.000Z,1), (2024-01-16T16:30:00.000Z,2), (2024-01-16T16:45:00.000Z,3), (2024-01-16T17:00:00.000Z,4)]
+            */
+
+            DateTime test = new(2024, 1, 16);
+            string testString = test.ToISODateTimeString();
+
+            var job = CreateJob(timeOffsetMilliseconds: 60 * 60 * 1000);
+            SetupClient(_witsmlClient, WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME);
+            var expectedData = new List<string>
+            {
+                "2024-01-16T16:00:00.000Z,0",
+                "2024-01-16T16:15:00.000Z,1",
+                "2024-01-16T16:30:00.000Z,2",
+                "2024-01-16T16:45:00.000Z,3",
+                "2024-01-16T17:00:00.000Z,4"
+            };
+
+            var (result, refreshAction) = await _worker.Execute(job);
+
+            Assert.True(result.IsSuccess);
+            _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Once);
+            _witsmlClient.Verify(client => client.UpdateInStoreAsync(It.Is<WitsmlLogs>(logs => ValidateLogs(logs, expectedData))), Times.Once);
+        }
+
+        private bool ValidateLogs(WitsmlLogs logs, List<string> expectedData)
+        {
+            WitsmlLogData logData = logs.Logs.First().LogData;
+            if (logData.Data.Count != expectedData.Count) return false;
+            for (int i = 0; i < expectedData.Count; i++)
+            {
+                if (logData.Data[i].Data != expectedData[i]) return false;
+            }
+            return true;
+        }
+
+        private OffsetLogCurveJob CreateJob(double? depthOffset = null, long? timeOffsetMilliseconds = null)
+        {
+            return new OffsetLogCurveJob
+            {
+                LogCurveInfoReferences = new ComponentReferences
+                {
+                    Parent = new ObjectReference
+                    {
+                        WellUid = WellUid,
+                        WellboreUid = WellboreUid,
+                        Uid = LogUid,
+                        WellName = WellName,
+                        WellboreName = WellboreName,
+                        Name = LogName
+                    },
+                    ComponentUids = new string[] { "Curve1", }
+                },
+                DepthOffset = depthOffset,
+                TimeOffsetMilliseconds = timeOffsetMilliseconds,
+                JobInfo = new JobInfo
+                {
+                    Id = "123"
+                }
+            };
+        }
+
+        private void SetupClient(Mock<IWitsmlClient> witsmlClient, string indexType)
+        {
+            WitsmlLogs logHeader = GetTestLogHeader(indexType);
+            WitsmlLogs logData = GetTestLogData(indexType);
+
+            int getDataCount = 0;
+            // Mock fetching log
+            witsmlClient.Setup(client =>
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                .Returns((WitsmlLogs logs, OptionsIn options) =>
+            {
+                // Mock fetching the header
+                if (options.ReturnElements == ReturnElements.HeaderOnly)
+                {
+                    return Task.FromResult(logHeader);
+                }
+                // Mock feching log data for each log
+                else if (options.ReturnElements == ReturnElements.DataOnly)
+                {
+                    getDataCount++; // LogDataReader calls GetFromStoreAsync multiple times, so simulate end of data for every 2nd call.
+                    return getDataCount % 2 == 0
+                        ? Task.FromResult(new WitsmlLogs())
+                        : Task.FromResult(logData);
+                }
+                throw new ArgumentException("The sent request has not been mocked.");
+            });
+
+            witsmlClient.Setup(client =>
+                client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>()))
+                .Returns((WitsmlLogs logs) =>
+            {
+                return Task.FromResult(new QueryResult(true));
+            });
+
+            witsmlClient.Setup(client =>
+                client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()))
+                .Returns((WitsmlLogs logs) =>
+            {
+                return Task.FromResult(new QueryResult(true));
+            });
+        }
+
+        private WitsmlLogs GetTestLogHeader(string indexType)
+        {
+
+            return new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog>
+                {
+                    new WitsmlLog
+                    {
+                        Uid = LogUid,
+                        Name = LogName,
+                        UidWell = WellUid,
+                        NameWell = WellName,
+                        UidWellbore = WellboreUid,
+                        NameWellbore = WellboreName,
+                        Direction = WitsmlLog.WITSML_DIRECTION_INCREASING,
+                        IndexType = indexType,
+                        StartIndex = new WitsmlIndex { Value = "0", Uom = "m" },
+                        EndIndex = new WitsmlIndex { Value = "5", Uom = "m" },
+                        StartDateTimeIndex = "2024-01-16T15:00:00.000Z",
+                        EndDateTimeIndex = "2024-01-16T16:00:00.000Z",
+                        IndexCurve = new WitsmlIndexCurve { Value = "IndexCurve" },
+                        LogCurveInfo = new List<WitsmlLogCurveInfo>
+                        {
+                            new WitsmlLogCurveInfo
+                            {
+                                Uid = "Curve1",
+                                Mnemonic = "Curve1",
+                                MinIndex = new WitsmlIndex { Value = "0", Uom = "m" },
+                                MaxIndex = new WitsmlIndex { Value = "5", Uom = "m" },
+                                MinDateTimeIndex = "2024-01-16T15:00:00.000Z",
+                                MaxDateTimeIndex = "2024-01-16T16:00:00.000Z"
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        private WitsmlLogs GetTestLogData(string indexType)
+        {
+            var isDepthLog = indexType == WitsmlLog.WITSML_INDEX_TYPE_MD;
+            return new WitsmlLogs
+            {
+                Logs = new List<WitsmlLog>
+                {
+                    new WitsmlLog
+                    {
+                        Uid = LogUid,
+                        Name = LogName,
+                        UidWell = WellUid,
+                        NameWell = WellName,
+                        UidWellbore = WellboreUid,
+                        NameWellbore = WellboreName,
+                        IndexType = indexType,
+                        LogData = new WitsmlLogData
+                        {
+                            MnemonicList="IndexCurve,Curve1",
+                            UnitList="m,m",
+                            Data = isDepthLog
+                                ? new List<WitsmlData>
+                                {
+                                    new WitsmlData{ Data = "0,0" },
+                                    new WitsmlData{ Data = "1,1" },
+                                    new WitsmlData{ Data = "2,2" },
+                                    new WitsmlData{ Data = "3,3" },
+                                    new WitsmlData{ Data = "4,4" },
+                                    new WitsmlData{ Data = "5,5" },
+                                }
+                                : new List<WitsmlData>
+                                {
+                                    new WitsmlData{ Data = "2024-01-16T15:00:00.000Z,0" },
+                                    new WitsmlData{ Data = "2024-01-16T15:15:00.000Z,1" },
+                                    new WitsmlData{ Data = "2024-01-16T15:30:00.000Z,2" },
+                                    new WitsmlData{ Data = "2024-01-16T15:45:00.000Z,3" },
+                                    new WitsmlData{ Data = "2024-01-16T16:00:00.000Z,4" },
+                                }
+                        }
+                    }
+                }
+            };
+        }
+
+    }
+}

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
@@ -11,7 +11,6 @@ using Serilog;
 
 using Witsml;
 using Witsml.Data;
-using Witsml.Extensions;
 using Witsml.ServiceReference;
 
 using WitsmlExplorer.Api.Jobs;
@@ -58,7 +57,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             [(10,0), (11,1), (12,2), (13,3), (14,4), (15,5)]
             */
 
-            var job = CreateJob(depthOffset: 10);
+            var job = CreateJob("0", "5", depthOffset: 10);
             SetupClient(_witsmlClient, WitsmlLog.WITSML_INDEX_TYPE_MD);
             var expectedData = new List<string>
             {
@@ -90,10 +89,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             [(2024-01-16T16:00:00.000Z,0), (2024-01-16T16:15:00.000Z,1), (2024-01-16T16:30:00.000Z,2), (2024-01-16T16:45:00.000Z,3), (2024-01-16T17:00:00.000Z,4)]
             */
 
-            DateTime test = new(2024, 1, 16);
-            string testString = test.ToISODateTimeString();
-
-            var job = CreateJob(timeOffsetMilliseconds: 60 * 60 * 1000);
+            var job = CreateJob("2024-01-16T15:00:00.000Z", "2024-01-16T16:00:00.000Z", timeOffsetMilliseconds: 60 * 60 * 1000);
             SetupClient(_witsmlClient, WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME);
             var expectedData = new List<string>
             {
@@ -122,7 +118,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             return true;
         }
 
-        private OffsetLogCurveJob CreateJob(double? depthOffset = null, long? timeOffsetMilliseconds = null)
+        private OffsetLogCurveJob CreateJob(string startIndex, string endIndex, double? depthOffset = null, long? timeOffsetMilliseconds = null)
         {
             return new OffsetLogCurveJob
             {
@@ -141,6 +137,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 },
                 DepthOffset = depthOffset,
                 TimeOffsetMilliseconds = timeOffsetMilliseconds,
+                StartIndex = startIndex,
+                EndIndex = endIndex,
                 JobInfo = new JobInfo
                 {
                     Id = "123"


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #1948, #1949 and #1950

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Added a job that offsets log curve indexes for both time and depth logs. The job can be run from both the curve context menu and log data context menu.

![image](https://github.com/equinor/witsml-explorer/assets/70512270/115e111f-b97a-41cd-9b1d-26dad86f9910)

Added an option for a safety mechanism that saves the data that is to be offset into a temporary log.


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


