### PR TITLE
Add null value check of commonData when load well list

### DIFF
--- a/Src/WitsmlExplorer.Api/Services/WellService.cs
+++ b/Src/WitsmlExplorer.Api/Services/WellService.cs
@@ -124,9 +124,9 @@ namespace WitsmlExplorer.Api.Services
                         Operator = well.Operator,
                         NumLicense = well.NumLicense,
                         TimeZone = well.TimeZone,
-                        DateTimeCreation = well.CommonData.DTimCreation,
-                        DateTimeLastChange = well.CommonData.DTimLastChange,
-                        ItemState = well.CommonData.ItemState,
+                        DateTimeCreation = well.CommonData?.DTimCreation,
+                        DateTimeLastChange = well.CommonData?.DTimLastChange,
+                        ItemState = well.CommonData?.ItemState,
                         StatusWell = well.StatusWell,
                         PurposeWell = well.PurposeWell,
                         Country = well.Country


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes the issue of #2695 Cannot load well list when there is well doesn't have commonData.dTimCreation and commonData.dTimLastChange 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)
When query well List of server, explorer will list all well's commonData.dTimLastchange & commonData.dTimCreation. At the API level it didn't do null value check and will throw null value exception when there are some wells don't return these 2 values. It will cause all wells cannot be loaded at front-end. Just add null value check will fix it.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [x] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [x] API
* [ ] WITSML
* [x] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security
No change on documentation needed

*Code quality*
* [x] I have self-reviewed my code
* [ ] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


