### PR TITLE
Added optional CancellationToken argument to GetFromStore methods #2666

### DIFF
--- a/Src/Witsml/Metrics/WitsmlMetrics.cs
+++ b/Src/Witsml/Metrics/WitsmlMetrics.cs
@@ -52,14 +52,13 @@ internal sealed class WitsmlMetrics
             { "objectType", witsmlType },
         };
 
-        var ct = cancellationToken ?? CancellationToken.None;
         Stopwatch timer = null;
         TResponseType response;
         try
         {
             _activeRequests.Add(1, tagList);
             timer = Stopwatch.StartNew();
-            response = await wmlsTask.WaitAsync(ct);
+            response = await wmlsTask.WaitAsync(cancellationToken ?? CancellationToken.None);
         }
         finally
         {

--- a/Src/Witsml/Metrics/WitsmlMetrics.cs
+++ b/Src/Witsml/Metrics/WitsmlMetrics.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Serilog;
@@ -41,7 +42,7 @@ internal sealed class WitsmlMetrics
             "witsml.requests.active",
             description: "Number of active requests");
 
-    internal async Task<TResponseType> MeasureQuery<TResponseType>(Uri serverUri, WitsmlMethod method, string witsmlType, Task<TResponseType> wmlsTask)
+    internal async Task<TResponseType> MeasureQuery<TResponseType>(Uri serverUri, WitsmlMethod method, string witsmlType, Task<TResponseType> wmlsTask, CancellationToken? cancellationToken = null)
         where TResponseType : IWitsmlResponse
     {
         var tagList = new TagList
@@ -51,13 +52,14 @@ internal sealed class WitsmlMetrics
             { "objectType", witsmlType },
         };
 
+        var ct = cancellationToken ?? CancellationToken.None;
         Stopwatch timer = null;
         TResponseType response;
         try
         {
             _activeRequests.Add(1, tagList);
             timer = Stopwatch.StartNew();
-            response = await wmlsTask;
+            response = await wmlsTask.WaitAsync(ct);
         }
         finally
         {

--- a/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
+++ b/Src/WitsmlExplorer.Api/Services/LogObjectService.cs
@@ -26,8 +26,8 @@ namespace WitsmlExplorer.Api.Services
     public interface ILogObjectService
     {
         Task<ICollection<LogObject>> GetLogs(string wellUid, string wellboreUid);
-        Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid);
-        Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid, OptionsIn queryOptions);
+        Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid, CancellationToken? cancellationToken = null);
+        Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid, OptionsIn queryOptions, CancellationToken? cancellationToken = null);
         Task<ICollection<LogCurveInfo>> GetLogCurveInfo(string wellUid, string wellboreUid, string logUid);
         Task<ICollection<MultiLogCurveInfo>> GetMultiLogCurveInfo(string wellUid, string wellboreUid, IEnumerable<string> logUids);
         Task<LogData> GetMultiLogData(string wellUid, string wellboreUid, string startIndex, string endIndex, bool startIndexIsInclusive, Dictionary<string, List<string>> logMnemonics);
@@ -69,15 +69,15 @@ namespace WitsmlExplorer.Api.Services
                 }).OrderBy(log => log.Name).ToList();
         }
 
-        public async Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid)
+        public async Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid, CancellationToken? cancellationToken = null)
         {
-            return await GetLog(wellUid, wellboreUid, logUid, new OptionsIn(ReturnElements.HeaderOnly));
+            return await GetLog(wellUid, wellboreUid, logUid, new OptionsIn(ReturnElements.HeaderOnly), cancellationToken);
         }
 
-        public async Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid, OptionsIn queryOptions)
+        public async Task<LogObject> GetLog(string wellUid, string wellboreUid, string logUid, OptionsIn queryOptions, CancellationToken? cancellationToken = null)
         {
             WitsmlLogs query = LogQueries.GetWitsmlLogById(wellUid, wellboreUid, logUid);
-            WitsmlLogs result = await _witsmlClient.GetFromStoreAsync(query, queryOptions);
+            WitsmlLogs result = await _witsmlClient.GetFromStoreAsync(query, queryOptions, cancellationToken);
             WitsmlLog witsmlLog = result.Logs.FirstOrDefault();
             if (witsmlLog == null)
             {

--- a/Tests/WitsmlExplorer.Api.Tests/Services/MessageObjectServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/MessageObjectServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Moq;
@@ -68,8 +69,8 @@ namespace WitsmlExplorer.Api.Tests.Services
                 }.AsItemInList()
             };
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlMessages>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested)))
-                .Callback<WitsmlMessages, OptionsIn>((_, _) => { })
+                client.GetFromStoreAsync(It.IsAny<WitsmlMessages>(), It.Is<OptionsIn>(ops => ops.ReturnElements == ReturnElements.Requested), null))
+                .Callback<WitsmlMessages, OptionsIn, CancellationToken?>((_, _, _) => { })
                 .ReturnsAsync(messages);
 
             IEnumerable<MessageObject> result = await _service.GetMessageObjects("", "");

--- a/Tests/WitsmlExplorer.Api.Tests/Services/ObjectServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/ObjectServiceTests.cs
@@ -67,7 +67,7 @@ namespace WitsmlExplorer.Api.Tests.Services
                         queryIn.Objects.First().Uid == string.Empty &&
                         queryIn.TypeName == new WitsmlLogs().TypeName
                     ),
-                    It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.IdOnly)))
+                    It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.IdOnly), null))
                 .ReturnsAsync(logs);
 
             IEnumerable<ObjectOnWellbore> result = await _service.GetObjectsIdOnly(uidWell, uidWellbore, EntityType.Log);
@@ -115,7 +115,7 @@ namespace WitsmlExplorer.Api.Tests.Services
                         queryIn.Objects.First().Uid == string.Empty &&
                         queryIn.TypeName == new WitsmlMessages().TypeName
                     ),
-                    It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.IdOnly)))
+                    It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.IdOnly), null))
                 .ReturnsAsync(messages);
 
             IEnumerable<ObjectOnWellbore> result = await _service.GetObjectsIdOnly(uidWell, uidWellbore, EntityType.Message);
@@ -150,7 +150,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.Setup(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == objectList.TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .ReturnsAsync(objectList);
         }
 
@@ -160,7 +161,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.Setup(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == new WitsmlFluidsReports().TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .ReturnsAsync(() => null);
 
             Dictionary<EntityType, int> result = await _service.GetExpandableObjectsCount("uidWell", "uidWellbore");
@@ -173,7 +175,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.Setup(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == new WitsmlFluidsReports().TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .Throws(new SystemException());
 
             Dictionary<EntityType, int> result = await _service.GetExpandableObjectsCount("uidWell", "uidWellbore");
@@ -192,8 +195,9 @@ namespace WitsmlExplorer.Api.Tests.Services
 
             _witsmlClient.Setup(client =>
                 client.GetFromStoreNullableAsync(
-                    It.Is<IWitsmlObjectList>((queryIn) => queryIn.Objects.Count() == 1 && queryIn.Objects.All((o) => o is WitsmlRig)),
-                    It.Is<OptionsIn>((optionsIn) => optionsIn.ReturnElements == ReturnElements.Requested)))
+                    It.Is<IWitsmlObjectList>(queryIn => queryIn.Objects.Count() == 1 && queryIn.Objects.All(witsmlObjectOnWellbore => witsmlObjectOnWellbore is WitsmlRig)),
+                    It.Is<OptionsIn>((optionsIn) => optionsIn.ReturnElements == ReturnElements.Requested),
+                    null))
                 .ReturnsAsync(() => objectList);
 
             IEnumerable<ObjectSearchResult> result = await _service.GetObjectsByType(EntityType.Rig);
@@ -206,7 +210,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.Setup(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == new WitsmlRigs().TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .ReturnsAsync(() => null);
 
             IEnumerable<ObjectSearchResult> result = await _service.GetObjectsByType(EntityType.Rig);
@@ -229,7 +234,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.SetupSequence(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == new WitsmlLogs().TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .ReturnsAsync(() => objectList)
                 .ReturnsAsync(() => objectList);
 
@@ -253,7 +259,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.SetupSequence(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == new WitsmlLogs().TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .ReturnsAsync(() => objectList)
                 .ReturnsAsync(() => null);
 
@@ -274,7 +281,8 @@ namespace WitsmlExplorer.Api.Tests.Services
             _witsmlClient.SetupSequence(client =>
                 client.GetFromStoreNullableAsync(
                     It.Is<IWitsmlObjectList>((queryIn) => queryIn.TypeName == new WitsmlLogs().TypeName),
-                    It.IsAny<OptionsIn>()))
+                    It.IsAny<OptionsIn>(),
+                    null))
                 .ReturnsAsync(() => objectList)
                 .ReturnsAsync(() => objectList);
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/AnalyzeGapWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/AnalyzeGapWorkerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -156,8 +157,8 @@ public class AnalyzeGapWorkerTests
         bool isSuccess = false;
 
         _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) => Task.FromResult(new WitsmlLogs()));
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => Task.FromResult(new WitsmlLogs()));
 
         (WorkerResult Result, RefreshAction) analyzeGapTask = await _worker.Execute(job);
         Assert.Equal(isSuccess, analyzeGapTask.Result.IsSuccess);
@@ -172,21 +173,21 @@ public class AnalyzeGapWorkerTests
         var logDataWithoutGaps = GetTestLogDataWithoutGaps(isDepthLog);
         witsmlClient.InSequence(mockSequence)
             .Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) => isLogDataWithGaps
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => isLogDataWithGaps
                 ? Task.FromResult(GetTestWitsmlLogs(logDataWithGaps, isDepthLog, isIncreasing))
                 : Task.FromResult(GetTestWitsmlLogs(logDataWithoutGaps, isDepthLog, isIncreasing)));
 
         witsmlClient.InSequence(mockSequence)
             .Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) => isLogDataWithGaps
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => isLogDataWithGaps
                 ? Task.FromResult(GetTestWitsmlLogs(logDataWithGaps, isDepthLog, isIncreasing))
                 : Task.FromResult(GetTestWitsmlLogs(logDataWithoutGaps, isDepthLog, isIncreasing)));
 
         witsmlClient.InSequence(mockSequence)
             .Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
             .Returns(Task.FromResult(new WitsmlLogs() { Logs = new List<WitsmlLog>() }));
     }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/BatchModifyLogCurveInfoTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/BatchModifyLogCurveInfoTests.cs
@@ -63,7 +63,7 @@ public class BatchModifyLogCurveInfoTests
         job.JobInfo = jobInfo;
 
         _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
             .Returns(Task.FromResult(GetTestWitsmlLogs()));
 
         List<WitsmlLogs> updatedLogs = new();

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CheckLogHeaderWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CheckLogHeaderWorkerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -227,8 +228,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private static void SetupClient(Mock<IWitsmlClient> witsmlClient, string indexType, bool shouldBeConsistent)
         {
             witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-                .Returns((WitsmlLogs logs, OptionsIn options) =>
+                client.GetFromStoreNullableAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+                .Returns((WitsmlLogs logs, OptionsIn options, CancellationToken? _) =>
             {
                 if (options.MaxReturnNodes == 1)
                 {

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CompareLogDataWorker.Tests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CompareLogDataWorker.Tests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -764,8 +764,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             int getDataCount = 0;
             // Mock fetching log
             witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-                .Returns((WitsmlLogs logs, OptionsIn options) =>
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+                .Returns((WitsmlLogs logs, OptionsIn options, CancellationToken? _) =>
             {
                 // Mock fetching the header
                 if (options.ReturnElements == ReturnElements.HeaderOnly)

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyComponentsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyComponentsWorkerTests.cs
@@ -127,10 +127,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetFromStoreAsync(ComponentType componentType, string[] sourceComponentUids, string[] targetComponentUids)
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == SourceUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All)))
+                client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == SourceUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All), null))
             .ReturnsAsync(GetWitsmlObject(sourceComponentUids, SourceUid, componentType));
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == TargetUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested)))
+                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == TargetUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested), null))
             .ReturnsAsync(GetWitsmlObject(targetComponentUids, TargetUid, componentType));
         }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogDataWorkerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -72,8 +73,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, _witsmlClient);
             List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlClient);
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() => LogUtils.GetSourceLogData(query.Logs.First().StartDateTimeIndex, query.Logs.First().EndDateTimeIndex));
 
             await _worker.Execute(job);
@@ -125,8 +126,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             LogUtils.SetupSourceLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>(optionsIn => optionsIn.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
                     double startIndex = double.Parse(query.Logs.First().StartIndex.Value);
@@ -155,8 +156,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
 
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
                     double startIndex = double.Parse(query.Logs.First().StartIndex.Value);
@@ -200,8 +201,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient);
 
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
                     double startIndex = double.Parse(query.Logs.First().StartIndex.Value);
@@ -233,8 +234,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_MD, _witsmlClient, targetLog);
 
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
                     double startIndex = double.Parse(query.Logs.First().StartIndex.Value);
@@ -302,8 +303,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             LogUtils.SetupTargetLog(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, _witsmlClient);
             List<WitsmlLogs> updatedLogs = LogUtils.SetupUpdateInStoreAsync(_witsmlClient);
             WitsmlLogs query = null;
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() => LogUtils.GetSourceLogData(query.Logs.First().StartDateTimeIndex, query.Logs.First().EndDateTimeIndex));
 
             await _worker.Execute(job);

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyLogWorkerTests.cs
@@ -135,12 +135,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, DepthStart, DepthEnd));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     _witsmlClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, TimeStart, TimeEnd));
                     break;
                 default:
@@ -151,7 +151,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested), null))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyObjectsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyObjectsWorkerTests.cs
@@ -52,7 +52,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             _witsmlSourceClient.Setup(client =>
                     client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(
                         witsmlObjects => witsmlObjects.Objects.First().Uid == ObjectUid),
-                        It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All)))
+                        It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All), null))
                 .ReturnsAsync(GetEmptySourceObjects());
             SetupGetWellbore();
 
@@ -67,7 +67,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             CopyObjectsJob copyObjectJob = CreateJobTemplate();
             _witsmlSourceClient.Setup(client =>
-                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(witsmlObjects => witsmlObjects.Objects.First().Uid == ObjectUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All)))
+                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(witsmlObjects => witsmlObjects.Objects.First().Uid == ObjectUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All), null))
                 .ReturnsAsync(GetSourceObjects());
             SetupGetWellbore();
             CopyTestsUtils.SetupAddInStoreAsync<IWitsmlObjectList>(_witsmlTargetClient);
@@ -80,7 +80,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlTargetClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested), null))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyWellWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyWellWorkerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging.Abstractions;
@@ -52,8 +53,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             WitsmlWells query = WellQueries.GetWitsmlWellByUid(wellUid);
             string queryText = XmlHelper.Serialize(WellQueries.GetWitsmlWellByUid(wellUid));
 
-            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>()))
-                               .ReturnsAsync((WitsmlWells q, OptionsIn op) => existingWells);
+            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>(), null))
+                               .ReturnsAsync((WitsmlWells q, OptionsIn op, CancellationToken? _) => existingWells);
 
             CopyWellJob job = CreateJobTemplate(wellUid);
 
@@ -75,10 +76,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             WitsmlWells query = WellQueries.GetWitsmlWellByUid(wellUid);
 
-            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>()))
+            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(new WitsmlWells { Wells = new List<WitsmlWell>() });
 
-            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>()))
+            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(sourceWells);
 
             QueryResult successQueryResult = new(true);
@@ -104,10 +105,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             WitsmlWells query = WellQueries.GetWitsmlWellByUid(wellUid);
 
-            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>()))
+            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(new WitsmlWells { Wells = new List<WitsmlWell>() });
 
-            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>()))
+            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(sourceWells);
 
             QueryResult failureQueryResult = new(false, "test");

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CopyWellboreWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CopyWellboreWorkerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging.Abstractions;
@@ -54,8 +55,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             WitsmlWellbores query = WellboreQueries.GetWitsmlWellboreByUid(WellUid, wellboreUid);
             string queryText = XmlHelper.Serialize(WellQueries.GetWitsmlWellByUid(wellboreUid));
 
-            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>()))
-                               .ReturnsAsync((WitsmlWellbores q, OptionsIn op) => existingWells);
+            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>(), null))
+                               .ReturnsAsync((WitsmlWellbores q, OptionsIn op, CancellationToken? _) => existingWells);
 
             CopyWellboreJob job = CreateJobTemplate(wellboreUid);
 
@@ -77,10 +78,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             WitsmlWellbores query = WellboreQueries.GetWitsmlWellboreByUid(WellUid, wellboreUid);
 
-            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>()))
+            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(new WitsmlWellbores { Wellbores = new List<WitsmlWellbore>() });
 
-            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>()))
+            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(sourceWells);
 
             QueryResult successQueryResult = new(true);
@@ -106,10 +107,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             WitsmlWellbores query = WellboreQueries.GetWitsmlWellboreByUid(WellUid, wellboreUid);
 
-            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>()))
+            _targetWitsmlClient.Setup(c => c.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(new WitsmlWellbores { Wellbores = new List<WitsmlWellbore>() });
 
-            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>()))
+            _sourceWitsmlClient.Setup(c => c.GetFromStoreAsync(IsQuery(query), It.IsAny<OptionsIn>(), null))
                                .ReturnsAsync(sourceWells);
 
             QueryResult failureQueryResult = new(false, "test");

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CountLogDataRowWorkerTest.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CountLogDataRowWorkerTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -104,8 +105,8 @@ public class CountLogDataRowWorkerTest
         bool isSuccess = false;
 
         _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) => Task.FromResult(new WitsmlLogs()));
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => Task.FromResult(new WitsmlLogs()));
 
         (WorkerResult Result, RefreshAction) countLogDataRowTask = await _worker.Execute(job);
         Assert.Equal(isSuccess, countLogDataRowTask.Result.IsSuccess);
@@ -120,8 +121,8 @@ public class CountLogDataRowWorkerTest
         job.JobInfo = jobInfo;
 
         _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) => Task.FromResult(GetTestWitsmlLogs(null, true, emptyLogCurveInfo: true)));
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => Task.FromResult(GetTestWitsmlLogs(null, true, emptyLogCurveInfo: true)));
 
         (WorkerResult Result, RefreshAction) countLogDataRowTask = await _worker.Execute(job);
         CountLogDataReport report = (CountLogDataReport)jobInfo.Report;
@@ -138,19 +139,19 @@ public class CountLogDataRowWorkerTest
 
         witsmlClient.InSequence(mockSequence)
             .Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) =>
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) =>
                 Task.FromResult(GetTestWitsmlLogs(GetTestLogData(isDepthLog, numberOfData), isDepthLog)));
 
         witsmlClient.InSequence(mockSequence)
             .Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-            .Returns((WitsmlLogs logs, OptionsIn options) =>
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+            .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) =>
                 Task.FromResult(GetTestWitsmlLogs(GetTestLogData(isDepthLog, numberOfData), isDepthLog)));
 
         witsmlClient.InSequence(mockSequence)
             .Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
             .Returns(Task.FromResult(new WitsmlLogs() { Logs = new List<WitsmlLog>() }));
     }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CreateWellWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CreateWellWorkerTests.cs
@@ -91,7 +91,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 client.AddToStoreAsync(It.IsAny<WitsmlWells>()))
                 .Callback<WitsmlWells>(createdWells.Add)
                 .ReturnsAsync(new QueryResult(true));
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>()))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>(), null))
                 .ReturnsAsync(new WitsmlWells() { Wells = new List<WitsmlWell>() { new WitsmlWell() } });
 
             await _worker.Execute(job);

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/CreateWellboreWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/CreateWellboreWorkerTests.cs
@@ -100,7 +100,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                     client.AddToStoreAsync(It.IsAny<WitsmlWellbores>()))
                 .Callback<WitsmlWellbores>(wellbores => createdWellbores.Add(wellbores))
                 .ReturnsAsync(new QueryResult(true));
-            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>()))
+            _witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>(), null))
                 .ReturnsAsync(new WitsmlWellbores { Wellbores = new List<WitsmlWellbore> { new WitsmlWellbore() } });
 
             await _worker.Execute(job);

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteCurveValuesWorkerTest.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteCurveValuesWorkerTest.cs
@@ -65,7 +65,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             DeleteCurveValuesJob job = CreateJobTemplate() with { IndexRanges = Array.Empty<IndexRange>() };
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -81,7 +81,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -98,7 +98,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             job.LogReference.Uid = "NOT_A_LOG";
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.False(result.IsSuccess);
         }
@@ -110,7 +110,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             DeleteCurveValuesJob job = CreateJobTemplate();
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Once());
             Assert.True(result.IsSuccess);
         }
@@ -128,7 +128,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.Is<WitsmlLogs>(logs => logs.Logs.First().StartIndex.Value == "20" && logs.Logs.First().EndIndex.Value == "10")), Times.Once());
             Assert.True(result.IsSuccess);
         }
@@ -148,7 +148,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Exactly(2));
             Assert.True(result.IsSuccess);
         }
@@ -179,7 +179,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Exactly(2));
             Assert.True(result.IsSuccess);
         }
@@ -202,7 +202,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -228,7 +228,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             (WorkerResult result, RefreshAction _) = await _worker.Execute(job);
 
-            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)), Times.Once);
+            _witsmlClient.Verify(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null), Times.Once);
             _witsmlClient.Verify(client => client.DeleteFromStoreAsync(It.IsAny<WitsmlLogs>()), Times.Never);
             Assert.True(result.IsSuccess);
         }
@@ -237,11 +237,11 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupLog(string indexType, Index startIndex, Index endIndex, string direction = null)
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                 .ReturnsAsync(GetLogs(indexType, startIndex, endIndex, direction));
 
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid != LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid != LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                 .ReturnsAsync(new WitsmlLogs());
 
             _witsmlClient.Setup(client =>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteEmptyMnemonicsWorkerTest.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/DeleteEmptyMnemonicsWorkerTest.cs
@@ -220,7 +220,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 .Returns(Task.Run(() => new List<LogObject> { new LogObject() { Uid = "123", IndexType = WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME } }.AsCollection()));
 
             _logObjectService
-                .Setup(los => los.GetLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(los => los.GetLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null))
                 .Returns(Task.Run(() => new LogObject() { Uid = "123", IndexType = WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME }));
 
             var lcis = new List<LogCurveInfo>();
@@ -258,7 +258,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
                 .Returns(Task.Run(() => new List<LogObject> { new LogObject() { Uid = "123", IndexType = WitsmlLog.WITSML_INDEX_TYPE_MD } }.AsCollection()));
 
             _logObjectService
-                .Setup(los => los.GetLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(los => los.GetLog(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null))
                 .Returns(Task.Run(() => new LogObject() { Uid = "123", IndexType = WitsmlLog.WITSML_INDEX_TYPE_MD }));
 
             var lcis = new List<LogCurveInfo>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/ImportLogDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/ImportLogDataWorkerTests.cs
@@ -78,7 +78,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
 
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly))).ReturnsAsync(returnedWitsmlLog);
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null)).ReturnsAsync(returnedWitsmlLog);
             _witsmlClient.Setup(client =>
                 client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>())).ReturnsAsync(new QueryResult(true));
 
@@ -122,7 +122,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             };
 
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly))).ReturnsAsync(returnedWitsmlLog);
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null)).ReturnsAsync(returnedWitsmlLog);
             _witsmlClient.Setup(client =>
                 client.UpdateInStoreAsync(It.IsAny<WitsmlLogs>())).ReturnsAsync(new QueryResult(true));
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/LogUtils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 using Moq;
 
@@ -41,12 +42,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     witsmlSourceClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, DepthStart, DepthEnd));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     witsmlSourceClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == SourceLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                         .ReturnsAsync(sourceLogs ?? GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME, TimeStart, TimeEnd));
                     break;
                 default:
@@ -60,12 +61,12 @@ namespace WitsmlExplorer.Api.Tests.Workers
             {
                 case WitsmlLog.WITSML_INDEX_TYPE_MD:
                     witsmlTargetClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                         .ReturnsAsync(targetLogs ?? GetTargetLogs(WitsmlLog.WITSML_INDEX_TYPE_MD));
                     break;
                 case WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME:
                     witsmlTargetClient.Setup(client =>
-                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                            client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == TargetLogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                         .ReturnsAsync(targetLogs ?? GetTargetLogs(WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME));
                     break;
                 default:
@@ -84,8 +85,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
         public static void SetupGetDepthIndexed(Mock<IWitsmlClient> witsmlClient, WitsmlLogs query = null)
         {
-            witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
                     double startIndex = double.Parse(query!.Logs.First().StartIndex.Value);
@@ -96,8 +97,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
         public static void SetupGetDepthIndexedDecreasing(Mock<IWitsmlClient> witsmlClient, WitsmlLogs query = null)
         {
-            witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
-                .Callback<WitsmlLogs, OptionsIn>((logs, _) => query = logs)
+            witsmlClient.Setup(client => client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
+                .Callback<WitsmlLogs, OptionsIn, CancellationToken?>((logs, _, _) => query = logs)
                 .ReturnsAsync(() =>
                 {
                     double startIndex = double.Parse(query!.Logs.First().StartIndex.Value);
@@ -396,7 +397,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
         public static void SetupGetDepthIndexed(Mock<IWitsmlClient> witsmlClient, Func<WitsmlLogs, bool> predicate, List<WitsmlData> data)
         {
-            witsmlClient.Setup(client => client.GetFromStoreAsync(It.Is<WitsmlLogs>(logs => predicate(logs)), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly)))
+            witsmlClient.Setup(client => client.GetFromStoreAsync(It.Is<WitsmlLogs>(logs => predicate(logs)), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.DataOnly), null))
                 .ReturnsAsync(() => new WitsmlLogs
                 {
                     Logs = new WitsmlLog

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/LogWorkerToolsTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/LogWorkerToolsTests.cs
@@ -46,7 +46,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
             WitsmlLog expectedLog = CreateLog();
             CreateObjectOnWellboreJob job = CreateJobTemplate(WitsmlLog.WITSML_INDEX_TYPE_MD);
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly))).ReturnsAsync(expectedLog.AsItemInWitsmlList());
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null)).ReturnsAsync(expectedLog.AsItemInWitsmlList());
 
             var log = await LogWorkerTools.GetLog(_witsmlClient.Object, job.Object, ReturnElements.HeaderOnly);
             Assert.Equal(expectedLog.Uid, log.Uid);
@@ -60,7 +60,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         {
             WitsmlLog expectedLog = CreateLog();
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly))).ReturnsAsync(expectedLog.AsItemInWitsmlList);
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null)).ReturnsAsync(expectedLog.AsItemInWitsmlList);
             WitsmlLog log = LogUtils.GetSourceLogs(WitsmlLog.WITSML_INDEX_TYPE_MD, 123.11, 123.12, "Depth").Logs.First();
             LogUtils.SetupGetDepthIndexed(_witsmlClient, (logs) => logs.Logs.First().StartIndex?.Value == "123.11",
                 new() { new() { Data = "123.11,1," }, new() { Data = "123.12,,2" } });

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/MinimumDataQcWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/MinimumDataQcWorkerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -351,21 +352,21 @@ namespace WitsmlExplorer.Api.Tests.Workers
             var logDataWithoutGaps = GetTestLogDataWithoutGaps(isDepthLog);
             witsmlClient.InSequence(mockSequence)
                 .Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-                .Returns((WitsmlLogs logs, OptionsIn options) => isLogDataWithIssues
+                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+                .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => isLogDataWithIssues
                     ? Task.FromResult(GetTestWitsmlLogs(logDataWithGaps, isDepthLog, isIncreasing))
                     : Task.FromResult(GetTestWitsmlLogs(logDataWithoutGaps, isDepthLog, isIncreasing)));
 
             witsmlClient.InSequence(mockSequence)
                 .Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-                .Returns((WitsmlLogs logs, OptionsIn options) => isLogDataWithIssues
+                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+                .Returns((WitsmlLogs _, OptionsIn _, CancellationToken? _) => isLogDataWithIssues
                     ? Task.FromResult(GetTestWitsmlLogs(logDataWithGaps, isDepthLog, isIncreasing))
                     : Task.FromResult(GetTestWitsmlLogs(logDataWithoutGaps, isDepthLog, isIncreasing)));
 
             witsmlClient.InSequence(mockSequence)
                 .Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(new WitsmlLogs() { Logs = new List<WitsmlLog>() }));
         }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/MissingDataWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/MissingDataWorkerTests.cs
@@ -108,7 +108,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task Execute_CheckWellProperties_AddsMissingProperties()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreNullableAsync(It.IsAny<WitsmlWells>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(GetTestWells()));
             var properties = new List<string>
             {
@@ -144,7 +144,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task Execute_CheckWellboreProperties_AddsMissingProperties()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreNullableAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(GetTestWellboresForWell1()));
             var properties = new List<string>
             {
@@ -180,7 +180,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task Execute_CheckRigProperties_AddsMissingProperties()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.IsAny<IWitsmlObjectList>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreNullableAsync(It.IsAny<IWitsmlObjectList>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(GetAllTestRigs()));
             var properties = new List<string>
             {
@@ -215,7 +215,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task Execute_CheckMissingWellbore_AddsWellboresWithNoRigs()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreNullableAsync(It.IsAny<WitsmlWellbores>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(GetAllTestWellbores()));
             var checks = new List<MissingDataCheck> {
                 new MissingDataCheck
@@ -237,7 +237,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task Execute_CheckMissingRig_AddsWellboresWithNoRigs()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.IsAny<IWitsmlObjectList>(), It.IsAny<OptionsIn>()))
+                client.GetFromStoreNullableAsync(It.IsAny<IWitsmlObjectList>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(GetTestRigsForWell1()));
             var checks = new List<MissingDataCheck> {
                 new MissingDataCheck

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/ModifyLogCurveInfoWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/ModifyLogCurveInfoWorkerTests.cs
@@ -85,7 +85,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             _witsmlClient
                 .Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(testWitsmlLogs));
 
             List<WitsmlLogs> updatedLogs = new();
@@ -114,7 +114,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
 
             _witsmlClient
                 .Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
                 .Returns(Task.FromResult(testWitsmlLogs));
 
             List<WitsmlLogs> updatedLogs = new();

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/OffsetLogCurveWorkerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -155,8 +156,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             int getDataCount = 0;
             // Mock fetching log
             witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-                .Returns((WitsmlLogs logs, OptionsIn options) =>
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+                .Returns((WitsmlLogs _, OptionsIn options, CancellationToken? _) =>
             {
                 // Mock fetching the header
                 if (options.ReturnElements == ReturnElements.HeaderOnly)

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/ReplaceComponentsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/ReplaceComponentsWorkerTests.cs
@@ -135,10 +135,10 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetFromStoreAsync(ComponentType componentType, string[] sourceComponentUids, string[] targetComponentUids)
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == SourceUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All)))
+                client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == SourceUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All), null))
             .ReturnsAsync(GetWitsmlObject(sourceComponentUids, SourceUid, componentType));
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == TargetUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested)))
+                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(query => query.Objects.First().Uid == TargetUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested), null))
             .ReturnsAsync(GetWitsmlObject(targetComponentUids, TargetUid, componentType));
         }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/ReplaceObjectsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/ReplaceObjectsWorkerTests.cs
@@ -118,7 +118,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetUpStoreForCopy(bool emptyResult = false)
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(witsmlObjects => witsmlObjects.Objects.First().Uid == ObjectUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All)))
+                    client.GetFromStoreNullableAsync(It.Is<IWitsmlObjectList>(witsmlObjects => witsmlObjects.Objects.First().Uid == ObjectUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.All), null))
                 .ReturnsAsync(emptyResult ? GetEmptySourceObjects() : GetSourceObjects());
             SetupGetWellbore();
             CopyTestsUtils.SetupAddInStoreAsync<IWitsmlObjectList>(_witsmlClient);
@@ -127,7 +127,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupGetWellbore()
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested)))
+                    client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.Requested), null))
                 .ReturnsAsync(new WitsmlWellbores
                 {
                     Wellbores = new List<WitsmlWellbore>

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/SpliceLogsWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/SpliceLogsWorkerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
@@ -513,8 +514,8 @@ namespace WitsmlExplorer.Api.Tests.Workers
             int getDataCount = 0;
             // Mock fetching log
             witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>()))
-                .Returns((WitsmlLogs logs, OptionsIn options) =>
+                client.GetFromStoreAsync(It.IsAny<WitsmlLogs>(), It.IsAny<OptionsIn>(), null))
+                .Returns((WitsmlLogs logs, OptionsIn options, CancellationToken? _) =>
             {
                 // Mock fetching the header
                 if (options.ReturnElements == ReturnElements.HeaderOnly)

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/TrimLogObjectWorkerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/TrimLogObjectWorkerTests.cs
@@ -307,7 +307,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         private void SetupLog(string indexType, Index startIndex, Index endIndex)
         {
             _witsmlClient.Setup(client =>
-                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly)))
+                    client.GetFromStoreAsync(It.Is<WitsmlLogs>(witsmlLogs => witsmlLogs.Logs.First().Uid == LogUid), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null))
                 .ReturnsAsync(GetLogs(indexType, startIndex, endIndex));
         }
 

--- a/Tests/WitsmlExplorer.Api.Tests/Workers/WorkerToolsTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Workers/WorkerToolsTests.cs
@@ -33,7 +33,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task GetWellTest_OK()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly))).ReturnsAsync(CreateWells());
+                client.GetFromStoreAsync(It.IsAny<WitsmlWells>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null)).ReturnsAsync(CreateWells());
             var wellReference = new WellReference() { WellName = WellName };
             var well = await WorkerTools.GetWell(_witsmlClient.Object, wellReference, ReturnElements.HeaderOnly);
             Assert.Equal(WellName, well.Name);
@@ -43,7 +43,7 @@ namespace WitsmlExplorer.Api.Tests.Workers
         public async Task GetWellBoreTest_OK()
         {
             _witsmlClient.Setup(client =>
-                client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly))).ReturnsAsync(CreateWellbores());
+                client.GetFromStoreAsync(It.IsAny<WitsmlWellbores>(), It.Is<OptionsIn>((ops) => ops.ReturnElements == ReturnElements.HeaderOnly), null)).ReturnsAsync(CreateWellbores());
             var wellboreReference = new WellboreReference() { WellName = WellName, WellboreName = WellboreName };
             var wellbore = await WorkerTools.GetWellbore(_witsmlClient.Object, wellboreReference, ReturnElements.HeaderOnly);
             Assert.Equal(WellboreName, wellbore.Name);

--- a/Tests/WitsmlExplorer.IntegrationTests/Witsml/CancellationTokenTests.cs
+++ b/Tests/WitsmlExplorer.IntegrationTests/Witsml/CancellationTokenTests.cs
@@ -1,0 +1,61 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+using Witsml;
+using Witsml.Data;
+using Witsml.ServiceReference;
+
+using Xunit;
+
+namespace WitsmlExplorer.IntegrationTests.Witsml;
+
+public class CancellationTokenTests
+{
+    private readonly WitsmlClient _client;
+
+    public CancellationTokenTests()
+    {
+        var config = ConfigurationReader.GetWitsmlConfiguration();
+        _client = new WitsmlClient(options =>
+        {
+            options.Hostname = config.Hostname;
+            options.Credentials = new WitsmlCredentials(config.Username, config.Password);
+        });
+    }
+
+    [Fact(Skip = "Should only be run manually")]
+    public async Task Verify_that_TaskCanceledException_IsThrown_OnCancellationTokenCancelled()
+    {
+        var query = new WitsmlWellbores
+        {
+            Wellbores =
+            [
+                new WitsmlWellbore { Name = "", IsActive = "true" }
+            ]
+        };
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(100);
+
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            _client.GetFromStoreAsync(query, new OptionsIn(ReturnElements.All),
+                cts.Token));
+    }
+
+    [Fact(Skip = "Should only be run manually")]
+    public async Task Verify_that_TaskCanceledException_IsNotThrown_IfQueryReturnsBeforeCancellation()
+    {
+        var query = new WitsmlWellbores
+        {
+            Wellbores =
+            [
+                new WitsmlWellbore { Name = "", IsActive = "true" }
+            ]
+        };
+        var cts = new CancellationTokenSource();
+        cts.CancelAfter(5000);
+
+        var response = await _client.GetFromStoreAsync(query, new OptionsIn(ReturnElements.All), cts.Token);
+
+        Assert.True(response.Wellbores.Count > 1);
+    }
+}


### PR DESCRIPTION
## Fixes

This pull request fixes #2666

## Description

It adds an optional `CancellationToken` argument to the GetFromStore methods in `WitsmlClient` and implements cancelling of the task in `WitsmlMetrics.MeasureQuery()`


## Type of change

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

* [ ] Frontend
* [ ] API
* [x] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests