### PR TITLE
DWO properties are ellipsible with tooltips #2877

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ReadOnlyProperties/ReadOnlyPropertiesGrid.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ReadOnlyProperties/ReadOnlyPropertiesGrid.tsx
@@ -33,7 +33,10 @@ const Layout = styled.div<{ columns: number; noMargin?: boolean }>`
           margin-bottom: 12px;
         `}
   display: grid;
-  grid-template-columns: repeat(${(props) => props.columns}, auto);
+  grid-template-columns: repeat(
+    ${(props) => props.columns},
+    minmax(auto, 200px)
+  );
   gap: 20px;
   justify-content: start;
 `;

--- a/Src/WitsmlExplorer.Frontend/components/ReadOnlyProperties/ReadOnlyProperty.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ReadOnlyProperties/ReadOnlyProperty.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@equinor/eds-core-react";
+import { Tooltip as EdsTooltip, Typography } from "@equinor/eds-core-react";
 import { useOperationState } from "hooks/useOperationState";
 import styled from "styled-components";
 import { Colors } from "styles/Colors";
@@ -19,13 +19,24 @@ export const ReadOnlyProperty = ({
     operationState: { colors }
   } = useOperationState();
 
+  const renderValueWithTooltip = () => {
+    if (value === "-")
+      return <PropertyValue colors={colors}>{value}</PropertyValue>;
+    else
+      return (
+        <Tooltip title={value}>
+          <PropertyValue colors={colors}>{value}</PropertyValue>
+        </Tooltip>
+      );
+  };
+
   return (
     <PropertyLayout>
       <PropertyLabel colors={colors}>{label}</PropertyLabel>
       {renderValue ? (
         renderValue(value)
       ) : (
-        <PropertyValue colors={colors}>{value}</PropertyValue>
+        <EllipsibleHolder>{renderValueWithTooltip()}</EllipsibleHolder>
       )}
     </PropertyLayout>
   );
@@ -35,7 +46,6 @@ const PropertyLayout = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  width: minmax(150px, 300px);
 `;
 
 const PropertyLabel = styled(Typography)<{ colors: Colors }>`
@@ -44,6 +54,21 @@ const PropertyLabel = styled(Typography)<{ colors: Colors }>`
 `;
 
 const PropertyValue = styled(Typography)<{ colors: Colors }>`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   font-size: 14px;
   color: ${(props) => props.colors.text.staticIconsDefault};
+  width: fit-content;
+  max-width: 100%;
+`;
+
+const Tooltip = styled(EdsTooltip)`
+  white-space: pre-wrap;
+  max-width: 30rem;
+  width: auto;
+`;
+
+const EllipsibleHolder = styled.div`
+  min-width: 0;
 `;


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

ReadOnlyProperties rendering of longer content - ellipsible. Related to #2877 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Properties in DWO grid view are now ellipsible when overflown. Full calues are also available in tooltips when different then "-" values. Tooltips are available only when string is rendered - custom render is omitted in this flow (e.g. chips...).
<img width="802" height="135" alt="image" src="https://github.com/user-attachments/assets/beed2ef1-691d-4653-8a55-09c6aa33a047" />


## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


