### PR TITLE
FIX-2947 Improve logging for index unit mismatch and potentially fix …

### DIFF
--- a/Src/Witsml/Data/Curves/DepthIndex.cs
+++ b/Src/Witsml/Data/Curves/DepthIndex.cs
@@ -41,7 +41,7 @@ namespace Witsml.Data.Curves
         private Index Subtract(Index that)
         {
             DepthIndex thatIndex = GetDepthFromIndex(that);
-            return HasSameUnitAs(thatIndex) ? new DepthIndex(Value - thatIndex.Value, Uom) : throw new ArgumentException("Cannot subtract depths with different types");
+            return HasSameUnitAs(thatIndex) ? new DepthIndex(Value - thatIndex.Value, Uom) : throw new ArgumentException($"Cannot subtract depths with different unit types: {Value} {Uom} - {thatIndex.Value} {thatIndex.Uom}");
         }
 
         public override int CompareTo(Index that)
@@ -49,7 +49,7 @@ namespace Witsml.Data.Curves
             DepthIndex thatDepthIndex = GetDepthFromIndex(that);
             if (!HasSameUnitAs(thatDepthIndex))
             {
-                throw new ArgumentException("Cannot compare depths with different unit types");
+                throw new ArgumentException($"Cannot compare depths with different unit types: {Value} {Uom} vs {thatDepthIndex.Value} {thatDepthIndex.Uom}");
             }
             var isEqual = Math.Abs(Value - thatDepthIndex.Value) < CommonConstants.DepthIndex.Epsilon;
             return isEqual ? 0 : Value.CompareTo(thatDepthIndex.Value);
@@ -115,7 +115,7 @@ namespace Witsml.Data.Curves
         {
             if (!index1.HasSameUnitAs(index2))
             {
-                throw new ArgumentException("Cannot subtract depths with different types");
+                throw new ArgumentException($"Cannot subtract depths with different unit types: {index1.Value} {index1.Uom} - {index2.Value} {index2.Uom}");
             }
 
             return new DepthIndex(index1.Value - index2.Value, index1.Uom);

--- a/Src/Witsml/Data/Curves/Index.cs
+++ b/Src/Witsml/Data/Curves/Index.cs
@@ -92,7 +92,7 @@ namespace Witsml.Data.Curves
                 ? null
                 : indexType switch
                 {
-                    WitsmlLog.WITSML_INDEX_TYPE_MD => new DepthIndex(double.Parse(logCurveInfo.MinIndex.Value, CultureInfo.InvariantCulture), logCurveInfo.MinIndex.Uom),
+                    WitsmlLog.WITSML_INDEX_TYPE_MD => new DepthIndex(double.Parse(logCurveInfo.MinIndex.Value, CultureInfo.InvariantCulture), logCurveInfo.MinIndex.Uom ?? CommonConstants.DepthIndex.DefaultUnit),
                     WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(logCurveInfo.MinDateTimeIndex, CultureInfo.InvariantCulture)),
                     _ => throw new Exception($"Invalid index type: '{indexType}'")
                 };
@@ -104,7 +104,7 @@ namespace Witsml.Data.Curves
                 ? null
                 : indexType switch
                 {
-                    WitsmlLog.WITSML_INDEX_TYPE_MD => new DepthIndex(double.Parse(logCurveInfo.MaxIndex.Value, CultureInfo.InvariantCulture), logCurveInfo.MaxIndex.Uom),
+                    WitsmlLog.WITSML_INDEX_TYPE_MD => new DepthIndex(double.Parse(logCurveInfo.MaxIndex.Value, CultureInfo.InvariantCulture), logCurveInfo.MaxIndex.Uom ?? CommonConstants.DepthIndex.DefaultUnit),
                     WitsmlLog.WITSML_INDEX_TYPE_DATE_TIME => new DateTimeIndex(DateTime.Parse(logCurveInfo.MaxDateTimeIndex, CultureInfo.InvariantCulture)),
                     _ => throw new Exception($"Invalid index type: '{indexType}'")
                 };


### PR DESCRIPTION
…cause


[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #2947 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

* Improved some logging.
* Hopefully solved the bug by using the same default units if there's no value. If this didn't solve it, just having the index logged when we get the exception can be useful. 

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [ ] API
* [x] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


