### PR TITLE
Potential fix for code scanning alert no. 2: Log entries created from user input

### DIFF
--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -148,7 +148,7 @@ namespace WitsmlExplorer.Api.Services
                     ?.SelectMany(n => n.CredentialIds)
                     ?.ToList()
                     ?? new List<string>();
-                _logger.LogDebug("Matching on {credentialIdOrHost} for server {server}", credentialIds.Count == 0 ? "host" : $"credentialIds {string.Join(", ", credentialIds)}", server);
+                _logger.LogDebug("Matching on {credentialIdOrHost} for server {server}", credentialIds.Count == 0 ? "host" : $"credentialIds {string.Join(", ", credentialIds)}", SanitizeForLog(server));
                 var matchingCredentials = credentialIds.IsNullOrEmpty()
                     ? _witsmlServerCredentials.WitsmlCreds.Where(n => n.Host.EqualsIgnoreCase(server))
                     : _witsmlServerCredentials.WitsmlCreds.Where(n => credentialIds.Contains(n.CredentialId, StringComparer.InvariantCultureIgnoreCase));
@@ -239,6 +239,16 @@ namespace WitsmlExplorer.Api.Services
         public string GetCacheId(IEssentialHeaders eh)
         {
             return _useOAuth2 ? GetClaimFromToken(eh.GetBearerToken(), SUBJECT) : eh.GetCookieValue();
+        }
+        /// <summary>
+        /// Sanitizes user provided Uri for logging to avoid log-forging attacks.
+        /// Removes carriage returns and newlines.
+        /// </summary>
+        private static string SanitizeForLog(Uri uri)
+        {
+            if (uri == null) return string.Empty;
+            // Remove \r and \n to prevent log forging
+            return uri.ToString().Replace("\r", "").Replace("\n", "");
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/equinor/witsml-explorer/security/code-scanning/2](https://github.com/equinor/witsml-explorer/security/code-scanning/2)

To fix the issue, all values derived from user input and sent to logs should first be sanitized, particularly by removing newlines and carriage return characters (commonly used to forge log entries). In this code, the `server` parameter (a `Uri`), which ultimately originates from HTTP headers, should be safely stringified and sanitized before logging.

- The best solution is to replace or supplement the use of `{server}` in the logging call with a sanitized string version of the URI, where newlines and carriage returns (`\r`/`\n`) are stripped or replaced.
- This can be achieved by calling `server.ToString().Replace("\r", "").Replace("\n", "")` or by creating a helper method for sanitizing, e.g., `SanitizeForLog(string value)`, and using that on the string.
- Only the code in the immediate area of the log call needs to be changed, so changes are confined to the line logging the user input.

**Required:**
- Add a small local sanitizer method if deemed more readable and reusable.
- Only change CredentialsService.cs, as per the shown code and instructions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
