### PR TITLE
FIX-2494 Allow unspecified returnElements in queryView

### DIFF
--- a/Src/WitsmlExplorer.Api/Models/WitsmlQuery.cs
+++ b/Src/WitsmlExplorer.Api/Models/WitsmlQuery.cs
@@ -7,7 +7,7 @@ namespace WitsmlExplorer.Api.Models
     public class WitsmlQuery
     {
         [JsonConverter(typeof(JsonStringEnumConverter))]
-        public ReturnElements ReturnElements { get; init; }
+        public ReturnElements? ReturnElements { get; init; }
         public string OptionsInString { get; init; }
         public string Body { get; init; }
     }

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/QueryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/QueryView.tsx
@@ -53,7 +53,8 @@ const QueryView = (): React.ReactElement => {
       dispatchOperation?.({ type: OperationType.HideModal });
       setIsLoading(true);
       const requestReturnElements =
-        storeFunction === StoreFunction.GetFromStore
+        storeFunction === StoreFunction.GetFromStore &&
+        returnElements !== ReturnElements.None
           ? returnElements
           : undefined;
       let response = await QueryService.postQuery(

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/QueryViewUtils.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/QueryViewUtils.tsx
@@ -8,7 +8,8 @@ export enum ReturnElements {
   DataOnly = "dataOnly",
   StationLocationOnly = "stationLocationOnly",
   LatestChangeOnly = "latestChangeOnly",
-  Requested = "requested"
+  Requested = "requested",
+  None = ""
 }
 
 export enum StoreFunction {


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2494 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

It's now possible to select an empty returnElements. This is needed when specifying requestObjectSelectionCapability=true in optionsIn.

![image](https://github.com/equinor/witsml-explorer/assets/70512270/c3a912a1-247d-47b2-9de7-61042089002a)


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


