### PR TITLE
FIX-2444 Open credential modal when navigating back to another server

### DIFF
--- a/Src/WitsmlExplorer.Frontend/contexts/operationStateReducer.tsx
+++ b/Src/WitsmlExplorer.Frontend/contexts/operationStateReducer.tsx
@@ -1,3 +1,4 @@
+import UserCredentialsModal from "components/Modals/UserCredentialsModal";
 import OperationType from "contexts/operationType";
 import { Dispatch, ReactElement, useReducer } from "react";
 import { Colors, light } from "styles/Colors";
@@ -179,7 +180,14 @@ const displayModal = (
   state: OperationState,
   { payload }: DisplayModalAction
 ) => {
-  const modals = state.modals.concat(payload);
+  const isUserCredentialsModal = payload.type === UserCredentialsModal;
+
+  const modals = isUserCredentialsModal // We don't want to stack login modals
+    ? state.modals
+        .filter((modal) => modal.type !== UserCredentialsModal)
+        .concat(payload)
+    : state.modals.concat(payload);
+
   return {
     ...state,
     contextMenu: EMPTY_CONTEXT_MENU,

--- a/Src/WitsmlExplorer.Frontend/routes/AuthRoute.tsx
+++ b/Src/WitsmlExplorer.Frontend/routes/AuthRoute.tsx
@@ -59,11 +59,12 @@ export default function AuthRoute() {
   }, []);
 
   useEffect(() => {
-    if (servers && !connectedServer) {
+    if (servers && (!connectedServer || connectedServer.url != serverUrl)) {
+      setConnectedServer(null);
       const server = servers.find((server) => server.url === serverUrl);
       if (server) showCredentialsModal(server, true);
     }
-  }, [servers]);
+  }, [servers, serverUrl]);
 
   const showCredentialsModal = (server: Server, initialLogin: boolean) => {
     const userCredentialsModalProps: UserCredentialsModalProps = {


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2444 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Credential modals will always show up when navigating back or forth to a different server.
* Credential modals will not stack.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


