### PR TITLE
feat: Add 'Last Fetched' timestamp to content table views

### DIFF
--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
@@ -7,7 +7,7 @@ import {
 import BhaRunContextMenu from "components/ContextMenus/BhaRunContextMenu";
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -35,10 +35,7 @@ export default function BhaRunsListView() {
     wellboreUid,
     ObjectType.BhaRun
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.BhaRun);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
@@ -7,7 +7,9 @@ import {
 import BhaRunContextMenu from "components/ContextMenus/BhaRunContextMenu";
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -29,12 +31,11 @@ export default function BhaRunsListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: bhaRuns, responseTime, dataUpdatedAt } = useGetObjects(
-    connectedServer,
-    wellUid,
-    wellboreUid,
-    ObjectType.BhaRun
-  );
+  const {
+    objects: bhaRuns,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.BhaRun);
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.BhaRun);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/BhaRunsListView.tsx
@@ -29,12 +29,15 @@ export default function BhaRunsListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: bhaRuns, responseTime } = useGetObjects(
+  const { objects: bhaRuns, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.BhaRun
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.BhaRun);
 
@@ -131,6 +134,7 @@ export default function BhaRunsListView() {
         showRefresh
         downloadToCsvFileName="BhaRuns"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
@@ -18,12 +18,15 @@ export default function ChangeLogsListView() {
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
 
-  const { objects: changeLogs, responseTime } = useGetObjects(
+  const { objects: changeLogs, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.ChangeLog
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.ChangeLog);
 
@@ -77,6 +80,7 @@ export default function ChangeLogsListView() {
         showRefresh
         downloadToCsvFileName="ChangeLogs"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
@@ -3,7 +3,9 @@ import {
   ContentTableColumn,
   ContentType
 } from "components/ContentViews/table";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
@@ -18,7 +20,11 @@ export default function ChangeLogsListView() {
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
 
-  const { objects: changeLogs, responseTime, dataUpdatedAt } = useGetObjects(
+  const {
+    objects: changeLogs,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/ChangeLogsListView.tsx
@@ -3,7 +3,7 @@ import {
   ContentTableColumn,
   ContentType
 } from "components/ContentViews/table";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import { useGetObjects } from "hooks/query/useGetObjects";
 import { useExpandSidebarNodes } from "hooks/useExpandObjectGroupNodes";
@@ -24,10 +24,7 @@ export default function ChangeLogsListView() {
     wellboreUid,
     ObjectType.ChangeLog
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.ChangeLog);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -18,8 +18,11 @@ import {
 } from "components/ContentViews/table";
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import MnemonicsContextMenu from "components/ContextMenus/MnemonicsContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, { formatTimeWithOffset } from "components/DateFormatter";
 import ConfirmModal from "components/Modals/ConfirmModal";
+import DownloadOptionsSelectionModal, {
+  DownloadOptionsSelectionModalProps
+} from "components/Modals/DownloadOptionsSelectionModal.tsx";
 import { ShowLogDataOnServerModal } from "components/Modals/ShowLogDataOnServerModal";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { Button } from "components/StyledComponents/Button";
@@ -61,9 +64,7 @@ import {
   CommonPanelContainer,
   ContentContainer
 } from "../StyledComponents/Container";
-import DownloadOptionsSelectionModal, {
-  DownloadOptionsSelectionModalProps
-} from "components/Modals/DownloadOptionsSelectionModal.tsx";
+
 
 const TIME_INDEX_START_OFFSET = SECONDS_IN_MINUTE * 20; // offset before log end index that defines the start index for streaming (in seconds).
 const DEPTH_INDEX_START_OFFSET = 20; // offset before log end index that defines the start index for streaming.
@@ -91,6 +92,7 @@ export const CurveValuesView = (): React.ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [selectedRows, setSelectedRows] = useState<CurveValueRow[]>([]);
   const [showPlot, setShowPlot] = useState<boolean>(false);
+  const [lastFetchedAt, setLastFetchedAt] = useState<number>(0);
   const [autoRefresh, setAutoRefresh] = useState<boolean>(false);
   const [refreshDelay, setRefreshDelay] = useState<number>(
     DEFAULT_REFRESH_DELAY
@@ -424,6 +426,7 @@ export const CurveValuesView = (): React.ReactElement => {
       } else {
         setTableData(logDataRows);
       }
+      setLastFetchedAt(Date.now());
     }
   };
 
@@ -480,6 +483,11 @@ export const CurveValuesView = (): React.ReactElement => {
             <Typography style={{ minWidth: "max-content" }}>
               Show Plot
             </Typography>
+            {formatTimeWithOffset(lastFetchedAt, timeZone) && (
+              <Typography style={{ minWidth: "max-content", marginLeft: "16px" }}>
+                Last fetched: {formatTimeWithOffset(lastFetchedAt, timeZone)}
+              </Typography>
+            )}
           </EdsProvider>
           {log?.objectGrowing && (
             <>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/CurveValuesView.tsx
@@ -18,7 +18,9 @@ import {
 } from "components/ContentViews/table";
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import MnemonicsContextMenu from "components/ContextMenus/MnemonicsContextMenu";
-import formatDateString, { formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import ConfirmModal from "components/Modals/ConfirmModal";
 import DownloadOptionsSelectionModal, {
   DownloadOptionsSelectionModalProps
@@ -64,7 +66,6 @@ import {
   CommonPanelContainer,
   ContentContainer
 } from "../StyledComponents/Container";
-
 
 const TIME_INDEX_START_OFFSET = SECONDS_IN_MINUTE * 20; // offset before log end index that defines the start index for streaming (in seconds).
 const DEPTH_INDEX_START_OFFSET = 20; // offset before log end index that defines the start index for streaming.
@@ -484,7 +485,9 @@ export const CurveValuesView = (): React.ReactElement => {
               Show Plot
             </Typography>
             {formatTimeWithOffset(lastFetchedAt, timeZone) && (
-              <Typography style={{ minWidth: "max-content", marginLeft: "16px" }}>
+              <Typography
+                style={{ minWidth: "max-content", marginLeft: "16px" }}
+              >
                 Last fetched: {formatTimeWithOffset(lastFetchedAt, timeZone)}
               </Typography>
             )}

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import FluidsReportContextMenu from "components/ContextMenus/FluidsReportContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -32,7 +34,11 @@ export default function FluidsReportsListView() {
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
   const navigate = useNavigate();
-  const { objects: fluidsReports, responseTime, dataUpdatedAt } = useGetObjects(
+  const {
+    objects: fluidsReports,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import FluidsReportContextMenu from "components/ContextMenus/FluidsReportContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -38,10 +38,7 @@ export default function FluidsReportsListView() {
     wellboreUid,
     ObjectType.FluidsReport
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FluidsReport);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsReportListView.tsx
@@ -32,12 +32,15 @@ export default function FluidsReportsListView() {
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
   const navigate = useNavigate();
-  const { objects: fluidsReports, responseTime } = useGetObjects(
+  const { objects: fluidsReports, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.FluidsReport
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FluidsReport);
 
@@ -132,6 +135,7 @@ export default function FluidsReportsListView() {
         showRefresh
         downloadToCsvFileName="FluidsReports"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
@@ -8,7 +8,9 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import FluidContextMenu, {
   FluidContextMenuProps
 } from "components/ContextMenus/FluidContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -71,7 +73,10 @@ export default function FluidsView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
-  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const dataUpdatedAt = Math.max(
+    dataUpdatedAtObject ?? 0,
+    dataUpdatedAtComponents ?? 0
+  );
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FluidsReport);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
@@ -8,7 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import FluidContextMenu, {
   FluidContextMenuProps
 } from "components/ContextMenus/FluidContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -72,9 +72,7 @@ export default function FluidsView() {
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
   const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FluidsReport);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FluidsView.tsx
@@ -43,7 +43,8 @@ export default function FluidsView() {
     object: fluidsReport,
     responseTime: responseTimeObject,
     isFetching: isFetchingFluidsReport,
-    isFetched: isFetchedFluidsReport
+    isFetched: isFetchedFluidsReport,
+    dataUpdatedAt: dataUpdatedAtObject
   } = useGetObject(
     connectedServer,
     wellUid,
@@ -55,7 +56,8 @@ export default function FluidsView() {
   const {
     components: fluids,
     isFetching: isFetchingFluids,
-    responseTime: responseTimeComponents
+    responseTime: responseTimeComponents,
+    dataUpdatedAt: dataUpdatedAtComponents
   } = useGetComponents(
     connectedServer,
     wellUid,
@@ -69,6 +71,10 @@ export default function FluidsView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
+  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FluidsReport);
 
@@ -303,6 +309,7 @@ export default function FluidsView() {
         showRefresh
         downloadToCsvFileName={`FluidsReport_${fluidsReport?.name}`}
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     </>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
@@ -31,12 +31,15 @@ export default function FormationMarkersListView() {
   const { dispatchOperation } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: formationMarkers, responseTime } = useGetObjects(
+  const { objects: formationMarkers, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.FormationMarker
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FormationMarker);
 
@@ -113,6 +116,7 @@ export default function FormationMarkersListView() {
         showRefresh
         downloadToCsvFileName="FormationMarkers"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import FormationMarkerContextMenu from "components/ContextMenus/FormationMarkerContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -31,7 +33,11 @@ export default function FormationMarkersListView() {
   const { dispatchOperation } = useOperationState();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: formationMarkers, responseTime, dataUpdatedAt } = useGetObjects(
+  const {
+    objects: formationMarkers,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/FormationMarkersListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import FormationMarkerContextMenu from "components/ContextMenus/FormationMarkerContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -37,10 +37,7 @@ export default function FormationMarkersListView() {
     wellboreUid,
     ObjectType.FormationMarker
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.FormationMarker);
 
   const structToString = (struct: StratigraphicStruct) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -9,7 +9,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import JobInfoContextMenu, {
   JobInfoContextMenuProps
 } from "components/ContextMenus/JobInfoContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import ConfirmModal from "components/Modals/ConfirmModal";
 import { ReportModal } from "components/Modals/ReportModal";
 import { Button } from "components/StyledComponents/Button";
@@ -45,10 +45,7 @@ export const JobsView = (): React.ReactElement => {
   const { jobInfos, isFetching, dataUpdatedAt } = useGetJobInfo(showAll, {
     placeholderData: []
   });
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   const [cancellingJobs, setCancellingJobs] = useState<string[]>([]);
 
   const onContextMenu = (

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/JobsView.tsx
@@ -9,7 +9,9 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import JobInfoContextMenu, {
   JobInfoContextMenuProps
 } from "components/ContextMenus/JobInfoContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import ConfirmModal from "components/Modals/ConfirmModal";
 import { ReportModal } from "components/Modals/ReportModal";
 import { Button } from "components/StyledComponents/Button";

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
@@ -58,7 +58,8 @@ export default function LogCurveInfoListView() {
     object: logObject,
     isFetching: isFetchingLog,
     isFetched: isFetchedLog,
-    responseTime: responseTimeObject
+    responseTime: responseTimeObject,
+    dataUpdatedAt: dataUpdatedAtObject
   } = useGetObject(
     connectedServer,
     wellUid,
@@ -72,7 +73,8 @@ export default function LogCurveInfoListView() {
   const {
     components: logCurveInfoList,
     isFetching: isFetchingLogCurveInfo,
-    responseTime: responseTimeComponents
+    responseTime: responseTimeComponents,
+    dataUpdatedAt: dataUpdatedAtComponents
   } = useGetComponents(
     connectedServer,
     wellUid,
@@ -98,6 +100,10 @@ export default function LogCurveInfoListView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
+  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
   const allPrioritizedCurves = [
     ...prioritizedLocalCurves,
     ...prioritizedUniversalCurves
@@ -287,6 +293,7 @@ export default function LogCurveInfoListView() {
           showRefresh
           downloadToCsvFileName={`LogCurveInfo_${logObject.name}`}
           responseTime={responseTime}
+          lastFetched={lastFetched}
         />
       )}
     </>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
@@ -101,7 +101,10 @@ export default function LogCurveInfoListView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
-  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const dataUpdatedAt = Math.max(
+    dataUpdatedAtObject ?? 0,
+    dataUpdatedAtComponents ?? 0
+  );
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   const allPrioritizedCurves = [
     ...prioritizedLocalCurves,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogCurveInfoListView.tsx
@@ -4,6 +4,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import LogCurveInfoContextMenu, {
   LogCurveInfoContextMenuProps
 } from "components/ContextMenus/LogCurveInfoContextMenu";
+import { formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { CommonPanelContainer } from "components/StyledComponents/Container";
 import { RoleLimitedAccess } from "components/UserRoles.ts";
@@ -101,9 +102,7 @@ export default function LogCurveInfoListView() {
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
   const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   const allPrioritizedCurves = [
     ...prioritizedLocalCurves,
     ...prioritizedUniversalCurves

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -59,8 +59,12 @@ export default function LogsListView() {
     objects: allLogs,
     isFetching: isFetchingLogs,
     responseTime: responseTime,
-    isFetched
+    isFetched,
+    dataUpdatedAt
   } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.Log);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
   const isTimeIndexed = logType === RouterLogType.TIME;
   const logs = filterLogsByType(
     allLogs,
@@ -199,6 +203,7 @@ export default function LogsListView() {
             onSelect={onSelect}
             data={getTableData()}
             responseTime={responseTime}
+            lastFetched={lastFetched}
             onContextMenu={onContextMenu}
             onRowSelectionChange={(rows) =>
               setSelectedRows(rows as LogObjectRow[])

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -13,7 +13,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import LogObjectContextMenu from "components/ContextMenus/LogObjectContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import {
   CommonPanelContainer,
@@ -62,9 +62,7 @@ export default function LogsListView() {
     isFetched,
     dataUpdatedAt
   } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.Log);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   const isTimeIndexed = logType === RouterLogType.TIME;
   const logs = filterLogsByType(
     allLogs,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/LogsListView.tsx
@@ -13,7 +13,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import LogObjectContextMenu from "components/ContextMenus/LogObjectContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import {
   CommonPanelContainer,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import MessageObjectContextMenu from "components/ContextMenus/MessageObjectContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -36,10 +36,7 @@ export default function MessagesListView() {
     wellboreUid,
     ObjectType.Message
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Message);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -30,12 +30,15 @@ export default function MessagesListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: messages, responseTime } = useGetObjects(
+  const { objects: messages, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.Message
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Message);
 
@@ -126,6 +129,7 @@ export default function MessagesListView() {
         showRefresh
         downloadToCsvFileName="Messages"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MessagesListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import MessageObjectContextMenu from "components/ContextMenus/MessageObjectContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -30,12 +32,11 @@ export default function MessagesListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: messages, responseTime, dataUpdatedAt } = useGetObjects(
-    connectedServer,
-    wellUid,
-    wellboreUid,
-    ObjectType.Message
-  );
+  const {
+    objects: messages,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.Message);
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Message);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
@@ -82,7 +82,10 @@ export default function MudLogView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
-  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const dataUpdatedAt = Math.max(
+    dataUpdatedAtObject ?? 0,
+    dataUpdatedAtComponents ?? 0
+  );
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.MudLog);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
@@ -50,7 +50,8 @@ export default function MudLogView() {
     object: mudLog,
     isFetching: isFetchingMudLog,
     isFetched: isFetchedMudLog,
-    responseTime: responseTimeObject
+    responseTime: responseTimeObject,
+    dataUpdatedAt: dataUpdatedAtObject
   } = useGetObject(
     connectedServer,
     wellUid,
@@ -62,7 +63,8 @@ export default function MudLogView() {
   const {
     components: geologyIntervals,
     isFetching: isFetchingGeologyIntervals,
-    responseTime: responseTimeComponents
+    responseTime: responseTimeComponents,
+    dataUpdatedAt: dataUpdatedAtComponents
   } = useGetComponents(
     connectedServer,
     wellUid,
@@ -76,6 +78,10 @@ export default function MudLogView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
+  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.MudLog);
 
@@ -169,6 +175,7 @@ export default function MudLogView() {
         showRefresh
         downloadToCsvFileName={`MudLog_${mudLog?.name}`}
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     </>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogView.tsx
@@ -8,6 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import GeologyIntervalContextMenu, {
   GeologyIntervalContextMenuProps
 } from "components/ContextMenus/GeologyIntervalContextMenu";
+import { formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -43,7 +44,10 @@ export interface GeologyIntervalRow extends ContentTableRow {
 }
 
 export default function MudLogView() {
-  const { dispatchOperation } = useOperationState();
+  const {
+    dispatchOperation,
+    operationState: { timeZone }
+  } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const {
@@ -79,9 +83,7 @@ export default function MudLogView() {
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
   const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.MudLog);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
@@ -40,12 +40,15 @@ export default function MudLogsListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: mudLogs, responseTime } = useGetObjects(
+  const { objects: mudLogs, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.MudLog
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.MudLog);
 
@@ -146,6 +149,7 @@ export default function MudLogsListView() {
         showRefresh
         downloadToCsvFileName="MudLogs"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import MudLogContextMenu from "components/ContextMenus/MudLogContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -40,12 +42,11 @@ export default function MudLogsListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: mudLogs, responseTime, dataUpdatedAt } = useGetObjects(
-    connectedServer,
-    wellUid,
-    wellboreUid,
-    ObjectType.MudLog
-  );
+  const {
+    objects: mudLogs,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.MudLog);
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.MudLog);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/MudLogsListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import MudLogContextMenu from "components/ContextMenus/MudLogContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -46,10 +46,7 @@ export default function MudLogsListView() {
     wellboreUid,
     ObjectType.MudLog
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.MudLog);
 
   const onSelect = (mudLogRow: MudLogRow) => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import RigContextMenu from "components/ContextMenus/RigContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -35,10 +35,7 @@ export default function RigsListView() {
     wellboreUid,
     ObjectType.Rig
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Rig);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
@@ -29,12 +29,15 @@ export default function RigsListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: rigs, responseTime } = useGetObjects(
+  const { objects: rigs, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.Rig
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Rig);
 
@@ -158,6 +161,7 @@ export default function RigsListView() {
         showRefresh
         downloadToCsvFileName="Rigs"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RigsListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import RigContextMenu from "components/ContextMenus/RigContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -29,12 +31,11 @@ export default function RigsListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: rigs, responseTime, dataUpdatedAt } = useGetObjects(
-    connectedServer,
-    wellUid,
-    wellboreUid,
-    ObjectType.Rig
-  );
+  const {
+    objects: rigs,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.Rig);
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Rig);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import RiskObjectContextMenu from "components/ContextMenus/RiskContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -30,12 +32,11 @@ export default function RisksListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: risks, responseTime, dataUpdatedAt } = useGetObjects(
-    connectedServer,
-    wellUid,
-    wellboreUid,
-    ObjectType.Risk
-  );
+  const {
+    objects: risks,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.Risk);
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Risk);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import RiskObjectContextMenu from "components/ContextMenus/RiskContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -36,10 +36,7 @@ export default function RisksListView() {
     wellboreUid,
     ObjectType.Risk
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Risk);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/RisksListView.tsx
@@ -30,12 +30,15 @@ export default function RisksListView() {
   } = useOperationState();
   const { wellUid, wellboreUid } = useParams();
   const { connectedServer } = useConnectedServer();
-  const { objects: risks, responseTime } = useGetObjects(
+  const { objects: risks, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.Risk
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Risk);
 
@@ -134,6 +137,7 @@ export default function RisksListView() {
         showRefresh
         downloadToCsvFileName="Risks"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
@@ -6,7 +6,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import TrajectoryContextMenu from "components/ContextMenus/TrajectoryContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -33,10 +33,7 @@ export default function TrajectoriesListView() {
     wellboreUid,
     ObjectType.Trajectory
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Trajectory);
 
   const onContextMenu = (

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
@@ -27,12 +27,15 @@ export default function TrajectoriesListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: trajectories, responseTime } = useGetObjects(
+  const { objects: trajectories, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.Trajectory
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Trajectory);
 
@@ -157,6 +160,7 @@ export default function TrajectoriesListView() {
         showRefresh
         downloadToCsvFileName="Trajectories"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoriesListView.tsx
@@ -6,7 +6,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import TrajectoryContextMenu from "components/ContextMenus/TrajectoryContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -27,7 +29,11 @@ export default function TrajectoriesListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: trajectories, responseTime, dataUpdatedAt } = useGetObjects(
+  const {
+    objects: trajectories,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
@@ -8,7 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import TrajectoryStationContextMenu, {
   TrajectoryStationContextMenuProps
 } from "components/ContextMenus/TrajectoryStationContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -75,9 +75,7 @@ export default function TrajectoryView() {
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
   const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Trajectory);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
@@ -8,7 +8,9 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import TrajectoryStationContextMenu, {
   TrajectoryStationContextMenuProps
 } from "components/ContextMenus/TrajectoryStationContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -74,7 +76,10 @@ export default function TrajectoryView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
-  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const dataUpdatedAt = Math.max(
+    dataUpdatedAtObject ?? 0,
+    dataUpdatedAtComponents ?? 0
+  );
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Trajectory);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TrajectoryView.tsx
@@ -46,7 +46,8 @@ export default function TrajectoryView() {
     object: trajectory,
     isFetching: isFetchingTrajectory,
     isFetched: isFetchedTrajectory,
-    responseTime: responseTimeObject
+    responseTime: responseTimeObject,
+    dataUpdatedAt: dataUpdatedAtObject
   } = useGetObject(
     connectedServer,
     wellUid,
@@ -58,7 +59,8 @@ export default function TrajectoryView() {
   const {
     components: trajectoryStations,
     isFetching: isFetchingTrajectoryStations,
-    responseTime: responseTimeComponents
+    responseTime: responseTimeComponents,
+    dataUpdatedAt: dataUpdatedAtComponents
   } = useGetComponents(
     connectedServer,
     wellUid,
@@ -72,6 +74,10 @@ export default function TrajectoryView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
+  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Trajectory);
 
@@ -154,6 +160,7 @@ export default function TrajectoryView() {
         showRefresh
         downloadToCsvFileName={`Trajectory_${trajectory?.name}`}
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     </>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
@@ -8,6 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import TubularComponentContextMenu, {
   TubularComponentContextMenuProps
 } from "components/ContextMenus/TubularComponentContextMenu";
+import {formatTimeWithOffset} from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -36,7 +37,10 @@ export interface TubularComponentRow extends ContentTableRow {
 }
 
 export default function TubularView() {
-  const { dispatchOperation } = useOperationState();
+  const {
+    dispatchOperation,
+    operationState: { timeZone }
+  } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const {
@@ -72,10 +76,7 @@ export default function TubularView() {
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
   const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Tubular);
 
   const onContextMenu = (

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
@@ -8,7 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import TubularComponentContextMenu, {
   TubularComponentContextMenuProps
 } from "components/ContextMenus/TubularComponentContextMenu";
-import {formatTimeWithOffset} from "components/DateFormatter";
+import { formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -75,7 +75,10 @@ export default function TubularView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
-  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const dataUpdatedAt = Math.max(
+    dataUpdatedAtObject ?? 0,
+    dataUpdatedAtComponents ?? 0
+  );
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Tubular);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularView.tsx
@@ -43,7 +43,8 @@ export default function TubularView() {
     object: tubular,
     isFetching: isFetchingTubular,
     isFetched: isFetchedTubular,
-    responseTime: responseTimeObject
+    responseTime: responseTimeObject,
+    dataUpdatedAt: dataUpdatedAtObject
   } = useGetObject(
     connectedServer,
     wellUid,
@@ -55,7 +56,8 @@ export default function TubularView() {
   const {
     components: tubularComponents,
     isFetching: isFetchingTubularComponents,
-    responseTime: responseTimeComponents
+    responseTime: responseTimeComponents,
+    dataUpdatedAt: dataUpdatedAtComponents
   } = useGetComponents(
     connectedServer,
     wellUid,
@@ -69,6 +71,10 @@ export default function TubularView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
+  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Tubular);
 
@@ -161,6 +167,7 @@ export default function TubularView() {
         showRefresh
         downloadToCsvFileName={`Tubular_${tubular?.name}`}
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     </>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -6,7 +6,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import TubularContextMenu from "components/ContextMenus/TubularContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -26,12 +28,11 @@ export default function TubularsListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: tubulars, responseTime, dataUpdatedAt } = useGetObjects(
-    connectedServer,
-    wellUid,
-    wellboreUid,
-    ObjectType.Tubular
-  );
+  const {
+    objects: tubulars,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(connectedServer, wellUid, wellboreUid, ObjectType.Tubular);
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Tubular);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -26,12 +26,15 @@ export default function TubularsListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: tubulars, responseTime } = useGetObjects(
+  const { objects: tubulars, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.Tubular
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Tubular);
 
@@ -111,6 +114,7 @@ export default function TubularsListView() {
         showRefresh
         downloadToCsvFileName="Tubulars"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/TubularsListView.tsx
@@ -6,7 +6,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import TubularContextMenu from "components/ContextMenus/TubularContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -32,10 +32,7 @@ export default function TubularsListView() {
     wellboreUid,
     ObjectType.Tubular
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.Tubular);
 
   const onContextMenu = (

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
@@ -7,7 +7,7 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import WbGeometryObjectContextMenu from "components/ContextMenus/WbGeometryContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -38,10 +38,7 @@ export default function WbGeometriesListView() {
     wellboreUid,
     ObjectType.WbGeometry
   );
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.WbGeometry);
 
   const getTableData = () => {

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
@@ -32,12 +32,15 @@ export default function WbGeometriesListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: wbGeometries, responseTime } = useGetObjects(
+  const { objects: wbGeometries, responseTime, dataUpdatedAt } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,
     ObjectType.WbGeometry
   );
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.WbGeometry);
 
@@ -134,6 +137,7 @@ export default function WbGeometriesListView() {
         showRefresh
         downloadToCsvFileName="WbGeometries"
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     )
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometriesListView.tsx
@@ -7,7 +7,9 @@ import {
 import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import { ObjectContextMenuProps } from "components/ContextMenus/ObjectMenuItems";
 import WbGeometryObjectContextMenu from "components/ContextMenus/WbGeometryContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
 import { useGetObjects } from "hooks/query/useGetObjects";
@@ -32,7 +34,11 @@ export default function WbGeometriesListView() {
   const navigate = useNavigate();
   const { connectedServer } = useConnectedServer();
   const { wellUid, wellboreUid } = useParams();
-  const { objects: wbGeometries, responseTime, dataUpdatedAt } = useGetObjects(
+  const {
+    objects: wbGeometries,
+    responseTime,
+    dataUpdatedAt
+  } = useGetObjects(
     connectedServer,
     wellUid,
     wellboreUid,

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
@@ -8,6 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import WbGeometrySectionContextMenu, {
   WbGeometrySectionContextMenuProps
 } from "components/ContextMenus/WbGeometrySectionContextMenu";
+import { formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -28,7 +29,10 @@ interface WbGeometrySectionRow extends ContentTableRow {
 }
 
 export default function WbGeometryView() {
-  const { dispatchOperation } = useOperationState();
+  const {
+    dispatchOperation,
+    operationState: { timeZone }
+  } = useOperationState();
   const { wellUid, wellboreUid, objectUid } = useParams();
   const { connectedServer } = useConnectedServer();
   const {
@@ -64,10 +68,7 @@ export default function WbGeometryView() {
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
   const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
-
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.WbGeometry);
 
   const onContextMenu = (

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
@@ -35,7 +35,8 @@ export default function WbGeometryView() {
     object: wbGeometry,
     isFetching: isFetchingWbGeometry,
     isFetched: isFetchedWbGeometry,
-    responseTime: responseTimeObject
+    responseTime: responseTimeObject,
+    dataUpdatedAt: dataUpdatedAtObject
   } = useGetObject(
     connectedServer,
     wellUid,
@@ -47,7 +48,8 @@ export default function WbGeometryView() {
   const {
     components: wbGeometrySections,
     isFetching: isFetchingWbGeometrySections,
-    responseTime: responseTimeComponents
+    responseTime: responseTimeComponents,
+    dataUpdatedAt: dataUpdatedAtComponents
   } = useGetComponents(
     connectedServer,
     wellUid,
@@ -61,6 +63,10 @@ export default function WbGeometryView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
+  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
 
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.WbGeometry);
 
@@ -150,6 +156,7 @@ export default function WbGeometryView() {
         showRefresh
         downloadToCsvFileName={`WbGeometry_${wbGeometry?.name}`}
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     </>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WbGeometryView.tsx
@@ -67,7 +67,10 @@ export default function WbGeometryView() {
   const responseTime = isFetching
     ? 0
     : Math.max(responseTimeObject, responseTimeComponents);
-  const dataUpdatedAt = Math.max(dataUpdatedAtObject ?? 0, dataUpdatedAtComponents ?? 0);
+  const dataUpdatedAt = Math.max(
+    dataUpdatedAtObject ?? 0,
+    dataUpdatedAtComponents ?? 0
+  );
   const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   useExpandSidebarNodes(wellUid, wellboreUid, ObjectType.WbGeometry);
 

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -8,7 +8,9 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import WellboreContextMenu, {
   WellboreContextMenuProps
 } from "components/ContextMenus/WellboreContextMenu";
-import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -8,7 +8,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import WellboreContextMenu, {
   WellboreContextMenuProps
 } from "components/ContextMenus/WellboreContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, {formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -42,14 +42,12 @@ export default function WellboresListView() {
     responseTime: responseTime,
     dataUpdatedAt
   } = useGetWellbores(connectedServer, wellUid);
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
   const isFetching = isFetchingWell || isFetchingWellbores;
   const {
     dispatchOperation,
     operationState: { timeZone, dateTimeFormat }
   } = useOperationState();
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   const navigate = useNavigate();
 
   useExpandSidebarNodes(wellUid);

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellboresListView.tsx
@@ -39,8 +39,12 @@ export default function WellboresListView() {
     wellbores,
     isFetching: isFetchingWellbores,
     isFetched: isFetchedWellbores,
-    responseTime: responseTime
+    responseTime: responseTime,
+    dataUpdatedAt
   } = useGetWellbores(connectedServer, wellUid);
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
   const isFetching = isFetchingWell || isFetchingWellbores;
   const {
     dispatchOperation,
@@ -148,6 +152,7 @@ export default function WellboresListView() {
         checkableRows
         showRefresh
         responseTime={responseTime}
+        lastFetched={lastFetched}
       />
     </>
   );

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -9,7 +9,7 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import WellContextMenu, {
   WellContextMenuProps
 } from "components/ContextMenus/WellContextMenu";
-import formatDateString from "components/DateFormatter";
+import formatDateString, { formatTimeWithOffset } from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";
@@ -33,14 +33,12 @@ export default function WellsListView() {
   } = useGetWells(connectedServer, {
     placeholderData: []
   });
-  const lastFetched = dataUpdatedAt
-    ? new Date(dataUpdatedAt).toLocaleTimeString()
-    : "";
   const { servers } = useGetServers();
   const {
     dispatchOperation,
     operationState: { timeZone, dateTimeFormat }
   } = useOperationState();
+  const lastFetched = formatTimeWithOffset(dataUpdatedAt, timeZone) ?? "";
   const navigate = useNavigate();
 
   const columns: ContentTableColumn[] = [

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -9,7 +9,9 @@ import { getContextMenuPosition } from "components/ContextMenus/ContextMenu";
 import WellContextMenu, {
   WellContextMenuProps
 } from "components/ContextMenus/WellContextMenu";
-import formatDateString, { formatTimeWithOffset } from "components/DateFormatter";
+import formatDateString, {
+  formatTimeWithOffset
+} from "components/DateFormatter";
 import { ProgressSpinnerOverlay } from "components/ProgressSpinner";
 import { useConnectedServer } from "contexts/connectedServerContext";
 import OperationType from "contexts/operationType";

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/WellsListView.tsx
@@ -28,10 +28,14 @@ export default function WellsListView() {
   const {
     wells,
     isFetching,
-    responseTime: responseTime
+    responseTime: responseTime,
+    dataUpdatedAt
   } = useGetWells(connectedServer, {
     placeholderData: []
   });
+  const lastFetched = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : "";
   const { servers } = useGetServers();
   const {
     dispatchOperation,
@@ -116,6 +120,7 @@ export default function WellsListView() {
           downloadToCsvFileName="Wells"
           showRefresh
           responseTime={responseTime}
+          lastFetched={lastFetched}
         />
       )}
     </>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/ContentTable.tsx
@@ -111,6 +111,7 @@ export const ContentTable = React.memo(
       stickyLeftColumns = 0,
       viewId,
       responseTime,
+      lastFetched,
       downloadToCsvFileName = null,
       onRowSelectionChange,
       onFilteredRowSelectionChange,
@@ -423,6 +424,7 @@ export const ContentTable = React.memo(
             disableFilters={disableFilters || nested}
             disableSearchParamsFilter={disableSearchParamsFilter}
             responseTime={responseTime}
+            lastFetched={lastFetched}
           />
         ) : null}
         <div

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
@@ -187,9 +187,7 @@ const Panel = (props: PanelProps) => {
         {responseTime != null && isUserRoleAdvanced(userRole) && (
           <Typography>Response time: {responseTime} ms</Typography>
         )}
-        {lastFetched && (
-          <Typography>Last fetched: {lastFetched}</Typography>
-        )}
+        {lastFetched && <Typography>Last fetched: {lastFetched}</Typography>}
         {panelElements}
       </EdsProvider>
     </PanelContainer>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
@@ -188,7 +188,7 @@ const Panel = (props: PanelProps) => {
           <Typography>Response time: {responseTime} ms</Typography>
         )}
         {lastFetched && (
-          <Typography>Last fetched: {lastFetched} ms</Typography>
+          <Typography>Last fetched: {lastFetched}</Typography>
         )}
         {panelElements}
       </EdsProvider>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
@@ -36,6 +36,7 @@ export interface PanelProps {
   disableFilters?: boolean;
   disableSearchParamsFilter?: boolean;
   responseTime?: number;
+  lastFetched?: string;
 }
 
 const csvIgnoreColumns = ["select", "expander"]; //Ids of the columns that should be ignored when downloading as csv

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/Panel.tsx
@@ -52,6 +52,7 @@ const Panel = (props: PanelProps) => {
     viewId,
     columns,
     responseTime,
+    lastFetched,
     expandableRows = false,
     downloadToCsvFileName = null,
     stickyLeftColumns,
@@ -185,6 +186,9 @@ const Panel = (props: PanelProps) => {
         )}
         {responseTime != null && isUserRoleAdvanced(userRole) && (
           <Typography>Response time: {responseTime} ms</Typography>
+        )}
+        {lastFetched && (
+          <Typography>Last fetched: {lastFetched} ms</Typography>
         )}
         {panelElements}
       </EdsProvider>

--- a/Src/WitsmlExplorer.Frontend/components/ContentViews/table/tableParts.ts
+++ b/Src/WitsmlExplorer.Frontend/components/ContentViews/table/tableParts.ts
@@ -46,6 +46,7 @@ export interface ContentTableProps {
   showPanel?: boolean;
   showRefresh?: boolean;
   responseTime?: number;
+  lastFetched?: string; // Timestamp of when data was last fetched, formatted as time string
   stickyLeftColumns?: number; // how many columns should be sticky
   viewId?: string; //id that will be used to save view settings to local storage, or null if should not save
   downloadToCsvFileName?: string;

--- a/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
+++ b/Src/WitsmlExplorer.Frontend/components/DateFormatter.ts
@@ -47,6 +47,30 @@ function formatDateString(
 
 export default formatDateString;
 
+export function formatTimeWithOffset(
+  dateNumber: number,
+  timeZone: TimeZone
+): string | null {
+  if (!dateNumber) return null;
+
+  try {
+    const date = new Date(dateNumber);
+
+    let offset: string;
+    if (timeZone === TimeZone.Local) {
+      offset = format(date, "xxx");
+    } else if (timeZone === TimeZone.Raw) {
+      offset = "+00:00"; // We don't know the offset of the actual data, but we assume it's UTC.
+    } else {
+      offset = getOffsetFromTimeZone(timeZone);
+    }
+
+    return formatInTimeZone(date, offset, "HH:mm:ss xxx");
+  } catch {
+    return null;
+  }
+}
+
 export function getOffsetFromTimeZone(timeZone: TimeZone): string {
   if (timeZone == TimeZone.Local) {
     return format(new Date(), "xxx");


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes `n/a`

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

This change adds a 'Last Fetched' timestamp display to all content table views, similar to the existing implementation in the Jobs view. This provides users with better visibility into data context.

- Updated `Panel.tsx` to accept and display `lastFetched` prop
- Updated `ContentTableProps` interface in `tableParts.ts`
- Updated `ContentTable.tsx` to pass `lastFetched` to Panel
- Updated 15 list views and 5 detail views to extract `dataUpdatedAt` from React Query hooks and pass it as a formatted timestamp, using `toLocaleTimeString()` for consistency with the Jobs view

**Views Updated**

**List Views:** Wells, Wellbores, Logs, LogCurveInfo, Trajectories, Tubulars, BhaRuns, Rigs, Risks, Messages, FormationMarkers, MudLogs, FluidReports, WbGeometries, ChangeLogs

**Detail Views:** Trajectory, Tubular, WbGeometry, MudLog, Fluids

**NOTES:**

- The `CurveValuesView` was not updated as it has a different architecture
- For views with multiple query hooks (like detail views), the most recent `dataUpdatedAt` is used
- The timestamp format uses `toLocaleTimeString()` consistent with the Jobs view

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [x] Frontend
* [ ] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


