### PR TITLE
FIX-2137 OperationContext Cleanup

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Alerts.tsx
@@ -2,9 +2,9 @@ import { Icon } from "@equinor/eds-core-react";
 import { Alert, AlertTitle, Collapse } from "@mui/material";
 import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
+import { useOperationState } from "hooks/useOperationState";
 import { capitalize } from "lodash";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import NotificationService from "services/notificationService";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
@@ -21,7 +21,7 @@ const Alerts = (): React.ReactElement => {
   const { connectedServer } = useConnectedServer();
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   useEffect(() => {
     const unsubscribeOnConnectionStateChanged =

--- a/Src/WitsmlExplorer.Frontend/components/ApplicationVersion.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ApplicationVersion.tsx
@@ -1,9 +1,9 @@
 import { EdsProvider, Typography } from "@equinor/eds-core-react";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
+import { useOperationState } from "hooks/useOperationState";
 import JobStatus from "models/jobStatus";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import JobService from "services/jobService";
 import NotificationService from "services/notificationService";
 import styled from "styled-components";
@@ -58,7 +58,7 @@ interface UpdateStatus {
 function DesktopUpdateStatus() {
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>(null);
 
   useEffect(() => {

--- a/Src/WitsmlExplorer.Frontend/components/Breadcrumbs.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Breadcrumbs.tsx
@@ -1,10 +1,10 @@
 import { Breadcrumbs as EdsBreadcrumbs } from "@equinor/eds-core-react";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useGetWell } from "hooks/query/useGetWell";
 import { useGetWellbore } from "hooks/query/useGetWellbore";
 import { useGetActiveRoute } from "hooks/useGetActiveRoute";
+import { useOperationState } from "hooks/useOperationState";
 import { capitalize } from "lodash";
 import {
   ObjectType,
@@ -14,7 +14,7 @@ import {
 import { Server } from "models/server";
 import Well from "models/well";
 import Wellbore from "models/wellbore";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   NavLink,
   NavigateFunction,
@@ -42,7 +42,7 @@ import { v4 as uuid } from "uuid";
 export function Breadcrumbs() {
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
   const {
     isJobsView,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
@@ -9,13 +9,13 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import BhaRun from "models/bhaRun";
 import { ObjectType } from "models/objectType";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 
 export interface BhaRunRow extends ContentTableRow, BhaRun {
@@ -26,7 +26,7 @@ export default function BhaRunsListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { objects: bhaRuns } = useGetObjects(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
@@ -5,17 +5,16 @@ import {
 } from "components/ContentViews/table";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
-import { useContext } from "react";
 import { useParams } from "react-router-dom";
 
 export default function ChangeLogsListView() {
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/Charts/LogsGraph.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/Charts/LogsGraph.tsx
@@ -4,6 +4,7 @@ import {
   CustomSeriesRenderItemAPI,
   CustomSeriesRenderItemParams
 } from "echarts";
+import { useOperationState } from "hooks/useOperationState";
 
 import {
   ReactEChartsProps,
@@ -11,10 +12,9 @@ import {
 } from "components/ContentViews/Charts/ReactLogChart";
 import { ContentTableRow } from "components/ContentViews/table";
 import formatDateString from "components/DateFormatter";
-import OperationContext from "contexts/operationContext";
 import { DateTimeFormat } from "contexts/operationStateReducer";
 import LogObject from "models/logObject";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { RouterLogType } from "routes/routerConstants";
 
@@ -57,11 +57,11 @@ export const LogsGraph = (props: LogsGraphProps): React.ReactElement => {
   const categories: number[] = [];
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { logs } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { logType } = useParams();
 
   const isTimeIndexed = logType === RouterLogType.TIME;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesPlot.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesPlot.tsx
@@ -4,10 +4,10 @@ import {
 } from "components/ContentViews/table";
 import formatDateString from "components/DateFormatter";
 import { ContentViewDimensionsContext } from "components/PageLayout";
-import OperationContext from "contexts/operationContext";
 import { DateTimeFormat, TimeZone } from "contexts/operationStateReducer";
 import { ECharts } from "echarts";
 import ReactEcharts from "echarts-for-react";
+import { useOperationState } from "hooks/useOperationState";
 import { CurveSpecification } from "models/logData";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
@@ -46,7 +46,7 @@ export const CurveValuesPlot = React.memo(
     );
     const {
       operationState: { colors, dateTimeFormat }
-    } = useContext(OperationContext);
+    } = useOperationState();
     const chart = useRef<ECharts>(null);
     const selectedLabels = useRef<Record<string, boolean>>(null);
     const scrollIndex = useRef<number>(0);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -30,7 +30,6 @@ import { ShowLogDataOnServerModal } from "components/Modals/ShowLogDataOnServerM
 import ProgressSpinner from "components/ProgressSpinner";
 import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { DispatchOperation, UserTheme } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
@@ -38,6 +37,7 @@ import { useGetObject } from "hooks/query/useGetObject";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
 import useExport from "hooks/useExport";
 import { useGetMnemonics } from "hooks/useGetMnemonics";
+import { useOperationState } from "hooks/useOperationState";
 import orderBy from "lodash/orderBy";
 import { ComponentType } from "models/componentType";
 import { IndexRange } from "models/jobs/deleteLogCurveValuesJob";
@@ -48,7 +48,6 @@ import { ObjectType } from "models/objectType";
 import React, {
   CSSProperties,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -90,7 +89,7 @@ export const CurveValuesView = (): React.ReactElement => {
   const {
     operationState: { timeZone, dateTimeFormat, colors, theme },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [searchParams, setSearchParams] = useSearchParams();
   const mnemonicsSearchParams = searchParams.get("mnemonics");
   const startIndex = searchParams.get("startIndex");

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/EditNumber.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/EditNumber.tsx
@@ -1,8 +1,8 @@
 import { Icon, Label, TextField } from "@equinor/eds-core-react";
 import { Tooltip } from "@mui/material";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
-import { ChangeEvent, ReactElement, useContext, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { ChangeEvent, ReactElement, useState } from "react";
 import styled from "styled-components";
 import { TooltipLayout } from "../StyledComponents/Tooltip";
 
@@ -24,7 +24,7 @@ const EditNumber = (props: EditNumberProps): ReactElement => {
   } = props;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [isEdited, setIsEdited] = useState(false);
   const [value, setValue] = useState<string>(String(defaultValue));
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/EditSelectedLogCurveInfo.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/EditSelectedLogCurveInfo.tsx
@@ -11,17 +11,16 @@ import formatDateString, {
 } from "components/DateFormatter";
 import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { DateTimeFormat, TimeZone } from "contexts/operationStateReducer";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetMnemonics } from "hooks/useGetMnemonics";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import {
   CSSProperties,
   ChangeEvent,
   Dispatch,
   SetStateAction,
-  useContext,
   useEffect,
   useState
 } from "react";
@@ -49,7 +48,7 @@ const EditSelectedLogCurveInfo = (
 ): React.ReactElement => {
   const { disabled, overrideStartIndex, overrideEndIndex, onClickRefresh } =
     props;
-  const { operationState } = useContext(OperationContext);
+  const { operationState } = useOperationState();
   const { theme, colors, timeZone } = operationState;
   const { wellUid, wellboreUid, logType, objectUid } = useParams();
   const isTimeLog = logType === RouterLogType.TIME;

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ErrorView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ErrorView.tsx
@@ -1,6 +1,5 @@
-import { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
 import styled from "styled-components";
-import OperationContext from "../../contexts/operationContext";
 import { useErrorMessage } from "../../hooks/useErrorMessage";
 import { Colors } from "../../styles/Colors";
 import Icon from "../../styles/Icons";
@@ -9,7 +8,7 @@ export function ErrorView() {
   const errorMessage = useErrorMessage();
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   return (
     <>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
@@ -9,14 +9,14 @@ import FluidsReportContextMenu from "components/ContextMenus/FluidsReportContext
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import FluidsReport from "models/fluidsReport";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 export interface FluidsReportRow extends ContentTableRow, FluidsReport {
@@ -27,7 +27,7 @@ export default function FluidsReportsListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
   const navigate = useNavigate();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
@@ -10,16 +10,16 @@ import FluidContextMenu, {
 } from "components/ContextMenus/FluidContextMenu";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import Fluid from "models/fluid";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 
@@ -32,7 +32,7 @@ interface FluidsRow extends ContentTableRow, FluidAsStrings {
 }
 
 export default function FluidsView() {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { object: fluidsReport } = useGetObject(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
@@ -9,15 +9,15 @@ import FormationMarkerContextMenu from "components/ContextMenus/FormationMarkerC
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import FormationMarker from "models/formationMarker";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
 import StratigraphicStruct from "models/stratigraphicStruct";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 
 export interface FormationMarkerRow extends ContentTableRow {
@@ -27,8 +27,8 @@ export interface FormationMarkerRow extends ContentTableRow {
 export default function FormationMarkersListView() {
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
-  const { dispatchOperation } = useContext(OperationContext);
+  } = useOperationState();
+  const { dispatchOperation } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
   const { objects: formationMarkers } = useGetObjects(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -13,12 +13,12 @@ import formatDateString from "components/DateFormatter";
 import { ReportModal } from "components/Modals/ReportModal";
 import { generateReport } from "components/ReportCreationHelper";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { refreshJobInfoQuery } from "hooks/query/queryRefreshHelpers";
 import { useGetJobInfo } from "hooks/query/useGetJobInfo";
 import { useGetServers } from "hooks/query/useGetServers";
 import useExport from "hooks/useExport";
+import { useOperationState } from "hooks/useOperationState";
 import JobStatus from "models/jobStatus";
 import ReportType from "models/reportType";
 import { Server } from "models/server";
@@ -28,7 +28,7 @@ import {
   getUserAppRoles,
   msalEnabled
 } from "msal/MsalAuthProvider";
-import React, { ChangeEvent, useContext, useMemo, useState } from "react";
+import React, { ChangeEvent, useMemo, useState } from "react";
 import JobService from "services/jobService";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
@@ -37,7 +37,7 @@ export const JobsView = (): React.ReactElement => {
   const {
     dispatchOperation,
     operationState: { timeZone, colors, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const queryClient = useQueryClient();
   const { servers } = useGetServers();
   const [showAll, setShowAll] = useState(false);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
@@ -8,17 +8,17 @@ import ProgressSpinner from "components/ProgressSpinner";
 import { CommonPanelContainer } from "components/StyledComponents/Container";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import { useCurveThreshold } from "contexts/curveThresholdContext";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 import { RouterLogType } from "routes/routerConstants";
@@ -34,8 +34,8 @@ export default function LogCurveInfoListView() {
   const { curveThreshold } = useCurveThreshold();
   const {
     operationState: { timeZone, dateTimeFormat, theme }
-  } = useContext(OperationContext);
-  const { dispatchOperation } = useContext(OperationContext);
+  } = useOperationState();
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, logType, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { servers } = useGetServers();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -16,15 +16,15 @@ import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems"
 import formatDateString from "components/DateFormatter";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useGetWellbore } from "hooks/query/useGetWellbore";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
-import { MouseEvent, useContext, useState } from "react";
+import { MouseEvent, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 import { RouterLogType } from "routes/routerConstants";
@@ -42,7 +42,7 @@ export default function LogsListView() {
   const {
     dispatchOperation,
     operationState: { timeZone, dateTimeFormat, theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [showGraph, setShowGraph] = useState<boolean>(false);
   const [selectedRows, setSelectedRows] = useState([]);
   const navigate = useNavigate();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -9,13 +9,13 @@ import MessageObjectContextMenu from "components/ContextMenus/MessageObjectConte
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import MessageObject from "models/messageObject";
 import { ObjectType } from "models/objectType";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 
 export interface MessageObjectRow extends ContentTableRow {
@@ -26,7 +26,7 @@ export default function MessagesListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { objects: messages } = useGetObjects(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
@@ -10,16 +10,16 @@ import GeologyIntervalContextMenu, {
 } from "components/ContextMenus/GeologyIntervalContextMenu";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import GeologyInterval from "models/geologyInterval";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 
@@ -43,7 +43,7 @@ export interface GeologyIntervalRow extends ContentTableRow {
 }
 
 export default function MudLogView() {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { object: mudLog, isFetched: isFetchedMudLog } = useGetObject(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
@@ -9,14 +9,14 @@ import MudLogContextMenu from "components/ContextMenus/MudLogContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { measureToString } from "models/measure";
 import MudLog from "models/mudLog";
 import { ObjectType } from "models/objectType";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 export interface MudLogRow extends ContentTableRow {
@@ -35,7 +35,7 @@ export default function MudLogsListView() {
   const {
     dispatchOperation,
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MultiLogCurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MultiLogCurveValuesView.tsx
@@ -10,14 +10,14 @@ import {
 import formatDateString from "components/DateFormatter";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { CurveSpecification, LogData, LogDataRow } from "models/logData";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useLocation, useParams, useSearchParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 import { truncateAbortHandler } from "services/apiClient";
@@ -34,7 +34,7 @@ interface CurveValueRow extends LogDataRow, ContentTableRow {}
 export const MultiLogCurveValuesView = (): React.ReactElement => {
   const {
     operationState: { timeZone, dateTimeFormat, theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const mnemonicsSearchParams = searchParams.get("mnemonics");

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MultiLogsCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MultiLogsCurveInfoListView.tsx
@@ -4,13 +4,13 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import LogCurveInfoContextMenu, {
   LogCurveInfoContextMenuProps
 } from "components/ContextMenus/LogCurveInfoContextMenu";
+import { useOperationState } from "hooks/useOperationState";
 
 import ProgressSpinner from "components/ProgressSpinner";
 import { CommonPanelContainer } from "components/StyledComponents/Container";
 import { useConnectedServer } from "contexts/connectedServerContext";
 
 import { useCurveThreshold } from "contexts/curveThresholdContext";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -19,7 +19,7 @@ import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
 import LogCurveInfo from "models/logCurveInfo";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { RouterLogType } from "routes/routerConstants";
 import { truncateAbortHandler } from "services/apiClient";
@@ -35,8 +35,8 @@ export default function MultiLogsCurveInfoListView() {
   const { curveThreshold } = useCurveThreshold();
   const {
     operationState: { timeZone, dateTimeFormat, theme }
-  } = useContext(OperationContext);
-  const { dispatchOperation } = useContext(OperationContext);
+  } = useOperationState();
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, logType } = useParams();
   const { connectedServer } = useConnectedServer();
   const [logCurveInfoList, setLogCurveInfoList] = useState<LogCurveInfo[]>();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ObjectSearchListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ObjectSearchListView.tsx
@@ -23,10 +23,10 @@ import {
   ObjectFilterType,
   filterTypeToProperty
 } from "contexts/filter";
-import OperationContext from "contexts/operationContext";
 import { MousePosition } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetObjectSearch } from "hooks/query/useGetObjectSearch";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
@@ -58,7 +58,7 @@ export interface ObjectSearchRow extends ContentTableRow, ObjectOnWellbore {
 
 export const ObjectSearchListView = (): ReactElement => {
   const { connectedServer } = useConnectedServer();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { selectedFilter, updateSelectedFilter } = useContext(FilterContext);
   const [searchParams] = useSearchParams();
   const { filterType } = useParams<{ filterType: ObjectFilterType }>();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/QueryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/QueryView.tsx
@@ -12,10 +12,10 @@ import { QueryEditor } from "components/QueryEditor";
 import { getTag } from "components/QueryEditorUtils";
 import { StyledNativeSelect } from "components/Select";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import { DispatchOperation } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { QueryActionType, QueryContext } from "contexts/queryContext";
+import { useOperationState } from "hooks/useOperationState";
 import React, { ChangeEvent, useContext, useState } from "react";
 import QueryService from "services/queryService";
 import styled from "styled-components";
@@ -26,7 +26,7 @@ const QueryView = (): React.ReactElement => {
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const {
     queryState: { queries, tabIndex },
     dispatchQuery

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
@@ -9,13 +9,13 @@ import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems"
 import RigContextMenu from "components/ContextMenus/RigContextMenu";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import Rig from "models/rig";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 
 export interface RigRow extends ContentTableRow, Rig {
@@ -26,7 +26,7 @@ export default function RigsListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { objects: rigs } = useGetObjects(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -9,13 +9,13 @@ import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems"
 import RiskObjectContextMenu from "components/ContextMenus/RiskContextMenu";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import RiskObject from "models/riskObject";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 
 export interface RiskObjectRow extends ContentTableRow, RiskObject {
@@ -26,7 +26,7 @@ export default function RisksListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { objects: risks } = useGetObjects(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ServerManager.tsx
@@ -18,12 +18,12 @@ import { useConnectedServer } from "contexts/connectedServerContext";
 import { getSearchRegex } from "contexts/filter";
 import { useLoggedInUsernames } from "contexts/loggedInUsernamesContext";
 import { LoggedInUsernamesActionType } from "contexts/loggedInUsernamesReducer";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { Server, emptyServer } from "models/server";
 import { adminRole, getUserAppRoles, msalEnabled } from "msal/MsalAuthProvider";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getWellsViewPath } from "routes/utils/pathBuilder";
 import AuthorizationService from "services/authorizationService";
@@ -44,7 +44,7 @@ const ServerManager = (): React.ReactElement => {
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const editDisabled = msalEnabled && !getUserAppRoles().includes(adminRole);
   const navigate = useNavigate();
   const { connectedServer, setConnectedServer } = useConnectedServer();
@@ -269,7 +269,7 @@ const ConnectButton = ({ isConnected, ...props }: ConnectButtonProps) => {
   const [isHovered, setIsHovered] = React.useState(false);
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   return (
     <StyledConnectButton

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
@@ -8,21 +8,21 @@ import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems"
 import TrajectoryContextMenu from "components/ContextMenus/TrajectoryContextMenu";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
 import Trajectory from "models/trajectory";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 export default function TrajectoriesListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
@@ -11,16 +11,16 @@ import TrajectoryStationContextMenu, {
 import formatDateString from "components/DateFormatter";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
 import TrajectoryStation from "models/trajectoryStation";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 
@@ -38,8 +38,8 @@ export interface TrajectoryStationRow extends ContentTableRow {
 export default function TrajectoryView() {
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
-  const { dispatchOperation } = useContext(OperationContext);
+  } = useOperationState();
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { object: trajectory, isFetched: isFetchedTrajectory } = useGetObject(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
@@ -10,15 +10,15 @@ import TubularComponentContextMenu, {
 } from "components/ContextMenus/TubularComponentContextMenu";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { ObjectType } from "models/objectType";
 import TubularComponent from "models/tubularComponent";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 
@@ -35,7 +35,7 @@ export interface TubularComponentRow extends ContentTableRow {
 }
 
 export default function TubularView() {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { object: tubular, isFetched: isFetchedTubular } = useGetObject(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -8,20 +8,20 @@ import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems"
 import TubularContextMenu from "components/ContextMenus/TubularContextMenu";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import Tubular from "models/tubular";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 export default function TubularsListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ViewNotFound.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ViewNotFound.tsx
@@ -1,12 +1,11 @@
-import { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
 import styled from "styled-components";
-import OperationContext from "../../contexts/operationContext";
 import { Colors } from "../../styles/Colors";
 
 export function ViewNotFound() {
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   return (
     <>
       <Heading colors={colors}>404 Not Found</Heading>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
@@ -9,14 +9,14 @@ import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems"
 import WbGeometryObjectContextMenu from "components/ContextMenus/WbGeometryContextMenu";
 import formatDateString from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
 import WbGeometryObject from "models/wbGeometry";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 export interface WbGeometryObjectRow extends ContentTableRow, WbGeometryObject {
@@ -27,7 +27,7 @@ export default function WbGeometriesListView() {
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
@@ -10,16 +10,16 @@ import WbGeometrySectionContextMenu, {
 } from "components/ContextMenus/WbGeometrySectionContextMenu";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { measureToString } from "models/measure";
 import { ObjectType } from "models/objectType";
 import WbGeometrySection from "models/wbGeometrySection";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 
@@ -28,7 +28,7 @@ interface WbGeometrySectionRow extends ContentTableRow {
 }
 
 export default function WbGeometryView() {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const { object: wbGeometry, isFetched: isFetchedWbGeometry } = useGetObject(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboreSearchListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboreSearchListView.tsx
@@ -17,11 +17,11 @@ import {
   WellboreFilterType,
   filterTypeToProperty
 } from "contexts/filter";
-import OperationContext from "contexts/operationContext";
 import { MousePosition } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useGetWellboreSearch } from "hooks/query/useGetWellboreSearch";
+import { useOperationState } from "hooks/useOperationState";
 import Well from "models/well";
 import Wellbore from "models/wellbore";
 import React, { ReactElement, useContext, useEffect } from "react";
@@ -37,7 +37,7 @@ export interface WellboreSearchRow extends ContentTableRow, Wellbore {
 
 export const WellboreSearchListView = (): ReactElement => {
   const { connectedServer } = useConnectedServer();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { selectedFilter, updateSelectedFilter } = useContext(FilterContext);
   const [searchParams] = useSearchParams();
   const { filterType } = useParams<{ filterType: WellboreFilterType }>();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -11,15 +11,15 @@ import WellboreContextMenu, {
 import formatDateString from "components/DateFormatter";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useGetWell } from "hooks/query/useGetWell";
 import { useGetWellbores } from "hooks/query/useGetWellbores";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
+import { useOperationState } from "hooks/useOperationState";
 import EntityType from "models/entityType";
 import Wellbore from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 import { OBJECT_GROUPS_PATH } from "routes/routerConstants";
@@ -43,7 +43,7 @@ export default function WellboresListView() {
   const {
     dispatchOperation,
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
 
   useExpandSidebarNodes(wellUid);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -12,12 +12,12 @@ import WellContextMenu, {
 import formatDateString from "components/DateFormatter";
 import ProgressSpinner from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useGetWells } from "hooks/query/useGetWells";
+import { useOperationState } from "hooks/useOperationState";
 import Well from "models/well";
-import React, { useContext } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { WELLBORES_PATH } from "routes/routerConstants";
 
@@ -32,7 +32,7 @@ export default function WellsListView() {
   const {
     dispatchOperation,
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const navigate = useNavigate();
 
   const columns: ContentTableColumn[] = [

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ColumnDef.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ColumnDef.tsx
@@ -21,9 +21,9 @@ import {
   ContentType
 } from "components/ContentViews/table/tableParts";
 import { getSearchRegex } from "contexts/filter";
-import OperationContext from "contexts/operationContext";
 import { DecimalPreference, UserTheme } from "contexts/operationStateReducer";
-import { useContext, useMemo } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { useMemo } from "react";
 import Icon from "styles/Icons";
 import {
   STORAGE_CONTENTTABLE_ORDER_KEY,
@@ -47,7 +47,7 @@ export const useColumnDef = (
 ) => {
   const {
     operationState: { decimals, theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const isCompactMode = theme === UserTheme.Compact;
 
   return useMemo(() => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ColumnOptionsMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ColumnOptionsMenu.tsx
@@ -18,17 +18,11 @@ import {
   ContentType
 } from "components/ContentViews/table/tableParts";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import { useLocalStorageState } from "hooks/useLocalStorageState";
+import { useOperationState } from "hooks/useOperationState";
 import { debounce } from "lodash";
-import {
-  ChangeEvent,
-  useCallback,
-  useContext,
-  useEffect,
-  useState
-} from "react";
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { checkIsUrlTooLong } from "routes/utils/checkIsUrlTooLong";
 import styled from "styled-components";
@@ -65,7 +59,7 @@ export const ColumnOptionsMenu = (props: {
   } = props;
   const {
     operationState: { colors, theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [draggedId, setDraggedId] = useState<string | null>();
   const [draggedOverId, setDraggedOverId] = useState<string | null>();
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -45,11 +45,11 @@ import {
   ContentTableColumn,
   ContentTableProps
 } from "components/ContentViews/table/tableParts";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
+import { useOperationState } from "hooks/useOperationState";
 import { indexToNumber } from "models/logObject";
 import * as React from "react";
-import { Fragment, useContext, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { Colors } from "styles/Colors";
 import Icon from "styles/Icons";
 
@@ -83,7 +83,7 @@ export const ContentTable = React.memo(
     } = contentTableProps;
     const {
       operationState: { colors, theme }
-    } = useContext(OperationContext);
+    } = useOperationState();
     const [previousIndex, setPreviousIndex] = useState<number>(null);
     const [rowSelection, setRowSelection] = useState<RowSelectionState>(
       Object.assign(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
@@ -3,7 +3,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Table } from "@tanstack/react-table";
 import { ColumnOptionsMenu } from "components/ContentViews/table/ColumnOptionsMenu";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import {
   refreshObjectQuery,
   refreshObjectsQuery,
@@ -11,8 +10,9 @@ import {
   refreshWellsQuery
 } from "hooks/query/queryRefreshHelpers";
 import useExport, { encloseCell } from "hooks/useExport";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
-import React, { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import Icon from "styles/Icons";
@@ -50,7 +50,7 @@ const Panel = (props: PanelProps) => {
   } = props;
   const {
     operationState: { theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { exportData, exportOptions } = useExport();
   const abortRefreshControllerRef = React.useRef<AbortController>();
   const queryClient = useQueryClient();

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/SortableEdsTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/SortableEdsTable.tsx
@@ -1,6 +1,6 @@
 import { CellProps, Table } from "@equinor/eds-core-react";
-import OperationContext from "contexts/operationContext";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
 import Icon from "styles/Icons";
@@ -37,7 +37,7 @@ const SortableEdsTable = (props: SortableEdsTableProps): React.ReactElement => {
   const { columns, data, caption } = props;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   const initColumns = (): Column[] =>
     columns.map((col) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/BatchModifyMenuItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/BatchModifyMenuItem.tsx
@@ -1,7 +1,7 @@
 import { Typography } from "@equinor/eds-core-react";
 import { MenuItem } from "@mui/material";
-import OperationContext from "contexts/operationContext";
-import { ReactElement, forwardRef, useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { ReactElement, forwardRef } from "react";
 import OperationType from "../../contexts/operationType";
 import ObjectOnWellbore from "../../models/objectOnWellbore";
 import { ObjectType } from "../../models/objectType";
@@ -24,7 +24,7 @@ export interface BatchModifyMenuItemProps {
 export const BatchModifyMenuItem = forwardRef(
   (props: BatchModifyMenuItemProps, ref: React.Ref<any>): ReactElement => {
     const { checkedObjects, objectType } = props;
-    const { dispatchOperation } = useContext(OperationContext);
+    const { dispatchOperation } = useOperationState();
     const batchModifyProperties = objectBatchModifyProperties[objectType];
 
     const onSubmitBatchModify = async (batchUpdates: {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/BhaRunContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/BhaRunContextMenu.tsx
@@ -12,20 +12,20 @@ import BhaRunPropertiesModal, {
 } from "components/Modals/BhaRunPropertiesModal";
 import { PropertiesModalMode } from "components/Modals/ModalParts";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import BhaRun from "models/bhaRun";
 import { ObjectType } from "models/objectType";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const BhaRunContextMenu = (
   props: ObjectContextMenuProps
 ): React.ReactElement => {
   const { checkedObjects } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const { servers } = useGetServers();
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenu.tsx
@@ -1,8 +1,8 @@
 import { Menu } from "@mui/material";
-import OperationContext from "contexts/operationContext";
 import { MousePosition } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
-import React, { ReactElement, useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import React, { ReactElement } from "react";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
 
@@ -25,7 +25,7 @@ export const getContextMenuPosition = (
 };
 
 const ContextMenu = (props: ContextMenuProps): React.ReactElement => {
-  const { operationState, dispatchOperation } = useContext(OperationContext);
+  const { operationState, dispatchOperation } = useOperationState();
   const { contextMenu, colors } = operationState;
 
   const handleClose = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuPresenter.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ContextMenuPresenter.tsx
@@ -1,8 +1,8 @@
-import React, { useContext } from "react";
-import OperationContext from "contexts/operationContext";
+import { useOperationState } from "hooks/useOperationState";
+import React from "react";
 
 const ContextMenuPresenter = (): React.ReactElement => {
-  const { operationState } = useContext(OperationContext);
+  const { operationState } = useOperationState();
   const { contextMenu } = operationState;
 
   return <>{contextMenu && contextMenu.component}</>;

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyComponentsToServer.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyComponentsToServer.tsx
@@ -6,14 +6,13 @@ import CopyRangeModal, {
   CopyRangeModalProps
 } from "components/Modals/CopyRangeModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import LogCurveInfo from "models/logCurveInfo";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { Server } from "models/server";
-import { useContext } from "react";
 import { copyComponentsToServer } from "./CopyComponentsToServerUtils";
 
 export interface CopyComponentsToServerMenuItemProps {
@@ -38,7 +37,7 @@ export const CopyComponentsToServerMenuItem = (
   } = props;
   const { connectedServer } = useConnectedServer();
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const menuComponents = menuItemText("copy", componentType, componentsToCopy);
   const menuText =
     withRange === true

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyComponentsToServerUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/CopyComponentsToServerUtils.tsx
@@ -21,12 +21,12 @@ import AuthorizationService from "../../services/authorizationService";
 import ComponentService from "../../services/componentService";
 import JobService, { JobType } from "../../services/jobService";
 import ObjectService from "../../services/objectService";
-import { displayMissingObjectModal } from "../Modals/MissingObjectModals";
-import { displayReplaceModal } from "../Modals/ReplaceModal";
-import { pluralize } from "./ContextMenuUtils";
 import CopyMnemonicsModal, {
   CopyMnemonicsModalProps
 } from "../Modals/CopyMnemonicsModal";
+import { displayMissingObjectModal } from "../Modals/MissingObjectModals";
+import { displayReplaceModal } from "../Modals/ReplaceModal";
+import { pluralize } from "./ContextMenuUtils";
 
 export interface OnClickCopyComponentToServerProps {
   targetServer: Server;

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/FluidContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/FluidContextMenu.tsx
@@ -15,15 +15,15 @@ import {
 import NestedMenuItem from "components/ContextMenus/NestedMenuItem";
 import { useClipboardComponentReferencesOfType } from "components/ContextMenus/UseClipboardComponentReferences";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import Fluid from "models/fluid";
 import FluidsReport from "models/fluidsReport";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
-import React, { useContext } from "react";
+import React from "react";
 import { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
 
@@ -34,7 +34,7 @@ export interface FluidContextMenuProps {
 
 const FluidContextMenu = (props: FluidContextMenuProps): React.ReactElement => {
   const { checkedFluids, fluidsReport } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const fluidReferences = useClipboardComponentReferencesOfType(
     ComponentType.Fluid
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/FluidsReportContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/FluidsReportContextMenu.tsx
@@ -13,12 +13,12 @@ import {
 } from "components/ContextMenus/ObjectMenuItems";
 import { useClipboardComponentReferencesOfType } from "components/ContextMenus/UseClipboardComponentReferences";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { ObjectType } from "models/objectType";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const FluidsReportContextMenu = (
@@ -26,7 +26,7 @@ const FluidsReportContextMenu = (
 ): React.ReactElement => {
   const { checkedObjects } = props;
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const fluidReferences = useClipboardComponentReferencesOfType(
     ComponentType.Fluid

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/FormationMarkerContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/FormationMarkerContextMenu.tsx
@@ -11,20 +11,20 @@ import FormationMarkerPropertiesModal, {
   FormationMarkerPropertiesModalProps
 } from "components/Modals/FormationMarkerPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import FormationMarker from "models/formationMarker";
 import { ObjectType } from "models/objectType";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const FormationMarkerContextMenu = (
   props: ObjectContextMenuProps
 ): React.ReactElement => {
   const { checkedObjects } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();
   const queryClient = useQueryClient();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/GeologyIntervalContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/GeologyIntervalContextMenu.tsx
@@ -14,14 +14,14 @@ import {
 import { useClipboardComponentReferencesOfType } from "components/ContextMenus/UseClipboardComponentReferences";
 import GeologyIntervalPropertiesModal from "components/Modals/GeologyIntervalPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import GeologyInterval from "models/geologyInterval";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import MudLog from "models/mudLog";
-import React, { useContext } from "react";
+import React from "react";
 import { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
 
@@ -34,7 +34,7 @@ const GeologyIntervalContextMenu = (
   props: GeologyIntervalContextMenuProps
 ): React.ReactElement => {
   const { checkedGeologyIntervals, mudLog } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { servers } = useGetServers();
   const { connectedServer } = useConnectedServer();
   const geologyIntervalReferences = useClipboardComponentReferencesOfType(

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurvePriorityContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogCurvePriorityContextMenu.tsx
@@ -1,7 +1,7 @@
 import { Typography } from "@equinor/eds-core-react";
 import { MenuItem } from "@mui/material";
-import React, { useContext } from "react";
-import OperationContext from "../../contexts/operationContext";
+import { useOperationState } from "hooks/useOperationState";
+import React from "react";
 import { MousePosition } from "../../contexts/operationStateReducer";
 import { StyledMenu, preventContextMenuPropagation } from "./ContextMenu";
 import { StyledIcon } from "./ContextMenuUtils";
@@ -17,7 +17,7 @@ export const LogCurvePriorityContextMenu = (
   props: LogCurvePriorityContextMenuProps
 ): React.ReactElement => {
   const { onDelete, onClose, position, open } = props;
-  const { operationState } = useContext(OperationContext);
+  const { operationState } = useOperationState();
   const { colors } = operationState;
 
   const onClickDelete = async () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/LogObjectContextMenu.tsx
@@ -37,11 +37,11 @@ import { ReportModal } from "components/Modals/ReportModal";
 import SpliceLogsModal from "components/Modals/SpliceLogsModal";
 import TrimLogObjectModal from "components/Modals/TrimLogObject/TrimLogObjectModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { DisplayModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import CheckLogHeaderJob from "models/jobs/checkLogHeaderJob";
 import CompareLogDataJob from "models/jobs/compareLogData";
@@ -50,7 +50,7 @@ import LogObject from "models/logObject";
 import ObjectOnWellbore, { toObjectReference } from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
-import React, { useContext } from "react";
+import React from "react";
 import { createSearchParams, useNavigate } from "react-router-dom";
 import { RouterLogType } from "routes/routerConstants";
 import {
@@ -69,7 +69,7 @@ const LogObjectContextMenu = (
   props: ObjectContextMenuProps
 ): React.ReactElement => {
   const { checkedObjects } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const logCurvesReference: CopyRangeClipboard =
     useClipboardComponentReferencesOfType(ComponentType.Mnemonic);

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/MessageObjectContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/MessageObjectContextMenu.tsx
@@ -21,22 +21,22 @@ import ObjectPickerModal, {
   ObjectPickerProps
 } from "components/Modals/ObjectPickerModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import MessageObject from "models/messageObject";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const MessageObjectContextMenu = (
   props: ObjectContextMenuProps
 ): React.ReactElement => {
   const { checkedObjects } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();
   const queryClient = useQueryClient();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/MnemonicsContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/MnemonicsContextMenu.tsx
@@ -10,8 +10,8 @@ import {
   OffsetLogCurveModal,
   OffsetLogCurveModalProps
 } from "components/Modals/OffsetLogCurveModal";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import {
   DeleteLogCurveValuesJob,
@@ -19,7 +19,7 @@ import {
 } from "models/jobs/deleteLogCurveValuesJob";
 import LogObject from "models/logObject";
 import { toObjectReference } from "models/objectOnWellbore";
-import React, { useContext } from "react";
+import React from "react";
 import JobService, { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
 
@@ -32,7 +32,7 @@ export interface MnemonicsContextMenuProps {
 const MnemonicsContextMenu = (
   props: MnemonicsContextMenuProps
 ): React.ReactElement => {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { log, mnemonics, indexRanges } = props;
 
   const deleteLogCurveValues = async () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/MudLogContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/MudLogContextMenu.tsx
@@ -16,14 +16,14 @@ import MudLogPropertiesModal, {
   MudLogPropertiesModalProps
 } from "components/Modals/MudLogPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import MudLog from "models/mudLog";
 import { ObjectType } from "models/objectType";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const MudLogContextMenu = (
@@ -34,7 +34,7 @@ const MudLogContextMenu = (
   const geologyIntervalReferences = useClipboardComponentReferencesOfType(
     ComponentType.GeologyInterval
   );
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();
   const queryClient = useQueryClient();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/NestedMenuItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/NestedMenuItem.tsx
@@ -2,13 +2,8 @@ import { Icon, Typography } from "@equinor/eds-core-react";
 import MenuItem, { MenuItemProps } from "@mui/material/MenuItem";
 import { StyledMenu } from "components/ContextMenus/ContextMenu";
 import { StyledIcon } from "components/ContextMenus/ContextMenuUtils";
-import OperationContext from "contexts/operationContext";
-import React, {
-  useContext,
-  useImperativeHandle,
-  useRef,
-  useState
-} from "react";
+import { useOperationState } from "hooks/useOperationState";
+import React, { useImperativeHandle, useRef, useState } from "react";
 
 export interface NestedMenuItemProps extends Omit<MenuItemProps, "button"> {
   label: string;
@@ -31,7 +26,7 @@ const NestedMenuItem = React.forwardRef<
   } = props;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   const { ref: containerRefProp, ...ContainerProps } = ContainerPropsProp;
 

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/ObjectsSidebarContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/ObjectsSidebarContextMenu.tsx
@@ -17,14 +17,14 @@ import { pasteObjectOnWellbore } from "components/ContextMenus/CopyUtils";
 import NestedMenuItem from "components/ContextMenus/NestedMenuItem";
 import { useClipboardReferencesOfType } from "components/ContextMenus/UseClipboardReferences";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { toWellboreReference } from "models/jobs/wellboreReference";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import Wellbore from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 import { v4 as uuid } from "uuid";
 
@@ -37,7 +37,7 @@ const ObjectsSidebarContextMenu = (
   props: ObjectsSidebarContextMenuProps
 ): React.ReactElement => {
   const { wellbore, objectType } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { servers } = useGetServers();
   const objectReferences = useClipboardReferencesOfType(objectType);
   const openInQueryView = useOpenInQueryView();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigContextMenu.tsx
@@ -13,18 +13,18 @@ import RigPropertiesModal, {
   RigPropertiesModalProps
 } from "components/Modals/RigPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import Rig from "models/rig";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const RigContextMenu = (props: ObjectContextMenuProps): React.ReactElement => {
   const { checkedObjects } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();
   const queryClient = useQueryClient();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigsContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RigsContextMenu.tsx
@@ -19,16 +19,16 @@ import RigPropertiesModal, {
   RigPropertiesModalProps
 } from "components/Modals/RigPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { DisplayModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { toWellboreReference } from "models/jobs/wellboreReference";
 import { ObjectType } from "models/objectType";
 import Rig from "models/rig";
 import { Server } from "models/server";
 import Wellbore from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 import { v4 as uuid } from "uuid";
 
@@ -39,7 +39,7 @@ export interface RigsContextMenuProps {
 
 const RigsContextMenu = (props: RigsContextMenuProps): React.ReactElement => {
   const { wellbore, servers } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const rigReferences = useClipboardReferencesOfType(ObjectType.Rig);
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/RiskContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/RiskContextMenu.tsx
@@ -12,13 +12,13 @@ import RiskPropertiesModal, {
   RiskPropertiesModalProps
 } from "components/Modals/RiskPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import RiskObject from "models/riskObject";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const RiskObjectContextMenu = (
@@ -26,7 +26,7 @@ const RiskObjectContextMenu = (
 ): React.ReactElement => {
   const { checkedObjects } = props;
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();
   const queryClient = useQueryClient();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoriesContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoriesContextMenu.tsx
@@ -19,16 +19,16 @@ import TrajectoryPropertiesModal, {
   TrajectoryPropertiesModalProps
 } from "components/Modals/TrajectoryPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { DisplayModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { toWellboreReference } from "models/jobs/wellboreReference";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import Trajectory from "models/trajectory";
 import Wellbore from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 import { v4 as uuid } from "uuid";
 
@@ -41,7 +41,7 @@ const TrajectoriesContextMenu = (
   props: TrajectoriesContextMenuProps
 ): React.ReactElement => {
   const { wellbore, servers } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const trajectoryReferences = useClipboardReferencesOfType(
     ObjectType.Trajectory
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryContextMenu.tsx
@@ -17,14 +17,14 @@ import TrajectoryPropertiesModal, {
   TrajectoryPropertiesModalProps
 } from "components/Modals/TrajectoryPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { ObjectType } from "models/objectType";
 import Trajectory from "models/trajectory";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const TrajectoryContextMenu = (
@@ -32,7 +32,7 @@ const TrajectoryContextMenu = (
 ): React.ReactElement => {
   const { checkedObjects } = props;
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const trajectoryStationReferences = useClipboardComponentReferencesOfType(
     ComponentType.TrajectoryStation
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TrajectoryStationContextMenu.tsx
@@ -17,15 +17,15 @@ import NestedMenuItem from "components/ContextMenus/NestedMenuItem";
 import { useClipboardComponentReferencesOfType } from "components/ContextMenus/UseClipboardComponentReferences";
 import TrajectoryStationPropertiesModal from "components/Modals/TrajectoryStationPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import Trajectory from "models/trajectory";
-import React, { useContext } from "react";
+import React from "react";
 import { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
 
@@ -38,7 +38,7 @@ const TrajectoryStationContextMenu = (
   props: TrajectoryStationContextMenuProps
 ): React.ReactElement => {
   const { checkedTrajectoryStations, trajectory } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { servers } = useGetServers();
   const { connectedServer } = useConnectedServer();
   const trajectoryStationReferences = useClipboardComponentReferencesOfType(

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularComponentContextMenu.tsx
@@ -19,15 +19,15 @@ import NestedMenuItem from "components/ContextMenus/NestedMenuItem";
 import { useClipboardComponentReferencesOfType } from "components/ContextMenus/UseClipboardComponentReferences";
 import TubularComponentPropertiesModal from "components/Modals/TubularComponentPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import Tubular from "models/tubular";
-import React, { useContext } from "react";
+import React from "react";
 import { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
 
@@ -41,7 +41,7 @@ const TubularComponentContextMenu = (
 ): React.ReactElement => {
   const { checkedTubularComponents, tubular } = props;
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const tubularComponentReferences = useClipboardComponentReferencesOfType(
     ComponentType.TubularComponent
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularContextMenu.tsx
@@ -15,14 +15,14 @@ import { useClipboardComponentReferencesOfType } from "components/ContextMenus/U
 import { PropertiesModalMode } from "components/Modals/ModalParts";
 import TubularPropertiesModal from "components/Modals/TubularPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { ObjectType } from "models/objectType";
 import Tubular from "models/tubular";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const TubularContextMenu = (
@@ -30,7 +30,7 @@ const TubularContextMenu = (
 ): React.ReactElement => {
   const { checkedObjects } = props;
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const tubularComponentReferences = useClipboardComponentReferencesOfType(
     ComponentType.TubularComponent
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularsContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/TubularsContextMenu.tsx
@@ -15,13 +15,13 @@ import { pasteObjectOnWellbore } from "components/ContextMenus/CopyUtils";
 import NestedMenuItem from "components/ContextMenus/NestedMenuItem";
 import { useClipboardReferencesOfType } from "components/ContextMenus/UseClipboardReferences";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { toWellboreReference } from "models/jobs/wellboreReference";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import Wellbore from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 import { v4 as uuid } from "uuid";
 
@@ -34,7 +34,7 @@ const TubularsContextMenu = (
   props: TubularsContextMenuProps
 ): React.ReactElement => {
   const { wellbore, servers } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const tubularReferences = useClipboardReferencesOfType(ObjectType.Tubular);
   const openInQueryView = useOpenInQueryView();
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometryContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometryContextMenu.tsx
@@ -17,14 +17,14 @@ import WbGeometryPropertiesModal, {
   WbGeometryPropertiesModalProps
 } from "components/Modals/WbGeometryPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { ObjectType } from "models/objectType";
 import WbGeometryObject from "models/wbGeometry";
-import React, { useContext } from "react";
+import React from "react";
 import { colors } from "styles/Colors";
 
 const WbGeometryObjectContextMenu = (
@@ -32,7 +32,7 @@ const WbGeometryObjectContextMenu = (
 ): React.ReactElement => {
   const { checkedObjects } = props;
   const { servers } = useGetServers();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const wbGeometrySectionReferences = useClipboardComponentReferencesOfType(
     ComponentType.WbGeometrySection
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometrySectionContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WbGeometrySectionContextMenu.tsx
@@ -16,16 +16,16 @@ import NestedMenuItem from "components/ContextMenus/NestedMenuItem";
 import { useClipboardComponentReferencesOfType } from "components/ContextMenus/UseClipboardComponentReferences";
 import WbGeometrySectionPropertiesModal from "components/Modals/WbGeometrySectionPropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import WbGeometry from "models/wbGeometry";
 import WbGeometrySection from "models/wbGeometrySection";
-import React, { useContext } from "react";
+import React from "react";
 import { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
 
@@ -41,7 +41,7 @@ const WbGeometrySectionContextMenu = (
   const wbGeometrySectionReferences = useClipboardComponentReferencesOfType(
     ComponentType.WbGeometrySection
   );
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { servers } = useGetServers();
   const { connectedServer } = useConnectedServer();
 

--- a/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContextMenus/WellboreContextMenu.tsx
@@ -31,19 +31,19 @@ import WellborePropertiesModal, {
   WellborePropertiesModalProps
 } from "components/Modals/WellborePropertiesModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { DisplayModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { refreshWellboreQuery } from "hooks/query/queryRefreshHelpers";
 import { useGetCapObjects } from "hooks/query/useGetCapObjects";
 import { useOpenInQueryView } from "hooks/useOpenInQueryView";
+import { useOperationState } from "hooks/useOperationState";
 import { DeleteWellboreJob } from "models/jobs/deleteJobs";
 import { toWellboreReference } from "models/jobs/wellboreReference";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
 import Wellbore from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { getObjectGroupsViewPath } from "routes/utils/pathBuilder";
 import JobService, { JobType } from "services/jobService";
 import { colors } from "styles/Colors";
@@ -60,7 +60,7 @@ const WellboreContextMenu = (
   props: WellboreContextMenuProps
 ): React.ReactElement => {
   const { wellbore, checkedWellboreRows, servers } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const openInQueryView = useOpenInQueryView();
   const objectReferences = useClipboardReferences();
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
@@ -1,5 +1,15 @@
+import OperationContext from "contexts/operationContext";
+import { ReactElement, useContext } from "react";
 import { createGlobalStyle } from "styled-components";
 import { Colors } from "styles/Colors";
+
+export const GlobalStylesWrapper = (): ReactElement => {
+  const {
+    operationState: { colors }
+  } = useContext(OperationContext);
+
+  return <GlobalStyles colors={colors} />;
+};
 
 const GlobalStyles = createGlobalStyle<{ colors: Colors }>`
 *,

--- a/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/GlobalStyles.tsx
@@ -1,12 +1,12 @@
-import OperationContext from "contexts/operationContext";
-import { ReactElement, useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { ReactElement } from "react";
 import { createGlobalStyle } from "styled-components";
 import { Colors } from "styles/Colors";
 
 export const GlobalStylesWrapper = (): ReactElement => {
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   return <GlobalStyles colors={colors} />;
 };

--- a/Src/WitsmlExplorer.Frontend/components/Modals/AnalyzeGapModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/AnalyzeGapModal.tsx
@@ -8,10 +8,10 @@ import ModalDialog from "components/Modals/ModalDialog";
 import { ReportModal } from "components/Modals/ReportModal";
 import AdjustDateTimeModal from "components/Modals/TrimLogObject/AdjustDateTimeModal";
 import AdjustNumberRangeModal from "components/Modals/TrimLogObject/AdjustNumberRangeModal";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import { formatIndexValue, indexToNumber } from "tools/IndexHelpers";
 
@@ -22,7 +22,7 @@ export interface AnalyzeGapModalProps {
 
 const AnalyzeGapModal = (props: AnalyzeGapModalProps): React.ReactElement => {
   const { logObject, mnemonics } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const timePattern = /^([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$/;
   const initialTime = "00:00:00";
   const [log] = useState<LogObject>(logObject);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/BatchModifyPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/BatchModifyPropertiesModal.tsx
@@ -1,7 +1,7 @@
 import { Autocomplete, TextField } from "@equinor/eds-core-react";
-import { ChangeEvent, ReactElement, useContext, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { ChangeEvent, ReactElement, useState } from "react";
 import styled from "styled-components";
-import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import ModalDialog from "./ModalDialog";
 
@@ -22,7 +22,7 @@ export const BatchModifyPropertiesModal = (
   props: BatchModifyModalProps
 ): ReactElement => {
   const { title, properties, onSubmit } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [batchUpdates, setBatchUpdates] = useState<{ [key: string]: string }>(
     properties.reduce((acc, prop) => ({ ...acc, [prop.property]: "" }), {})
   );

--- a/Src/WitsmlExplorer.Frontend/components/Modals/BhaRunPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/BhaRunPropertiesModal.tsx
@@ -3,16 +3,16 @@ import formatDateString from "components/DateFormatter";
 import { DateTimeField } from "components/Modals/DateTimeField";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import {
   DateTimeFormat,
   HideModalAction
 } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import BhaRun from "models/bhaRun";
 import { itemStateTypes } from "models/itemStateTypes";
 import { ObjectType } from "models/objectType";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 const typesOfBhaStatus = ["final", "progress", "plan", "unknown"];
@@ -29,7 +29,7 @@ const BhaRunPropertiesModal = (
   const { mode, bhaRun, dispatchOperation } = props;
   const {
     operationState: { timeZone }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableBhaRun, setEditableBhaRun] = useState<BhaRun>(null);
   const [dTimStartValid, setDTimStartValid] = useState<boolean>(true);
   const [dTimStopValid, setDTimStopValid] = useState<boolean>(true);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/CompareLogDataModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/CompareLogDataModal.tsx
@@ -3,11 +3,11 @@ import ModalDialog, {
   ModalWidth
 } from "components/Modals/ModalDialog";
 import { Checkbox } from "components/StyledComponents/Checkbox";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { Server } from "models/server";
-import { ChangeEvent, useContext, useState } from "react";
+import { ChangeEvent, useState } from "react";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
 
@@ -30,7 +30,7 @@ export default function CompareLogDataModal({
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [checkedCompareAllLogIndexes, setCheckedCompareAllLogIndexes] =
     useState(false);
   const onSubmit = async () => {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/CopyMnemonicsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/CopyMnemonicsModal.tsx
@@ -1,23 +1,23 @@
 import { Radio, Typography } from "@equinor/eds-core-react";
 import ModalDialog from "components/Modals/ModalDialog";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
-import { useContext, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { useState } from "react";
 import styled from "styled-components";
-import ObjectReference from "../../models/jobs/objectReference";
+import { ComponentType, getParentType } from "../../models/componentType";
 import ComponentReferences, {
   createComponentReferences
 } from "../../models/jobs/componentReferences";
 import { CopyComponentsJob } from "../../models/jobs/copyJobs";
-import JobService, { JobType } from "../../services/jobService";
 import { DeleteComponentsJob } from "../../models/jobs/deleteJobs";
+import ObjectReference from "../../models/jobs/objectReference";
 import { ReplaceComponentsJob } from "../../models/jobs/replaceComponentsJob";
-import { ComponentType, getParentType } from "../../models/componentType";
-import ComponentService from "../../services/componentService";
-import { Server } from "../../models/server";
-import ObjectService from "../../services/objectService";
-import AuthorizationService from "../../services/authorizationService";
 import LogObject from "../../models/logObject";
+import { Server } from "../../models/server";
+import AuthorizationService from "../../services/authorizationService";
+import ComponentService from "../../services/componentService";
+import JobService, { JobType } from "../../services/jobService";
+import ObjectService from "../../services/objectService";
 
 enum CopyMnemonicsType {
   DeleteInsert = "deleteInsert",
@@ -45,7 +45,7 @@ const CopyMnemonicsModal = (
     endIndex
   } = props;
 
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
 
   const [selectedCopyMnemonicsType, setCopyMnemonicsType] = useState<string>(
     CopyMnemonicsType.Paste

--- a/Src/WitsmlExplorer.Frontend/components/Modals/CopyRangeModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/CopyRangeModal.tsx
@@ -7,15 +7,15 @@ import ModalDialog from "components/Modals/ModalDialog";
 import AdjustDateTimeModal from "components/Modals/TrimLogObject/AdjustDateTimeModal";
 import AdjustNumberRangeModal from "components/Modals/TrimLogObject/AdjustNumberRangeModal";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import {
   CopyRangeClipboard,
   createComponentReferences
 } from "models/jobs/componentReferences";
 import LogObject, { indexToNumber } from "models/logObject";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 
 export interface CopyRangeModalProps {
   logObject: LogObject;
@@ -26,7 +26,7 @@ export interface CopyRangeModalProps {
 
 const CopyRangeModal = (props: CopyRangeModalProps): React.ReactElement => {
   const { connectedServer } = useConnectedServer();
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [startIndex, setStartIndex] = useState<string | number>();
   const [endIndex, setEndIndex] = useState<string | number>();
   const [confirmDisabled, setConfirmDisabled] = useState<boolean>(true);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/DeleteEmptyMnemonicsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/DeleteEmptyMnemonicsModal.tsx
@@ -3,14 +3,14 @@ import { DateTimeField } from "components/Modals/DateTimeField";
 import ModalDialog from "components/Modals/ModalDialog";
 import { ReportModal } from "components/Modals/ReportModal";
 import { Checkbox } from "components/StyledComponents/Checkbox";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { DeleteEmptyMnemonicsJob } from "models/jobs/deleteEmptyMnemonicsJob";
 import LogObject from "models/logObject";
 import { toObjectReference } from "models/objectOnWellbore";
 import Well from "models/well";
 import Wellbore from "models/wellbore";
-import { ChangeEvent, useContext, useState } from "react";
+import { ChangeEvent, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import styled from "styled-components";
 
@@ -27,7 +27,7 @@ const DeleteEmptyMnemonicsModal = (
   const {
     dispatchOperation,
     operationState: { timeZone, colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [nullDepthValue, setNullDepthValue] = useState<number>(-999.25);
   const [nullTimeValue, setNullTimeValue] = useState<string>(
     "1900-01-01T00:00:00.000Z"

--- a/Src/WitsmlExplorer.Frontend/components/Modals/FormationMarkerPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/FormationMarkerPropertiesModal.tsx
@@ -5,8 +5,8 @@ import {
   invalidStringInput,
   undefinedOnUnchagedEmptyString
 } from "components/Modals/PropertiesModalUtils";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import FormationMarker from "models/formationMarker";
 import { itemStateTypes } from "models/itemStateTypes";
 import MaxLength from "models/maxLength";
@@ -14,13 +14,7 @@ import Measure from "models/measure";
 import MeasureWithDatum from "models/measureWithDatum";
 import { ObjectType } from "models/objectType";
 import StratigraphicStruct from "models/stratigraphicStruct";
-import React, {
-  ChangeEvent,
-  Dispatch,
-  SetStateAction,
-  useContext,
-  useState
-} from "react";
+import React, { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import { Layout } from "../StyledComponents/Layout";
 
@@ -66,7 +60,7 @@ const FormationMarkerPropertiesModal = (
   props: FormationMarkerPropertiesModalProps
 ): React.ReactElement => {
   const { formationMarker } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [editable, setEditable] = useState<EditableFormationMarker>({});
   const [isLoading, setIsLoading] = useState<boolean>(false);
 

--- a/Src/WitsmlExplorer.Frontend/components/Modals/GeologyIntervalPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/GeologyIntervalPropertiesModal.tsx
@@ -7,8 +7,8 @@ import {
   invalidStringInput,
   undefinedOnUnchagedEmptyString
 } from "components/Modals/PropertiesModalUtils";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import GeologyInterval from "models/geologyInterval";
 import ObjectReference from "models/jobs/objectReference";
 import { lithologySources } from "models/lithologySources";
@@ -22,7 +22,6 @@ import React, {
   ChangeEvent,
   Dispatch,
   SetStateAction,
-  useContext,
   useEffect,
   useState
 } from "react";
@@ -75,7 +74,7 @@ const GeologyIntervalPropertiesModal = (
   props: GeologyIntervalPropertiesModalInterface
 ): React.ReactElement => {
   const { geologyInterval, mudLog: selectedMudLog } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [editable, setEditable] = useState<EditableGeologyInterval>({});
   const [editableLithologies, setEditableLithologies] = useState<
     Record<string, EditableLithology>

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogComparisonModal.tsx
@@ -19,16 +19,16 @@ import ModalDialog, {
   ModalWidth
 } from "components/Modals/ModalDialog";
 import ProgressSpinner from "components/ProgressSpinner";
-import OperationContext from "contexts/operationContext";
 import { DispatchOperation } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import LogCurveInfo from "models/logCurveInfo";
 import LogObject from "models/logObject";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import ComponentService from "services/componentService";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
@@ -53,7 +53,7 @@ const LogComparisonModal = (
   } = props;
   const {
     operationState: { timeZone, colors, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [sourceLogCurveInfo, setSourceLogCurveInfo] =
     useState<LogCurveInfo[]>(null);
   const [targetLogCurveInfo, setTargetLogCurveInfo] =

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogCurveInfoBatchUpdateModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogCurveInfoBatchUpdateModal.tsx
@@ -1,8 +1,8 @@
 import { Autocomplete, TextField } from "@equinor/eds-core-react";
 import { Grid } from "@mui/material";
-import React, { ChangeEvent, useContext, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import React, { ChangeEvent, useState } from "react";
 import styled from "styled-components";
-import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import BatchModifyLogCurveInfoJob from "../../models/jobs/batchModifyLogCurveInfoJob";
 import LogCurveInfo, { EmptyLogCurveInfo } from "../../models/logCurveInfo";
@@ -26,7 +26,7 @@ const LogCurveInfoBatchUpdateModal = (
   props: LogCurveInfoBatchUpdateModalProps
 ): React.ReactElement => {
   const { logCurveInfoRows, selectedLog } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [editableLogCurveInfo, setEditableLogCurveInfo] =
     useState<LogCurveInfo>(EmptyLogCurveInfo);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogCurvePriorityModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogCurvePriorityModal.tsx
@@ -1,8 +1,8 @@
 import { Icon, TextField } from "@equinor/eds-core-react";
 import { Button } from "components/StyledComponents/Button";
-import React, { ChangeEvent, useContext, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import React, { ChangeEvent, useState } from "react";
 import styled from "styled-components";
-import OperationContext from "../../contexts/operationContext";
 import { MousePosition } from "../../contexts/operationStateReducer";
 import OperationType from "../../contexts/operationType";
 import LogCurvePriorityService from "../../services/logCurvePriorityService";
@@ -34,7 +34,7 @@ export const LogCurvePriorityModal = (
   const [updatedPrioritizedCurves, setUpdatedPrioritizedCurves] =
     useState<string[]>(prioritizedCurves);
   const [newCurve, setNewCurve] = useState<string>("");
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [position, setPosition] = useState<MousePosition>({
     mouseX: null,
     mouseY: null

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogDataImportModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogDataImportModal.tsx
@@ -5,9 +5,9 @@ import { StyledAccordionHeader } from "components/Modals/LogComparisonModal";
 import ModalDialog from "components/Modals/ModalDialog";
 import WarningBar from "components/WarningBar";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetComponents } from "hooks/query/useGetComponents";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { IndexRange } from "models/jobs/deleteLogCurveValuesJob";
 import ImportLogDataJob from "models/jobs/importLogDataJob";
@@ -15,7 +15,7 @@ import ObjectReference from "models/jobs/objectReference";
 import LogCurveInfo from "models/logCurveInfo";
 import LogObject from "models/logObject";
 import { toObjectReference } from "models/objectOnWellbore";
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import styled from "styled-components";
 
@@ -42,7 +42,7 @@ const LogDataImportModal = (
   const {
     dispatchOperation,
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { components: logCurveInfoList, isFetching: isFetchingLogCurveInfo } =
     useGetComponents(
       connectedServer,

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogHeaderDateTimeField.tsx
@@ -3,9 +3,9 @@ import formatDateString, {
   getOffset,
   getOffsetFromTimeZone
 } from "components/DateFormatter";
-import OperationContext from "contexts/operationContext";
 import { DateTimeFormat, TimeZone } from "contexts/operationStateReducer";
-import { ChangeEvent, useContext, useEffect, useState } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { ChangeEvent, useEffect, useState } from "react";
 import styled from "styled-components";
 
 interface DateTimeFieldProps {
@@ -33,7 +33,7 @@ export const LogHeaderDateTimeField = (
   const { value, label, updateObject, minValue, maxValue } = props;
   const {
     operationState: { timeZone }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const offset =
     timeZone === TimeZone.Raw
       ? getOffset(value)

--- a/Src/WitsmlExplorer.Frontend/components/Modals/LogPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/LogPropertiesModal.tsx
@@ -3,12 +3,12 @@ import { WITSML_INDEX_TYPE_DATE_TIME } from "components/Constants";
 import formatDateString from "components/DateFormatter";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export enum IndexCurve {
@@ -28,7 +28,7 @@ const LogPropertiesModal = (
   const { mode, logObject, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableLogObject, setEditableLogObject] = useState<LogObject>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const editMode = mode === PropertiesModalMode.Edit;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MessageComparisonModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MessageComparisonModal.tsx
@@ -16,14 +16,14 @@ import ModalDialog, {
   ModalWidth
 } from "components/Modals/ModalDialog";
 import ProgressSpinner from "components/ProgressSpinner";
-import OperationContext from "contexts/operationContext";
 import { DispatchOperation } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import MessageObject from "models/messageObject";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
-import { useContext, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import ObjectService from "services/objectService";
 
 export interface MessageComparisonModalProps {
@@ -46,7 +46,7 @@ const MessageComparisonModal = (
   } = props;
   const {
     operationState: { timeZone, colors, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [targetMessage, setTargetMessage] = useState<MessageObject>(null);
   const [differenceFound, setDifferenceFound] = useState(false);
   const [data, setData] = useState(null);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MessagePropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MessagePropertiesModal.tsx
@@ -2,12 +2,12 @@ import { TextField } from "@equinor/eds-core-react";
 import formatDateString from "components/DateFormatter";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import MessageObject from "models/messageObject";
 import { ObjectType } from "models/objectType";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface MessagePropertiesModalProps {
@@ -22,7 +22,7 @@ const MessagePropertiesModal = (
   const { mode, messageObject, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableMessageObject, setEditableMessageObject] =
     useState<MessageObject>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MissingDataAgentModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MissingDataAgentModal.tsx
@@ -15,15 +15,15 @@ import ModalDialog, {
 } from "components/Modals/ModalDialog";
 import { ReportModal } from "components/Modals/ReportModal";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import useExport from "hooks/useExport";
 import { useLocalStorageState } from "hooks/useLocalStorageState";
+import { useOperationState } from "hooks/useOperationState";
 import MissingDataJob, { MissingDataCheck } from "models/jobs/missingDataJob";
 import WellReference from "models/jobs/wellReference";
 import WellboreReference from "models/jobs/wellboreReference";
 import { ObjectType } from "models/objectType";
-import { useContext, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import styled from "styled-components";
 import { STORAGE_MISSING_DATA_AGENT_CHECKS_KEY } from "tools/localStorageHelpers";
@@ -47,7 +47,7 @@ const MissingDataAgentModal = (
   const {
     dispatchOperation,
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [missingDataChecks, setMissingDataChecks] = useLocalStorageState<
     MissingDataCheck[]
   >(STORAGE_MISSING_DATA_AGENT_CHECKS_KEY, {

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ModalDialog.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ModalDialog.tsx
@@ -1,7 +1,7 @@
 import { Dialog, Progress, Typography } from "@equinor/eds-core-react";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import React, { ReactElement, useState } from "react";
 import styled from "styled-components";
 import { Colors, dark, light } from "styles/Colors";
@@ -44,7 +44,7 @@ const ModalDialog = (props: ModalDialogProps): React.ReactElement => {
     showCancelButton = true,
     buttonPosition: ButtonPosition = ControlButtonPosition.BOTTOM
   } = props;
-  const context = React.useContext(OperationContext);
+  const context = useOperationState();
   const [confirmButtonIsFocused, setConfirmButtonIsFocused] =
     useState<boolean>(false);
   const { operationState } = context;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ModalPresenter.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ModalPresenter.tsx
@@ -1,8 +1,8 @@
-import { Fragment, ReactElement, useContext } from "react";
-import OperationContext from "contexts/operationContext";
+import { useOperationState } from "hooks/useOperationState";
+import { Fragment, ReactElement } from "react";
 
 const ModalPresenter = (): ReactElement => {
-  const { operationState } = useContext(OperationContext);
+  const { operationState } = useOperationState();
   const { modals } = operationState;
   return (
     <>

--- a/Src/WitsmlExplorer.Frontend/components/Modals/MudLogPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/MudLogPropertiesModal.tsx
@@ -5,14 +5,14 @@ import {
   invalidStringInput,
   undefinedOnUnchagedEmptyString
 } from "components/Modals/PropertiesModalUtils";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { itemStateValues } from "models/commonData";
 import MaxLength from "models/maxLength";
 import MudLog from "models/mudLog";
 import ObjectOnWellbore, { toObjectReference } from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import { Layout } from "../StyledComponents/Layout";
 
@@ -33,7 +33,7 @@ const MudLogPropertiesModal = (
   const {
     operationState: { timeZone, dateTimeFormat },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableMudLog, setEditableMudLog] = useState<EditableMudLog>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ObjectPickerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ObjectPickerModal.tsx
@@ -7,14 +7,14 @@ import ModalDialog, {
 import { Banner } from "components/StyledComponents/Banner";
 import { Button } from "components/StyledComponents/Button";
 import { Checkbox } from "components/StyledComponents/Checkbox";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import MaxLength from "models/maxLength";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { Server } from "models/server";
-import { ChangeEvent, useContext, useState } from "react";
+import { ChangeEvent, useState } from "react";
 import ObjectService from "services/objectService";
 import styled from "styled-components";
 import Icon from "styles/Icons";
@@ -43,7 +43,7 @@ const ObjectPickerModal = ({
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [targetServer, setTargetServer] = useState<Server>();
   const [wellUid, setWellUid] = useState<string>(sourceObject.wellUid);
   const [wellboreUid, setWellboreUid] = useState<string>(

--- a/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/OffsetLogCurveModal.tsx
@@ -15,15 +15,15 @@ import AdjustNumberRangeModal from "components/Modals/TrimLogObject/AdjustNumber
 import { Checkbox } from "components/StyledComponents/Checkbox";
 import WarningBar from "components/WarningBar";
 import { useConnectedServer } from "contexts/connectedServerContext";
+import { useOperationState } from "hooks/useOperationState";
 import { ComponentType } from "models/componentType";
 import { createComponentReferences } from "models/jobs/componentReferences";
 import { OffsetLogCurveJob } from "models/jobs/offsetLogCurveJob";
 import LogObject from "models/logObject";
-import React, { ChangeEvent, ReactElement, useContext, useState } from "react";
+import React, { ChangeEvent, ReactElement, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import styled from "styled-components";
 import { indexToNumber } from "tools/IndexHelpers";
-import OperationContext from "../../contexts/operationContext";
 import OperationType from "../../contexts/operationType";
 import ModalDialog from "./ModalDialog";
 
@@ -44,7 +44,7 @@ export const OffsetLogCurveModal = (
     endIndex: initialEndIndex
   } = props;
   const { connectedServer } = useConnectedServer();
-  const { operationState, dispatchOperation } = useContext(OperationContext);
+  const { operationState, dispatchOperation } = useOperationState();
   const { colors } = operationState;
   const isDepthLog = selectedLog.indexType === WITSML_INDEX_TYPE_MD;
   const [isValidInterval, setIsValidInterval] = useState<boolean>();

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ReportModal.tsx
@@ -16,10 +16,10 @@ import ModalDialog, { ModalWidth } from "components/Modals/ModalDialog";
 import { generateReport } from "components/ReportCreationHelper";
 import { Banner } from "components/StyledComponents/Banner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import useExport from "hooks/useExport";
 import { useLiveJobProgress } from "hooks/useLiveJobProgress";
+import { useOperationState } from "hooks/useOperationState";
 import BaseReport, { createReport } from "models/reports/BaseReport";
 import React, { useEffect, useState } from "react";
 import JobService from "services/jobService";
@@ -49,7 +49,7 @@ export const ReportModal = (props: ReportModal): React.ReactElement => {
   const {
     dispatchOperation,
     operationState: { colors }
-  } = React.useContext(OperationContext);
+  } = useOperationState();
   const [report, setReport] = useState<BaseReport>(reportProp);
   const fetchedReport = useGetReportOnJobFinished(jobId);
   const jobProgress = useLiveJobProgress(jobId);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/RigPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/RigPropertiesModal.tsx
@@ -7,14 +7,14 @@ import {
   validPhoneNumber,
   validText
 } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { itemStateTypes } from "models/itemStateTypes";
 import { ObjectType } from "models/objectType";
 import Rig from "models/rig";
 import { rigType } from "models/rigType";
-import React, { ChangeEvent, useContext, useState } from "react";
+import React, { ChangeEvent, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface RigPropertiesModalProps {
@@ -29,7 +29,7 @@ const RigPropertiesModal = (
   const { mode, rig, dispatchOperation } = props;
   const {
     operationState: { timeZone }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableRig, setEditableRig] = useState<Rig>({ ...rig });
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [dTimStartOpValid, setDTimStartOpValid] = useState<boolean>(true);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/RiskPropertiesModal.tsx
@@ -3,9 +3,9 @@ import formatDateString from "components/DateFormatter";
 import { DateTimeField } from "components/Modals/DateTimeField";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { itemStateTypes } from "models/itemStateTypes";
 import { ObjectType } from "models/objectType";
 import { riskAffectedPersonnel } from "models/riskAffectedPersonnel";
@@ -13,7 +13,7 @@ import { riskCategory } from "models/riskCategory";
 import RiskObject from "models/riskObject";
 import { riskSubCategory } from "models/riskSubCategory";
 import { riskType } from "models/riskType";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface RiskPropertiesModalProps {
@@ -28,7 +28,7 @@ const RiskPropertiesModal = (
   const { mode, riskObject, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableRiskObject, setEditableRiskObject] =
     useState<RiskObject>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/SelectIndexToDisplayModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/SelectIndexToDisplayModal.tsx
@@ -8,12 +8,12 @@ import AdjustDateTimeModal from "components/Modals/TrimLogObject/AdjustDateTimeM
 import AdjustNumberRangeModal from "components/Modals/TrimLogObject/AdjustNumberRangeModal";
 import { Banner } from "components/StyledComponents/Banner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetActiveRoute } from "hooks/useGetActiveRoute";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
 import { ObjectType } from "models/objectType";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { RouterLogType } from "routes/routerConstants";
 import {
@@ -40,7 +40,7 @@ const SelectIndexToDisplayModal = (
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const isTimeIndexed = log.indexType === WITSML_INDEX_TYPE_DATE_TIME;
   const [startIndex, setStartIndex] = useState<string | number>(
     getStartIndex(log, logCurveInfoRows, isMultiLog)

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ServerModal.tsx
@@ -9,13 +9,13 @@ import UserCredentialsModal, {
 } from "components/Modals/UserCredentialsModal";
 import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import {
   DisplayModalAction,
   HideModalAction
 } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { refreshServersQuery } from "hooks/query/queryRefreshHelpers";
+import { useOperationState } from "hooks/useOperationState";
 import { Server } from "models/server";
 import { msalEnabled } from "msal/MsalAuthProvider";
 import React, {
@@ -23,7 +23,6 @@ import React, {
   ChangeEvent,
   Dispatch,
   SetStateAction,
-  useContext,
   useState
 } from "react";
 import AuthorizationService from "services/authorizationService";
@@ -39,7 +38,7 @@ export interface ServerModalProps {
 
 const ServerModal = (props: ServerModalProps): React.ReactElement => {
   const queryClient = useQueryClient();
-  const { operationState, dispatchOperation } = useContext(OperationContext);
+  const { operationState, dispatchOperation } = useOperationState();
   const { colors } = operationState;
   const [server, setServer] = useState<Server>(props.server);
   const [connectionVerified, setConnectionVerified] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/SettingsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/SettingsModal.tsx
@@ -4,7 +4,6 @@ import ModalDialog from "components/Modals/ModalDialog";
 import { StyledNativeSelect } from "components/Select";
 import { Button } from "components/StyledComponents/Button";
 import { Checkbox } from "components/StyledComponents/Checkbox";
-import OperationContext from "contexts/operationContext";
 import {
   DateTimeFormat,
   DecimalPreference,
@@ -12,8 +11,9 @@ import {
   UserTheme
 } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { getAccountInfo, msalEnabled, signOut } from "msal/MsalAuthProvider";
-import React, { CSSProperties, ChangeEvent, useContext, useState } from "react";
+import React, { CSSProperties, ChangeEvent, useState } from "react";
 import AuthorizationService from "services/authorizationService";
 import styled from "styled-components";
 import { dark, light } from "styles/Colors";
@@ -54,7 +54,7 @@ const SettingsModal = (): React.ReactElement => {
       hotKeysEnabled
     },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [checkedDecimalPreference, setCheckedDecimalPreference] =
     useState<string>(() => {
       return decimals === DecimalPreference.Raw

--- a/Src/WitsmlExplorer.Frontend/components/Modals/ShowLogDataOnServerModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/ShowLogDataOnServerModal.tsx
@@ -7,11 +7,11 @@ import {
 import ModalDialog from "components/Modals/ModalDialog";
 import { Banner } from "components/StyledComponents/Banner";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
+import { useOperationState } from "hooks/useOperationState";
 import { Server } from "models/server";
-import { CSSProperties, ChangeEvent, useContext, useState } from "react";
+import { CSSProperties, ChangeEvent, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { checkIsUrlTooLong } from "routes/utils/checkIsUrlTooLong";
 import { createLogCurveValuesSearchParams } from "routes/utils/createLogCurveValuesSearchParams";
@@ -35,7 +35,7 @@ export function ShowLogDataOnServerModal() {
   const {
     operationState: { colors, theme },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { wellUid, wellboreUid, objectGroup, objectUid, logType } = useParams();
   const [isUrlTooLong, setIsUrlTooLong] = useState(false);
   const [searchParams] = useSearchParams();

--- a/Src/WitsmlExplorer.Frontend/components/Modals/SpliceLogsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/SpliceLogsModal.tsx
@@ -2,8 +2,8 @@ import { Accordion, TextField, Typography } from "@equinor/eds-core-react";
 import { StyledAccordionHeader } from "components/Modals/LogComparisonModal";
 import ModalDialog, { ModalWidth } from "components/Modals/ModalDialog";
 import { validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import SpliceLogsJob from "models/jobs/spliceLogsJob";
 import LogObject from "models/logObject";
 import ObjectOnWellbore, { toObjectReferences } from "models/objectOnWellbore";
@@ -12,7 +12,6 @@ import {
   ChangeEvent,
   DragEvent,
   ReactElement,
-  useContext,
   useEffect,
   useState
 } from "react";
@@ -32,7 +31,7 @@ const SpliceLogsModal = (props: SpliceLogsProps): ReactElement => {
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [draggedId, setDraggedId] = useState(null);
   const [draggedOverId, setDraggedOverId] = useState(null);
   const [orderedLogs, setOrderedLogs] = useState<LogObject[]>([]);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrajectoryPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrajectoryPropertiesModal.tsx
@@ -2,12 +2,12 @@
 import { DateTimeField } from "components/Modals/DateTimeField";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import Trajectory, { aziRefValues } from "models/trajectory";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import { itemStateTypes } from "../../models/itemStateTypes";
 export interface TrajectoryPropertiesModalProps {
@@ -22,7 +22,7 @@ const TrajectoryPropertiesModal = (
   const { mode, trajectory, dispatchOperation } = props;
   const {
     operationState: { timeZone }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableTrajectory, setEditableTrajectory] =
     useState<Trajectory>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrajectoryStationPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrajectoryStationPropertiesModal.tsx
@@ -2,15 +2,15 @@ import { TextField } from "@equinor/eds-core-react";
 import formatDateString from "components/DateFormatter";
 import { DateTimeField } from "components/Modals/DateTimeField";
 import ModalDialog from "components/Modals/ModalDialog";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import ObjectReference from "models/jobs/objectReference";
 import { measureToString } from "models/measure";
 import { toObjectReference } from "models/objectOnWellbore";
 import Trajectory from "models/trajectory";
 import TrajectoryStation from "models/trajectoryStation";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface TrajectoryStationPropertiesModalInterface {
@@ -25,7 +25,7 @@ const TrajectoryStationPropertiesModal = (
   const { trajectoryStation, trajectory, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableTrajectoryStation, setEditableTrajectoryStation] =
     useState<TrajectoryStation>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/TrimLogObjectModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/TrimLogObject/TrimLogObjectModal.tsx
@@ -7,11 +7,11 @@ import ModalDialog from "components/Modals/ModalDialog";
 import AdjustDateTimeModal from "components/Modals/TrimLogObject/AdjustDateTimeModal";
 import AdjustNumberRangeModal from "components/Modals/TrimLogObject/AdjustNumberRangeModal";
 import WarningBar from "components/WarningBar";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { createTrimLogObjectJob } from "models/jobs/trimLogObjectJob";
 import LogObject, { indexToNumber } from "models/logObject";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface TrimLogObjectModalProps {
@@ -22,7 +22,7 @@ const TrimLogObjectModal = (
   props: TrimLogObjectModalProps
 ): React.ReactElement => {
   const { logObject } = props;
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [log] = useState<LogObject>(logObject);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [startIndex, setStartIndex] = useState<string | number>();

--- a/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/UserCredentialsModal.tsx
@@ -8,10 +8,10 @@ import ModalDialog, { ModalWidth } from "components/Modals/ModalDialog";
 import { validText } from "components/Modals/ModalParts";
 import { Button } from "components/StyledComponents/Button";
 import { Checkbox } from "components/StyledComponents/Checkbox";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { Server } from "models/server";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import AuthorizationService, {
   AuthorizationStatus,
   BasicServerCredentials,
@@ -34,7 +34,7 @@ const UserCredentialsModal = (
   const {
     operationState: { colors },
     dispatchOperation
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [username, setUsername] = useState<string>();
   const [password, setPassword] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WbGeometryPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WbGeometryPropertiesModal.tsx
@@ -2,13 +2,13 @@ import { Autocomplete, TextField } from "@equinor/eds-core-react";
 import formatDateString from "components/DateFormatter";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import { itemStateTypes } from "models/itemStateTypes";
 import { ObjectType } from "models/objectType";
 import WbGeometryObject from "models/wbGeometry";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface WbGeometryPropertiesModalProps {
@@ -23,7 +23,7 @@ const WbGeometryPropertiesModal = (
   const { mode, wbGeometryObject, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableWbGeometryObject, setEditableWbGeometryObject] =
     useState<WbGeometryObject>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellPropertiesModal.tsx
@@ -6,11 +6,11 @@ import {
   validText,
   validTimeZone
 } from "components/Modals/ModalParts";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import Well from "models/well";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 
 export interface WellPropertiesModalProps {
@@ -25,7 +25,7 @@ const WellPropertiesModal = (
   const { mode, well, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableWell, setEditableWell] = useState<Well>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const editMode = mode === PropertiesModalMode.Edit;

--- a/Src/WitsmlExplorer.Frontend/components/Modals/WellborePropertiesModal.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Modals/WellborePropertiesModal.tsx
@@ -4,12 +4,12 @@ import { DateTimeField } from "components/Modals/DateTimeField";
 import ModalDialog from "components/Modals/ModalDialog";
 import { PropertiesModalMode, validText } from "components/Modals/ModalParts";
 import { invalidStringInput } from "components/Modals/PropertiesModalUtils";
-import OperationContext from "contexts/operationContext";
 import { HideModalAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import MaxLength from "models/maxLength";
 import Wellbore, { wellboreHasChanges } from "models/wellbore";
-import React, { ChangeEvent, useContext, useEffect, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import JobService, { JobType } from "services/jobService";
 import styled from "styled-components";
 
@@ -35,7 +35,7 @@ const WellborePropertiesModal = (
   const { mode, wellbore, dispatchOperation } = props;
   const {
     operationState: { timeZone, dateTimeFormat }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [editableWellbore, setEditableWellbore] = useState<Wellbore>(null);
   const [pristineWellbore, setPristineWellbore] = useState<Wellbore>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/Src/WitsmlExplorer.Frontend/components/PageLayout.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/PageLayout.tsx
@@ -8,14 +8,13 @@ import Nav from "components/Nav";
 import PropertiesPanel from "components/PropertiesPanel";
 import Sidebar from "components/Sidebar/Sidebar";
 import { Button } from "components/StyledComponents/Button";
-import OperationContext from "contexts/operationContext";
 import useDocumentDimensions from "hooks/useDocumentDimensions";
+import { useOperationState } from "hooks/useOperationState";
 import { msalEnabled } from "msal/MsalAuthProvider";
 import {
   ReactElement,
   createContext,
   useCallback,
-  useContext,
   useEffect,
   useRef,
   useState
@@ -32,7 +31,7 @@ const PageLayout = (): ReactElement => {
   const [sidebarWidth, setSidebarWidth] = useState(316);
   const { width: documentWidth, height: documentHeight } =
     useDocumentDimensions();
-  const { operationState } = useContext(OperationContext);
+  const { operationState } = useOperationState();
   const { colors } = operationState;
 
   const startResizing = useCallback(() => {

--- a/Src/WitsmlExplorer.Frontend/components/PropertiesPanel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/PropertiesPanel.tsx
@@ -1,20 +1,20 @@
 import { Typography } from "@equinor/eds-core-react";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { useGetObject } from "hooks/query/useGetObject";
 import { useGetWell } from "hooks/query/useGetWell";
 import { useGetWellbore } from "hooks/query/useGetWellbore";
+import { useOperationState } from "hooks/useOperationState";
 import { getObjectOnWellboreProperties } from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { getWellProperties } from "models/well";
 import { getWellboreProperties } from "models/wellbore";
-import React, { useContext } from "react";
+import React from "react";
 import { useParams } from "react-router-dom";
 
 const PropertiesPanel = (): React.ReactElement => {
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid, objectGroup, objectUid } = useParams();
   const { well } = useGetWell(connectedServer, wellUid);

--- a/Src/WitsmlExplorer.Frontend/components/QueryEditor.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/QueryEditor.tsx
@@ -5,8 +5,7 @@ import "ace-builds/src-noconflict/theme-merbivore";
 import "ace-builds/src-noconflict/theme-xcode";
 import { customCommands, customCompleter } from "components/QueryEditorUtils";
 import { updateLinesWithWidgets } from "components/QueryEditorWidgetUtils";
-import OperationContext from "contexts/operationContext";
-import { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
 import AceEditor from "react-ace";
 import styled from "styled-components";
 import { Colors, dark } from "styles/Colors";
@@ -21,7 +20,7 @@ export const QueryEditor = (props: QueryEditorProps) => {
   const { value, onChange, readonly } = props;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   const onLoad = (editor: any) => {
     editor.renderer.setPadding(10);

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/FilterPanel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/FilterPanel.tsx
@@ -9,8 +9,8 @@ import { Checkbox } from "components/StyledComponents/Checkbox";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import { useCurveThreshold } from "contexts/curveThresholdContext";
 import { FilterContext, VisibilityStatus } from "contexts/filter";
-import OperationContext from "contexts/operationContext";
 import { useGetCapObjects } from "hooks/query/useGetCapObjects";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import React, { ChangeEvent, useContext } from "react";
 import styled from "styled-components";
@@ -29,7 +29,7 @@ const FilterPanel = (): React.ReactElement => {
   const { selectedFilter, updateSelectedFilter } = useContext(FilterContext);
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { capObjects } = useGetCapObjects(connectedServer, {
     placeholderData: Object.entries(ObjectType)

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/LogItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/LogItem.tsx
@@ -5,10 +5,10 @@ import {
 import LogObjectContextMenu from "components/ContextMenus/LogObjectContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import TreeItem from "components/Sidebar/TreeItem";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { getNameOccurrenceSuffix } from "tools/logSameNamesHelper";
 
 interface LogItemProps {
@@ -28,7 +28,7 @@ export default function LogItem({
   objectGrowing,
   to
 }: LogItemProps) {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
 
   const onContextMenu = (event: MouseEvent<HTMLLIElement>, log: LogObject) => {
     preventContextMenuPropagation(event);

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/LogTypeItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/LogTypeItem.tsx
@@ -14,10 +14,10 @@ import { IndexCurve } from "components/Modals/LogPropertiesModal";
 import LogItem from "components/Sidebar/LogItem";
 import TreeItem from "components/Sidebar/TreeItem";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useGetWellbore } from "hooks/query/useGetWellbore";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
 import { calculateObjectNodeId } from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
@@ -29,7 +29,7 @@ import Wellbore, {
   calculateMultipleLogsNodeItem,
   calculateObjectNodeId as calculateWellboreObjectNodeId
 } from "models/wellbore";
-import { Fragment, MouseEvent, useContext } from "react";
+import { Fragment, MouseEvent } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { RouterLogType } from "routes/routerConstants";
 import {
@@ -48,7 +48,7 @@ export default function LogTypeItem({
   wellUid,
   wellboreUid
 }: LogTypeItemProps) {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const [searchParams] = useSearchParams();
   const { servers } = useGetServers();
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectGroupItem.tsx
@@ -20,7 +20,6 @@ import {
   isObjectFilterType,
   objectFilterTypeToObjects
 } from "contexts/filter";
-import OperationContext from "contexts/operationContext";
 import { OperationAction } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useSidebar } from "contexts/sidebarContext";
@@ -29,6 +28,7 @@ import { useGetObjectCount } from "hooks/query/useGetObjectCount";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useGetWellbore } from "hooks/query/useGetWellbore";
 import { useObjectFilter } from "hooks/useObjectFilter";
+import { useOperationState } from "hooks/useOperationState";
 import LogObject from "models/logObject";
 import ObjectOnWellbore, {
   calculateObjectNodeId
@@ -60,7 +60,7 @@ export default function ObjectGroupItem({
   ObjectContextMenu,
   onGroupContextMenu
 }: ObjectGroupItemProps) {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { selectedFilter } = useContext(FilterContext);
   const { expandedTreeNodes } = useSidebar();
   const {

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectOnWellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/ObjectOnWellboreItem.tsx
@@ -5,12 +5,12 @@ import {
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import TreeItem from "components/Sidebar/TreeItem";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import ObjectOnWellbore from "models/objectOnWellbore";
 import { ObjectType } from "models/objectType";
 import { calculateObjectNodeId } from "models/wellbore";
-import { ComponentType, MouseEvent, useContext } from "react";
+import { ComponentType, MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 import { getObjectViewPath } from "routes/utils/pathBuilder";
 
@@ -31,7 +31,7 @@ export default function ObjectOnWellboreItem({
   wellUid,
   wellboreUid
 }: ObjectOnWellboreItemProps) {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const {
     wellUid: urlWellUid,

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/SearchFilter.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/SearchFilter.tsx
@@ -14,8 +14,8 @@ import {
   isObjectFilterType,
   isWellboreFilterType
 } from "contexts/filter";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
+import { useOperationState } from "hooks/useOperationState";
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { createSearchParams, useNavigate } from "react-router-dom";
 import { getSearchViewPath } from "routes/utils/pathBuilder";
@@ -26,13 +26,13 @@ import Icons from "styles/Icons";
 const searchOptions = Object.values(FilterType);
 
 const SearchFilter = (): React.ReactElement => {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { selectedFilter, updateSelectedFilter } = useContext(FilterContext);
   const { connectedServer } = useConnectedServer();
   const selectedOption = selectedFilter?.filterType;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const [expanded, setExpanded] = useState<boolean>(false);
   const [nameFilter, setNameFilter] = useState<string>(selectedFilter.name);
   const textFieldRef = useRef<HTMLInputElement>(null);

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/Sidebar.tsx
@@ -9,14 +9,14 @@ import ProgressSpinner from "components/ProgressSpinner";
 import SearchFilter from "components/Sidebar/SearchFilter";
 import WellItem from "components/Sidebar/WellItem";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import { useSidebar } from "contexts/sidebarContext";
 import { SidebarActionType } from "contexts/sidebarReducer";
 import { useGetWells } from "hooks/query/useGetWells";
+import { useOperationState } from "hooks/useOperationState";
 import { useWellFilter } from "hooks/useWellFilter";
 import Well from "models/well";
-import { Fragment, useContext, useEffect, useRef } from "react";
+import { Fragment, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import Icon from "styles/Icons";
@@ -30,7 +30,7 @@ export default function Sidebar() {
   const isDeepLink = useRef<boolean>(!!wellUid);
   const {
     operationState: { colors, theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const isCompactMode = theme === UserTheme.Compact;
   const filteredWells = useWellFilter(wells);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/TreeItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/TreeItem.tsx
@@ -1,9 +1,9 @@
 import { DotProgress } from "@equinor/eds-core-react";
 import { Tooltip } from "@mui/material";
 import { TreeItem, TreeItemProps } from "@mui/x-tree-view";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
-import React, { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import React from "react";
 import { NavLink } from "react-router-dom";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
@@ -22,12 +22,12 @@ const StyledTreeItem = (props: StyledTreeItemProps): React.ReactElement => {
     props;
   const {
     operationState: { theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const isCompactMode = theme === UserTheme.Compact;
 
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   return (
     <TreeItem

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellItem.tsx
@@ -9,19 +9,19 @@ import { EmptyTreeItem } from "components/Sidebar/EmptyTreeItem";
 import TreeItem from "components/Sidebar/TreeItem";
 import WellboreItem from "components/Sidebar/WellboreItem";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { useSidebar } from "contexts/sidebarContext";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useGetWell } from "hooks/query/useGetWell";
 import { useGetWellbores } from "hooks/query/useGetWellbores";
+import { useOperationState } from "hooks/useOperationState";
 import { useWellboreFilter } from "hooks/useWellboreFilter";
 import Well from "models/well";
 import Wellbore, {
   calculateWellNodeId,
   calculateWellboreNodeId
 } from "models/wellbore";
-import React, { MouseEvent, useContext } from "react";
+import React, { MouseEvent } from "react";
 import { useParams } from "react-router-dom";
 import { getWellboresViewPath } from "routes/utils/pathBuilder";
 
@@ -30,7 +30,7 @@ interface WellItemProps {
 }
 
 export default function WellItem({ wellUid }: WellItemProps) {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { servers } = useGetServers();
   const { wellUid: urlWellUid, wellboreUid: urlWellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/Sidebar/WellboreItem.tsx
@@ -26,14 +26,14 @@ import WellboreContextMenu, {
 import ObjectGroupItem from "components/Sidebar/ObjectGroupItem";
 import TreeItem from "components/Sidebar/TreeItem";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
 import OperationType from "contexts/operationType";
 import { useGetServers } from "hooks/query/useGetServers";
 import { useGetWellbore } from "hooks/query/useGetWellbore";
+import { useOperationState } from "hooks/useOperationState";
 import { ObjectType } from "models/objectType";
 import Wellbore from "models/wellbore";
-import { MouseEvent, useContext } from "react";
+import { MouseEvent } from "react";
 import { getObjectGroupsViewPath } from "routes/utils/pathBuilder";
 import styled from "styled-components";
 import { WellIndicator } from "../StyledComponents/WellIndicator";
@@ -55,11 +55,11 @@ export default function WellboreItem({
   const {
     dispatchOperation,
     operationState: { theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const isCompactMode = theme === UserTheme.Compact;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { wellbore, isFetching } = useGetWellbore(
     connectedServer,

--- a/Src/WitsmlExplorer.Frontend/components/StyledComponents/Button.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/StyledComponents/Button.tsx
@@ -2,9 +2,9 @@ import {
   Button as EdsButton,
   ButtonProps as EdsButtonProps
 } from "@equinor/eds-core-react";
-import OperationContext from "contexts/operationContext";
 import { UserTheme } from "contexts/operationStateReducer";
-import React, { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import React from "react";
 import styled, { css } from "styled-components";
 import { Colors } from "styles/Colors";
 
@@ -17,7 +17,7 @@ export type Ref = HTMLButtonElement;
 export const Button = React.forwardRef<Ref, ButtonProps>((props, ref) => {
   const {
     operationState: { colors, theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   if (!props.variant || props.variant === "contained") {
     return <ContainedButton ref={ref} {...props} colors={colors} />;

--- a/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/TopRightCornerMenu.tsx
@@ -6,10 +6,9 @@ import { Button } from "components/StyledComponents/Button";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import { useLoggedInUsernames } from "contexts/loggedInUsernamesContext";
 import { LoggedInUsernamesActionType } from "contexts/loggedInUsernamesReducer";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import useDocumentDimensions from "hooks/useDocumentDimensions";
-import { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
 import { useNavigate } from "react-router-dom";
 import { getJobsViewPath, getQueryViewPath } from "routes/utils/pathBuilder";
 import AuthorizationService from "services/authorizationService";
@@ -17,7 +16,7 @@ import styled from "styled-components";
 import Icon from "styles/Icons";
 
 export default function TopRightCornerMenu() {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { width: documentWidth } = useDocumentDimensions();
   const showLabels = documentWidth > 1180;
   const { connectedServer } = useConnectedServer();

--- a/Src/WitsmlExplorer.Frontend/contexts/MuiThemeProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/MuiThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from "@mui/material";
-import OperationContext from "contexts/operationContext";
-import { ReactElement, ReactNode, useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { ReactElement, ReactNode } from "react";
 import { getTheme } from "styles/material-eds";
 
 interface MuiThemeProviderProps {
@@ -12,7 +12,7 @@ export const MuiThemeProvider = ({
 }: MuiThemeProviderProps): ReactElement => {
   const {
     operationState: { theme }
-  } = useContext(OperationContext);
+  } = useOperationState();
 
   return <ThemeProvider theme={getTheme(theme)}>{children}</ThemeProvider>;
 };

--- a/Src/WitsmlExplorer.Frontend/contexts/MuiThemeProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/MuiThemeProvider.tsx
@@ -1,0 +1,18 @@
+import { ThemeProvider } from "@mui/material";
+import OperationContext from "contexts/operationContext";
+import { ReactElement, ReactNode, useContext } from "react";
+import { getTheme } from "styles/material-eds";
+
+interface MuiThemeProviderProps {
+  children: ReactNode;
+}
+
+export const MuiThemeProvider = ({
+  children
+}: MuiThemeProviderProps): ReactElement => {
+  const {
+    operationState: { theme }
+  } = useContext(OperationContext);
+
+  return <ThemeProvider theme={getTheme(theme)}>{children}</ThemeProvider>;
+};

--- a/Src/WitsmlExplorer.Frontend/contexts/operationStateProvider.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/operationStateProvider.tsx
@@ -1,0 +1,108 @@
+import OperationContext from "contexts/operationContext";
+import {
+  DateTimeFormat,
+  DecimalPreference,
+  SetDateTimeFormatAction,
+  SetDecimalAction,
+  SetHotKeysEnabledAction,
+  SetModeAction,
+  SetThemeAction,
+  SetTimeZoneAction,
+  TimeZone,
+  UserTheme,
+  initOperationStateReducer
+} from "contexts/operationStateReducer";
+import OperationType from "contexts/operationType";
+import { enableDarkModeDebug } from "debugUtils/darkModeDebug";
+import { ReactNode, useEffect } from "react";
+import { dark, light } from "styles/Colors";
+import {
+  STORAGE_DATETIMEFORMAT_KEY,
+  STORAGE_DECIMAL_KEY,
+  STORAGE_HOTKEYS_ENABLED_KEY,
+  STORAGE_MODE_KEY,
+  STORAGE_THEME_KEY,
+  STORAGE_TIMEZONE_KEY,
+  getLocalStorageItem
+} from "tools/localStorageHelpers";
+
+interface OperationStateProviderProps {
+  children: ReactNode;
+}
+
+export const OperationStateProvider = ({
+  children
+}: OperationStateProviderProps) => {
+  const [operationState, dispatchOperation] = initOperationStateReducer();
+
+  useEffect(() => {
+    if (typeof localStorage != "undefined") {
+      const localStorageTheme =
+        getLocalStorageItem<UserTheme>(STORAGE_THEME_KEY);
+      if (localStorageTheme) {
+        const action: SetThemeAction = {
+          type: OperationType.SetTheme,
+          payload: localStorageTheme
+        };
+        dispatchOperation(action);
+      }
+      const storedTimeZone =
+        getLocalStorageItem<TimeZone>(STORAGE_TIMEZONE_KEY);
+      if (storedTimeZone) {
+        const action: SetTimeZoneAction = {
+          type: OperationType.SetTimeZone,
+          payload: storedTimeZone
+        };
+        dispatchOperation(action);
+      }
+      const storedMode = getLocalStorageItem<"light" | "dark">(
+        STORAGE_MODE_KEY
+      );
+      if (storedMode) {
+        const action: SetModeAction = {
+          type: OperationType.SetMode,
+          payload: storedMode == "light" ? light : dark
+        };
+        dispatchOperation(action);
+      }
+      const storedDateTimeFormat = getLocalStorageItem<DateTimeFormat>(
+        STORAGE_DATETIMEFORMAT_KEY
+      );
+      if (storedDateTimeFormat) {
+        const action: SetDateTimeFormatAction = {
+          type: OperationType.SetDateTimeFormat,
+          payload: storedDateTimeFormat
+        };
+        dispatchOperation(action);
+      }
+      const storedDecimals =
+        getLocalStorageItem<DecimalPreference>(STORAGE_DECIMAL_KEY);
+      if (storedDecimals) {
+        const action: SetDecimalAction = {
+          type: OperationType.SetDecimal,
+          payload: storedDecimals
+        };
+        dispatchOperation(action);
+      }
+      const storedHotKeysEnabled = getLocalStorageItem<boolean>(
+        STORAGE_HOTKEYS_ENABLED_KEY
+      );
+      if (storedHotKeysEnabled != null) {
+        const action: SetHotKeysEnabledAction = {
+          type: OperationType.SetHotKeysEnabled,
+          payload: storedHotKeysEnabled
+        };
+        dispatchOperation(action);
+      }
+    }
+    if (import.meta.env.VITE_DARK_MODE_DEBUG) {
+      return enableDarkModeDebug(dispatchOperation);
+    }
+  }, []);
+
+  return (
+    <OperationContext.Provider value={{ operationState, dispatchOperation }}>
+      {children}
+    </OperationContext.Provider>
+  );
+};

--- a/Src/WitsmlExplorer.Frontend/contexts/queryContext.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/queryContext.tsx
@@ -1,5 +1,3 @@
-import React, { Dispatch, useEffect } from "react";
-import { v4 as uuid } from "uuid";
 import {
   QueryTemplatePreset,
   ReturnElements,
@@ -7,10 +5,12 @@ import {
   getQueryTemplateWithPreset
 } from "components/ContentViews/QueryViewUtils";
 import { useLocalStorageState } from "hooks/useLocalStorageState";
+import React, { Dispatch, useEffect } from "react";
 import {
   STORAGE_QUERYVIEW_DATA,
   getLocalStorageItem
 } from "tools/localStorageHelpers";
+import { v4 as uuid } from "uuid";
 
 export interface QueryElement {
   query: string;

--- a/Src/WitsmlExplorer.Frontend/hooks/query/queryRefreshHelpers.tsx
+++ b/Src/WitsmlExplorer.Frontend/hooks/query/queryRefreshHelpers.tsx
@@ -1,19 +1,19 @@
 import { QueryClient } from "@tanstack/react-query";
+import { ObjectFilterType } from "../../contexts/filter";
 import { ComponentType, getParentType } from "../../models/componentType";
 import { ObjectType } from "../../models/objectType";
 import {
   QUERY_KEY_COMPONENTS,
   QUERY_KEY_JOB_INFO,
   QUERY_KEY_OBJECT,
-  QUERY_KEY_OBJECT_SEARCH,
   QUERY_KEY_OBJECTS,
+  QUERY_KEY_OBJECT_SEARCH,
   QUERY_KEY_SERVERS,
   QUERY_KEY_WELL,
   QUERY_KEY_WELLBORE,
   QUERY_KEY_WELLBORES,
   QUERY_KEY_WELLS
 } from "./queryKeys";
-import { ObjectFilterType } from "../../contexts/filter";
 
 export const refreshServersQuery = (queryClient: QueryClient) => {
   queryClient.invalidateQueries({

--- a/Src/WitsmlExplorer.Frontend/hooks/useOpenInQueryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/hooks/useOpenInQueryView.tsx
@@ -1,8 +1,8 @@
 import { QueryTemplatePreset } from "components/ContentViews/QueryViewUtils";
 import { useConnectedServer } from "contexts/connectedServerContext";
-import OperationContext from "contexts/operationContext";
 import OperationType from "contexts/operationType";
 import { QueryActionType, QueryContext } from "contexts/queryContext";
+import { useOperationState } from "hooks/useOperationState";
 import { useCallback, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { getQueryViewPath } from "routes/utils/pathBuilder";
@@ -11,7 +11,7 @@ export type OpenInQueryView = (templatePreset: QueryTemplatePreset) => void;
 
 export const useOpenInQueryView = () => {
   const { dispatchQuery } = useContext(QueryContext);
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const navigate = useNavigate();
 

--- a/Src/WitsmlExplorer.Frontend/hooks/useOperationState.tsx
+++ b/Src/WitsmlExplorer.Frontend/hooks/useOperationState.tsx
@@ -1,0 +1,11 @@
+import OperationContext from "contexts/operationContext";
+import { useContext } from "react";
+
+export function useOperationState() {
+  const context = useContext(OperationContext);
+  if (!context)
+    throw new Error(
+      `useOperationState() has to be used within <OperationStateProvider>`
+    );
+  return context;
+}

--- a/Src/WitsmlExplorer.Frontend/routes/AuthRoute.tsx
+++ b/Src/WitsmlExplorer.Frontend/routes/AuthRoute.tsx
@@ -1,14 +1,14 @@
 import { useIsAuthenticated } from "@azure/msal-react";
 import { useLoggedInUsernames } from "contexts/loggedInUsernamesContext";
 import { LoggedInUsernamesActionType } from "contexts/loggedInUsernamesReducer";
-import { useContext, useEffect } from "react";
+import { useOperationState } from "hooks/useOperationState";
+import { useEffect } from "react";
 import { Outlet, useNavigate, useParams } from "react-router-dom";
 import { ItemNotFound } from "routes/ItemNotFound";
 import UserCredentialsModal, {
   UserCredentialsModalProps
 } from "../components/Modals/UserCredentialsModal";
 import { useConnectedServer } from "../contexts/connectedServerContext";
-import OperationContext from "../contexts/operationContext";
 import OperationType from "../contexts/operationType";
 import { useGetServers } from "../hooks/query/useGetServers";
 import { Server } from "../models/server";
@@ -19,7 +19,7 @@ import AuthorizationService, {
 } from "../services/authorizationService";
 
 export default function AuthRoute() {
-  const { dispatchOperation } = useContext(OperationContext);
+  const { dispatchOperation } = useOperationState();
   const isAuthenticated = !msalEnabled || useIsAuthenticated();
   const { servers } = useGetServers({ enabled: isAuthenticated });
   const { serverUrl } = useParams();

--- a/Src/WitsmlExplorer.Frontend/routes/ItemNotFound.tsx
+++ b/Src/WitsmlExplorer.Frontend/routes/ItemNotFound.tsx
@@ -1,7 +1,6 @@
 import { Typography } from "@equinor/eds-core-react";
-import { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
 import styled from "styled-components";
-import OperationContext from "../contexts/operationContext";
 import { Colors } from "../styles/Colors";
 
 export interface ItemNotFoundProps {
@@ -12,7 +11,7 @@ export function ItemNotFound(props: ItemNotFoundProps) {
   const { itemType } = props;
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   return (
     <>
       <Heading colors={colors}>{`${itemType} Not Found`}</Heading>

--- a/Src/WitsmlExplorer.Frontend/routes/PageNotFound.tsx
+++ b/Src/WitsmlExplorer.Frontend/routes/PageNotFound.tsx
@@ -1,12 +1,11 @@
-import { useContext } from "react";
+import { useOperationState } from "hooks/useOperationState";
 import styled from "styled-components";
-import OperationContext from "../contexts/operationContext";
 import { Colors } from "../styles/Colors";
 
 export function PageNotFound() {
   const {
     operationState: { colors }
-  } = useContext(OperationContext);
+  } = useOperationState();
   return (
     <>
       <Heading colors={colors}>404 Not Found</Heading>

--- a/Src/WitsmlExplorer.Frontend/routes/Root.tsx
+++ b/Src/WitsmlExplorer.Frontend/routes/Root.tsx
@@ -1,124 +1,26 @@
 import { InteractionType } from "@azure/msal-browser";
 import { MsalAuthenticationTemplate, MsalProvider } from "@azure/msal-react";
-import { ThemeProvider } from "@mui/material";
+import ContextMenuPresenter from "components/ContextMenus/ContextMenuPresenter";
 import { DesktopAppEventHandler } from "components/DesktopAppEventHandler";
+import { GlobalStylesWrapper } from "components/GlobalStyles";
 import { HotKeyHandler } from "components/HotKeyHandler";
+import ModalPresenter from "components/Modals/ModalPresenter";
+import PageLayout from "components/PageLayout";
+import RefreshHandler from "components/RefreshHandler";
+import { Snackbar } from "components/Snackbar";
+import { MuiThemeProvider } from "contexts/MuiThemeProvider";
+import { ConnectedServerProvider } from "contexts/connectedServerContext";
+import { CurveThresholdProvider } from "contexts/curveThresholdContext";
+import { FilterContextProvider } from "contexts/filter";
 import { LoggedInUsernamesProvider } from "contexts/loggedInUsernamesContext";
+import { OperationStateProvider } from "contexts/operationStateProvider";
+import { QueryContextProvider } from "contexts/queryContext";
+import { SidebarProvider } from "contexts/sidebarContext";
+import { authRequest, msalEnabled, msalInstance } from "msal/MsalAuthProvider";
 import { SnackbarProvider } from "notistack";
-import { useEffect } from "react";
 import { isDesktopApp } from "tools/desktopAppHelpers";
-import ContextMenuPresenter from "../components/ContextMenus/ContextMenuPresenter";
-import GlobalStyles from "../components/GlobalStyles";
-import ModalPresenter from "../components/Modals/ModalPresenter";
-import PageLayout from "../components/PageLayout";
-import RefreshHandler from "../components/RefreshHandler";
-import { Snackbar } from "../components/Snackbar";
-import { ConnectedServerProvider } from "../contexts/connectedServerContext";
-import { CurveThresholdProvider } from "../contexts/curveThresholdContext";
-import { FilterContextProvider } from "../contexts/filter";
-import OperationContext from "../contexts/operationContext";
-import {
-  DateTimeFormat,
-  DecimalPreference,
-  SetDateTimeFormatAction,
-  SetDecimalAction,
-  SetHotKeysEnabledAction,
-  SetModeAction,
-  SetThemeAction,
-  SetTimeZoneAction,
-  TimeZone,
-  UserTheme,
-  initOperationStateReducer
-} from "../contexts/operationStateReducer";
-import OperationType from "../contexts/operationType";
-import { QueryContextProvider } from "../contexts/queryContext";
-import { SidebarProvider } from "../contexts/sidebarContext";
-import { enableDarkModeDebug } from "../debugUtils/darkModeDebug";
-import {
-  authRequest,
-  msalEnabled,
-  msalInstance
-} from "../msal/MsalAuthProvider";
-import { dark, light } from "../styles/Colors";
-import { getTheme } from "../styles/material-eds";
-import {
-  STORAGE_DATETIMEFORMAT_KEY,
-  STORAGE_DECIMAL_KEY,
-  STORAGE_HOTKEYS_ENABLED_KEY,
-  STORAGE_MODE_KEY,
-  STORAGE_THEME_KEY,
-  STORAGE_TIMEZONE_KEY,
-  getLocalStorageItem
-} from "../tools/localStorageHelpers";
 
 export default function Root() {
-  const [operationState, dispatchOperation] = initOperationStateReducer();
-
-  useEffect(() => {
-    if (typeof localStorage != "undefined") {
-      const localStorageTheme =
-        getLocalStorageItem<UserTheme>(STORAGE_THEME_KEY);
-      if (localStorageTheme) {
-        const action: SetThemeAction = {
-          type: OperationType.SetTheme,
-          payload: localStorageTheme
-        };
-        dispatchOperation(action);
-      }
-      const storedTimeZone =
-        getLocalStorageItem<TimeZone>(STORAGE_TIMEZONE_KEY);
-      if (storedTimeZone) {
-        const action: SetTimeZoneAction = {
-          type: OperationType.SetTimeZone,
-          payload: storedTimeZone
-        };
-        dispatchOperation(action);
-      }
-      const storedMode = getLocalStorageItem<"light" | "dark">(
-        STORAGE_MODE_KEY
-      );
-      if (storedMode) {
-        const action: SetModeAction = {
-          type: OperationType.SetMode,
-          payload: storedMode == "light" ? light : dark
-        };
-        dispatchOperation(action);
-      }
-      const storedDateTimeFormat = getLocalStorageItem<DateTimeFormat>(
-        STORAGE_DATETIMEFORMAT_KEY
-      );
-      if (storedDateTimeFormat) {
-        const action: SetDateTimeFormatAction = {
-          type: OperationType.SetDateTimeFormat,
-          payload: storedDateTimeFormat
-        };
-        dispatchOperation(action);
-      }
-      const storedDecimals =
-        getLocalStorageItem<DecimalPreference>(STORAGE_DECIMAL_KEY);
-      if (storedDecimals) {
-        const action: SetDecimalAction = {
-          type: OperationType.SetDecimal,
-          payload: storedDecimals
-        };
-        dispatchOperation(action);
-      }
-      const storedHotKeysEnabled = getLocalStorageItem<boolean>(
-        STORAGE_HOTKEYS_ENABLED_KEY
-      );
-      if (storedHotKeysEnabled != null) {
-        const action: SetHotKeysEnabledAction = {
-          type: OperationType.SetHotKeysEnabled,
-          payload: storedHotKeysEnabled
-        };
-        dispatchOperation(action);
-      }
-    }
-    if (import.meta.env.VITE_DARK_MODE_DEBUG) {
-      return enableDarkModeDebug(dispatchOperation);
-    }
-  }, []);
-
   return (
     <MsalProvider instance={msalInstance}>
       {msalEnabled && (
@@ -127,9 +29,9 @@ export default function Root() {
           authenticationRequest={authRequest}
         />
       )}
-      <OperationContext.Provider value={{ operationState, dispatchOperation }}>
-        <ThemeProvider theme={getTheme(operationState.theme)}>
-          <GlobalStyles colors={operationState.colors} />
+      <OperationStateProvider>
+        <MuiThemeProvider>
+          <GlobalStylesWrapper />
           <LoggedInUsernamesProvider>
             <ConnectedServerProvider>
               <CurveThresholdProvider>
@@ -151,8 +53,8 @@ export default function Root() {
               </CurveThresholdProvider>
             </ConnectedServerProvider>
           </LoggedInUsernamesProvider>
-        </ThemeProvider>
-      </OperationContext.Provider>
+        </MuiThemeProvider>
+      </OperationStateProvider>
     </MsalProvider>
   );
 }


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2137 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Moved the logic of initiating OperationState with values from localStorage to a new context provider.
* Created a hook for using the operation context. 

The hook leads to a lot of files changed, although there are very differences in each file. I separated the two types of changes mentioned above to make it easier to see what changes I made and what was auto-updated by adding the hook.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


