### PR TITLE
FIX-3011 Update CredentialsService to support ETP

### DIFF
--- a/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
+++ b/Src/WitsmlExplorer.Api/HttpHandlers/AuthorizeHandler.cs
@@ -65,14 +65,27 @@ namespace WitsmlExplorer.Api.HttpHandlers
         public static async Task<IResult> VerifyUserIsLoggedIn(ConnectionInformation connectionInfo, HttpContext httpContext, [FromServices] ICredentialsService credentialsService)
         {
             EssentialHeaders eh = new(httpContext?.Request);
-            var creds = credentialsService.GetCredentials(eh, connectionInfo.ServerUrl.ToString(), connectionInfo.UserName);
-            if (creds == null)
-            {
-                return TypedResults.Unauthorized();
-            }
+
             try
             {
-                await credentialsService.VerifyCredentials(creds);
+                if (eh.WitsmlProtocol == WitsmlProtocol.Etp)
+                {
+                    ServerCredentials etpCredentials = await credentialsService.GetEtpCredentials(eh, connectionInfo.ServerUrl.ToString(), connectionInfo.UserName);
+                    if (etpCredentials == null)
+                    {
+                        return TypedResults.Unauthorized();
+                    }
+                    await credentialsService.VerifyEtpCredentials(etpCredentials);
+                }
+                else
+                {
+                    ServerCredentials soapCredentials = credentialsService.GetSoapCredentials(eh, connectionInfo.ServerUrl.ToString(), connectionInfo.UserName);
+                    if (soapCredentials == null)
+                    {
+                        return TypedResults.Unauthorized();
+                    }
+                    await credentialsService.VerifySoapCredentials(soapCredentials);
+                }
             }
             catch (Exception)
             {

--- a/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/CredentialsService.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Options;
 
 using Witsml;
 using Witsml.Data;
+using Witsml.ETP;
 using Witsml.Extensions;
 
 using WitsmlExplorer.Api.Configuration;
@@ -24,7 +25,13 @@ using WitsmlExplorer.Api.Repositories;
 
 namespace WitsmlExplorer.Api.Services
 {
-
+    /// <summary>
+    /// Manages credential verification and caching for WITSML server connections supporting both SOAP and ETP protocols.
+    /// 
+    /// Credentials are cached primarily by SOAP server URL. When ETP protocol is required, the service looks up
+    /// the SOAP URL in the server database to retrieve the corresponding ETP endpoint URL, then converts the
+    /// cached SOAP credentials for use with ETP authentication.
+    /// </summary>
     // ReSharper disable once UnusedMember.Global
     public class CredentialsService : ICredentialsService
     {
@@ -59,42 +66,70 @@ namespace WitsmlExplorer.Api.Services
             _enableHttp = StringHelpers.ToBoolean(configuration[ConfigConstants.EnableHttp]);
         }
 
-        public async Task VerifyCredentials(ServerCredentials creds)
+        public async Task VerifySoapCredentials(ServerCredentials soapCredentials)
         {
             var witsmlClient = new WitsmlClient(options =>
             {
-                options.Hostname = creds.Host.ToString();
-                options.Credentials = new WitsmlCredentials(creds.UserId, creds.Password);
+                options.Hostname = soapCredentials.Host.ToString();
+                options.Credentials = new WitsmlCredentials(soapCredentials.UserId, soapCredentials.Password);
                 options.ClientCapabilities = _clientCapabilities;
                 options.EnableHttp = _enableHttp;
             });
             await witsmlClient.TestConnectionAsync();
         }
 
+        public async Task VerifyEtpCredentials(ServerCredentials etpCredentials)
+        {
+            if (etpCredentials?.Host == null)
+            {
+                throw new ArgumentException("ETP host URL is required for ETP credential verification");
+            }
+
+            var sessionOptions = new EtpSessionOptions(
+                Endpoint: etpCredentials.Host,
+                AppName: "Witsml Explorer",
+                AppVersion: "1.0",
+                BasicAuth: new EtpBasicAuthCredentials(etpCredentials.UserId, etpCredentials.Password),
+                RequestedProtocols: null
+            );
+
+            await using var etpClient = await EtpClient.ConnectAsync(sessionOptions);
+            await etpClient.CloseSessionAsync();
+        }
+
         public async Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, HttpContext httpContext)
         {
-            ServerCredentials creds = HttpRequestExtensions.ParseServerHttpHeader(eh.WitsmlAuth, Decrypt);
-            if (creds.IsNullOrEmpty())
+            ServerCredentials soapCredentials = HttpRequestExtensions.ParseServerHttpHeader(eh.WitsmlAuth, Decrypt);
+            if (soapCredentials.IsNullOrEmpty())
             {
                 return false;
             }
+
             string cacheId = GetCacheId(eh);
             if (!_useOAuth2 && (string.IsNullOrEmpty(cacheId) || _credentialsCache.GetItem(cacheId) == null))
             {
                 cacheId = httpContext.CreateWitsmlExplorerCookie(_isDesktopApp);
             }
 
-            await VerifyCredentials(creds);
+            if (eh.WitsmlProtocol == WitsmlProtocol.Etp)
+            {
+                ServerCredentials etpCredentials = await GetEtpCredentialsFromSoapCredentials(soapCredentials);
+                await VerifyEtpCredentials(etpCredentials);
+            }
+            else
+            {
+                await VerifySoapCredentials(soapCredentials);
+            }
 
             double ttl = keep ? 24.0 : 1.0; // hours
-            CacheCredentials(cacheId, creds, ttl);
+            CacheCredentials(cacheId, soapCredentials, ttl);
             return true;
         }
 
-        private async Task<bool> UserHasRoleForHost(string[] roles, Uri host)
+        private async Task<bool> UserHasRoleForHost(string[] roles, Uri soapServerUrl)
         {
             ICollection<Server> allServers = await _witsmlServerRepository.GetDocumentsAsync();
-            bool validRole = allServers.Where(n => n.Url.EqualsIgnoreCase(host)).Any(n => n.Roles != null && n.Roles.Intersect(roles).Any());
+            bool validRole = allServers.Where(n => n.Url.EqualsIgnoreCase(soapServerUrl)).Any(n => n.Roles != null && n.Roles.Intersect(roles).Any());
             return validRole;
         }
 
@@ -125,31 +160,31 @@ namespace WitsmlExplorer.Api.Services
             _credentialsCache.Clear();
         }
 
-        public void CacheCredentials(string cacheId, ServerCredentials credentials, double ttl, Func<string, string> delEncrypt = null)
+        public void CacheCredentials(string cacheId, ServerCredentials soapCredentials, double ttl, Func<string, string> delEncrypt = null)
         {
             delEncrypt ??= Encrypt;
-            string encryptedPassword = delEncrypt(credentials.Password);
-            _credentialsCache.SetItem(cacheId, credentials.Host, encryptedPassword, ttl, credentials.UserId);
+            string encryptedPassword = delEncrypt(soapCredentials.Password);
+            _credentialsCache.SetItem(cacheId, soapCredentials.Host, encryptedPassword, ttl, soapCredentials.UserId);
         }
 
-        private async Task<List<ServerCredentials>> GetSystemCredentialsByToken(string token, Uri server)
+        private async Task<List<ServerCredentials>> GetSystemCredentialsByToken(string token, Uri soapServerUrl)
         {
             List<ServerCredentials> results = new List<ServerCredentials>();
             JwtSecurityTokenHandler handler = new();
             JwtSecurityToken jwt = handler.ReadJwtToken(token);
             string[] userRoles = jwt.Claims.Where(n => n.Type == "roles").Select(n => n.Value).ToArray();
             _logger.LogDebug("User roles in JWT: {roles}", string.Join(",", userRoles));
-            if (await UserHasRoleForHost(userRoles, server))
+            if (await UserHasRoleForHost(userRoles, soapServerUrl))
             {
                 ICollection<Server> allServers = await _witsmlServerRepository.GetDocumentsAsync();
                 List<string> credentialIds = allServers
-                    .Where(n => n.Url.EqualsIgnoreCase(server) && !n.CredentialIds.IsNullOrEmpty())
+                    .Where(n => n.Url.EqualsIgnoreCase(soapServerUrl) && !n.CredentialIds.IsNullOrEmpty())
                     ?.SelectMany(n => n.CredentialIds)
                     ?.ToList()
                     ?? new List<string>();
-                _logger.LogDebug("Matching on {credentialIdOrHost} for server {server}", credentialIds.Count == 0 ? "host" : $"credentialIds {string.Join(", ", credentialIds)}", SanitizeForLog(server));
+                _logger.LogDebug("Matching on {credentialIdOrHost} for server {server}", credentialIds.Count == 0 ? "host" : $"credentialIds {string.Join(", ", credentialIds)}", SanitizeForLog(soapServerUrl));
                 var matchingCredentials = credentialIds.IsNullOrEmpty()
-                    ? _witsmlServerCredentials.WitsmlCreds.Where(n => n.Host.EqualsIgnoreCase(server))
+                    ? _witsmlServerCredentials.WitsmlCreds.Where(n => n.Host.EqualsIgnoreCase(soapServerUrl))
                     : _witsmlServerCredentials.WitsmlCreds.Where(n => credentialIds.Contains(n.CredentialId, StringComparer.InvariantCultureIgnoreCase));
 
                 foreach (var credential in matchingCredentials)
@@ -173,9 +208,9 @@ namespace WitsmlExplorer.Api.Services
 
         public void VerifyUserIsLoggedIn(IEssentialHeaders eh, ServerType serverType)
         {
-            string server = serverType == ServerType.Target ? eh.TargetServer : eh.SourceServer;
+            string soapServer = serverType == ServerType.Target ? eh.TargetServer : eh.SourceServer;
             string username = serverType == ServerType.Target ? eh.TargetUsername : eh.SourceUsername;
-            ServerCredentials creds = GetCredentials(eh, server, username);
+            ServerCredentials creds = GetSoapCredentials(eh, soapServer, username);
             if (creds == null || creds.IsNullOrEmpty())
             {
                 string serverTypeName = serverType == ServerType.Target ? "target" : "source";
@@ -183,13 +218,13 @@ namespace WitsmlExplorer.Api.Services
             }
         }
 
-        public async Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri serverUrl)
+        public async Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri soapServerUrl)
         {
-            Dictionary<string, string> credentials = _credentialsCache.GetItem(GetCacheId(eh), serverUrl);
+            Dictionary<string, string> credentials = _credentialsCache.GetItem(GetCacheId(eh), soapServerUrl);
             List<string> usernames = credentials == null ? new() : credentials.Keys.ToList();
             if (_useOAuth2)
             {
-                List<ServerCredentials> systemCredentials = await GetSystemCredentialsByToken(eh.GetBearerToken(), serverUrl);
+                List<ServerCredentials> systemCredentials = await GetSystemCredentialsByToken(eh.GetBearerToken(), soapServerUrl);
                 foreach (var systemCredential in systemCredentials)
                 {
                     if (!systemCredential.IsNullOrEmpty() && !usernames.Contains(systemCredential.UserId))
@@ -198,14 +233,14 @@ namespace WitsmlExplorer.Api.Services
                     }
                 }
             }
-            _logger.LogDebug("Logged in usernames for server {server}: {usernames}", serverUrl, string.Join(",", usernames));
+            _logger.LogDebug("Logged in usernames for server {server}: {usernames}", soapServerUrl, string.Join(",", usernames));
             return usernames.ToArray();
         }
 
-        private ServerCredentials GetCredentialsFromCache(IEssentialHeaders eh, string serverUrl, string username, Func<string, string> delDecrypt = null)
+        private ServerCredentials GetCredentialsFromCache(IEssentialHeaders eh, string soapServerUrl, string username, Func<string, string> delDecrypt = null)
         {
             delDecrypt ??= Decrypt;
-            Dictionary<string, string> credentials = _credentialsCache.GetItem(GetCacheId(eh), new Uri(serverUrl));
+            Dictionary<string, string> credentials = _credentialsCache.GetItem(GetCacheId(eh), new Uri(soapServerUrl));
             if (credentials == null || !credentials.ContainsKey(username))
             {
                 return null;
@@ -214,18 +249,18 @@ namespace WitsmlExplorer.Api.Services
 
             return new ServerCredentials()
             {
-                Host = new Uri(serverUrl),
+                Host = new Uri(soapServerUrl),
                 UserId = username,
                 Password = password
             };
         }
 
-        public ServerCredentials GetCredentials(IEssentialHeaders eh, string server, string username)
+        public ServerCredentials GetSoapCredentials(IEssentialHeaders eh, string soapServer, string username)
         {
-            ServerCredentials creds = GetCredentialsFromCache(eh, server, username);
+            ServerCredentials creds = GetCredentialsFromCache(eh, soapServer, username);
             if (creds == null && _useOAuth2)
             {
-                List<ServerCredentials> credsList = GetSystemCredentialsByToken(eh.GetBearerToken(), new Uri(server)).Result;
+                List<ServerCredentials> credsList = GetSystemCredentialsByToken(eh.GetBearerToken(), new Uri(soapServer)).Result;
                 creds = credsList.FirstOrDefault(c => string.Equals(c.UserId, username, StringComparison.Ordinal));
                 if (creds == null || creds.IsNullOrEmpty())
                 {
@@ -235,10 +270,42 @@ namespace WitsmlExplorer.Api.Services
             return creds;
         }
 
+        public async Task<ServerCredentials> GetEtpCredentials(IEssentialHeaders eh, string soapServer, string username)
+        {
+            ServerCredentials soapCredentials = GetSoapCredentials(eh, soapServer, username);
+            ServerCredentials etpCredentials = await GetEtpCredentialsFromSoapCredentials(soapCredentials);
+            return etpCredentials;
+        }
+
         public string GetCacheId(IEssentialHeaders eh)
         {
             return _useOAuth2 ? GetClaimFromToken(eh.GetBearerToken(), SUBJECT) : eh.GetCookieValue();
         }
+
+        private async Task<ServerCredentials> GetEtpCredentialsFromSoapCredentials(ServerCredentials soapCredentials)
+        {
+            if (soapCredentials == null || soapCredentials.Host == null)
+            {
+                return null;
+            }
+
+            ICollection<Server> allServers = await _witsmlServerRepository.GetDocumentsAsync();
+            Server matchingServer = allServers.FirstOrDefault(s => s.Url.EqualsIgnoreCase(soapCredentials.Host));
+
+            if (matchingServer?.EtpUrl == null)
+            {
+                return null;
+            }
+
+            return new ServerCredentials
+            {
+                Host = matchingServer.EtpUrl,
+                UserId = soapCredentials.UserId,
+                Password = soapCredentials.Password,
+                CredentialId = soapCredentials.CredentialId
+            };
+        }
+
         /// <summary>
         /// Sanitizes user provided Uri for logging to avoid log-forging attacks.
         /// Removes carriage returns and newlines.

--- a/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
+++ b/Src/WitsmlExplorer.Api/Services/ICredentialsService.cs
@@ -13,11 +13,13 @@ namespace WitsmlExplorer.Api.Services
     {
         public void RemoveCachedCredentials(string cacheId);
         public void VerifyUserIsLoggedIn(IEssentialHeaders eh, ServerType serverType);
-        public Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri serverUrl);
+        public Task<string[]> GetLoggedInUsernames(IEssentialHeaders eh, Uri soapServerUrl);
         public string GetClaimFromToken(string token, string claim);
-        public Task VerifyCredentials(ServerCredentials credentials);
+        public Task VerifySoapCredentials(ServerCredentials soapCredentials);
+        public Task VerifyEtpCredentials(ServerCredentials etpCredentials);
         public Task<bool> VerifyAndCacheCredentials(IEssentialHeaders eh, bool keep, HttpContext httpContext);
-        public ServerCredentials GetCredentials(IEssentialHeaders eh, string server, string username);
+        public ServerCredentials GetSoapCredentials(IEssentialHeaders eh, string soapServer, string username);
+        public Task<ServerCredentials> GetEtpCredentials(IEssentialHeaders eh, string etpServer, string username);
         public string GetCacheId(IEssentialHeaders eh);
     }
 }

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -74,7 +74,7 @@ namespace WitsmlExplorer.Api.Services
         {
             if (_witsmlClient == null)
             {
-                _targetCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
+                _targetCreds = _credentialsService.GetSoapCredentials(_httpHeaders, _httpHeaders.TargetServer, _httpHeaders.TargetUsername);
                 _witsmlClient = (_targetCreds != null && !_targetCreds.IsNullOrEmpty())
                     ? new WitsmlClient(options =>
                     {
@@ -94,7 +94,7 @@ namespace WitsmlExplorer.Api.Services
         {
             if (_witsmlSourceClient == null)
             {
-                _sourceCreds = _credentialsService.GetCredentials(_httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
+                _sourceCreds = _credentialsService.GetSoapCredentials(_httpHeaders, _httpHeaders.SourceServer, _httpHeaders.SourceUsername);
                 _witsmlSourceClient = (_sourceCreds != null && !_sourceCreds.IsNullOrEmpty())
                     ? new WitsmlClient(options =>
                     {

--- a/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/CredentialsServiceTests.cs
@@ -68,6 +68,7 @@ namespace WitsmlExplorer.Api.Tests.Services
                 {
                     Name = "Test Server",
                     Url = new Uri("http://some.url.com"),
+                    EtpUrl = new Uri("wss://some.etp.url.com"),
                     Description = "Testserver for SystemCreds testing",
                     Roles = new List<string>() {"validrole","developer"}
                 },
@@ -123,8 +124,9 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://some.url.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetSoapCredentials(eh, server, "systemuser");
             Assert.True(creds.UserId == "systemuser" && creds.Password == "systempassword");
+            Assert.Equal(new Uri(server), creds.Host);
             _oauthCredentialsService.RemoveAllCachedCredentials();
         }
 
@@ -186,7 +188,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://some.invalidurl.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetSoapCredentials(eh, server, "systemuser");
             Assert.Null(creds);
             _oauthCredentialsService.RemoveAllCachedCredentials();
         }
@@ -197,7 +199,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://url3.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetSoapCredentials(eh, server, "systemuser");
             Assert.Null(creds);
             _oauthCredentialsService.RemoveAllCachedCredentials();
         }
@@ -208,7 +210,7 @@ namespace WitsmlExplorer.Api.Tests.Services
             string server = "http://some.url.com";
             EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "invalidrole" }, false, "tokenuser@arpa.net");
 
-            ServerCredentials creds = _oauthCredentialsService.GetCredentials(eh, server, "systemuser");
+            ServerCredentials creds = _oauthCredentialsService.GetSoapCredentials(eh, server, "systemuser");
             Assert.Null(creds);
             _oauthCredentialsService.RemoveAllCachedCredentials();
         }
@@ -227,8 +229,95 @@ namespace WitsmlExplorer.Api.Tests.Services
             headersMock.SetupGet(x => x.TargetServer).Returns(sc.Host.ToString());
 
             _basicCredentialsService.CacheCredentials(cacheId, sc, 1.0, n => n);
-            ServerCredentials fromCache = _basicCredentialsService.GetCredentials(headersMock.Object, headersMock.Object.TargetServer, userId);
+            ServerCredentials fromCache = _basicCredentialsService.GetSoapCredentials(headersMock.Object, headersMock.Object.TargetServer, userId);
             Assert.Equal(sc, fromCache);
+            _basicCredentialsService.RemoveAllCachedCredentials();
+        }
+
+        [Fact]
+        public async Task GetEtpCredentials_CredentialsInSoapCache_ReturnEtpCredentials()
+        {
+            string userId = "username";
+            string cacheId = Guid.NewGuid().ToString();
+            string soapServer = "http://some.url.com";
+            ServerCredentials soapCredentials = new()
+            {
+                UserId = userId,
+                Password = "dummypassword",
+                Host = new Uri(soapServer)
+            };
+
+            Mock<IEssentialHeaders> headersMock = new();
+            headersMock.Setup(x => x.GetCookieValue()).Returns(cacheId);
+
+            _basicCredentialsService.CacheCredentials(cacheId, soapCredentials, 1.0, n => n);
+            ServerCredentials etpCredentials = await _basicCredentialsService.GetEtpCredentials(headersMock.Object, soapServer, userId);
+
+            Assert.NotNull(etpCredentials);
+            Assert.Equal(new Uri("wss://some.etp.url.com"), etpCredentials.Host);
+            Assert.Equal(soapCredentials.UserId, etpCredentials.UserId);
+            Assert.Equal(soapCredentials.Password, etpCredentials.Password);
+            _basicCredentialsService.RemoveAllCachedCredentials();
+        }
+
+        [Fact]
+        public async Task GetEtpCredentials_ValidTokenAndRoles_ReturnSystemEtpCredentials()
+        {
+            string soapServer = "http://some.url.com";
+            EssentialHeaders eh = CreateEhWithAuthorization(new string[] { "validrole" }, false, "tokenuser@arpa.net");
+
+            ServerCredentials etpCredentials = await _oauthCredentialsService.GetEtpCredentials(eh, soapServer, "systemuser");
+
+            Assert.NotNull(etpCredentials);
+            Assert.Equal(new Uri("wss://some.etp.url.com"), etpCredentials.Host);
+            Assert.Equal("systemuser", etpCredentials.UserId);
+            Assert.Equal("systempassword", etpCredentials.Password);
+            _oauthCredentialsService.RemoveAllCachedCredentials();
+        }
+
+        [Fact]
+        public async Task GetEtpCredentials_ServerWithoutEtpUrl_ReturnNull()
+        {
+            string userId = "username";
+            string cacheId = Guid.NewGuid().ToString();
+            string soapServer = "http://some.url.without.its.own.keyvault.secret.com";
+            ServerCredentials soapCredentials = new()
+            {
+                UserId = userId,
+                Password = "dummypassword",
+                Host = new Uri(soapServer)
+            };
+
+            Mock<IEssentialHeaders> headersMock = new();
+            headersMock.Setup(x => x.GetCookieValue()).Returns(cacheId);
+
+            _basicCredentialsService.CacheCredentials(cacheId, soapCredentials, 1.0, n => n);
+            ServerCredentials etpCredentials = await _basicCredentialsService.GetEtpCredentials(headersMock.Object, soapServer, userId);
+
+            Assert.Null(etpCredentials);
+            _basicCredentialsService.RemoveAllCachedCredentials();
+        }
+
+        [Fact]
+        public async Task GetEtpCredentials_UnknownSoapServer_ReturnNull()
+        {
+            string userId = "username";
+            string cacheId = Guid.NewGuid().ToString();
+            string soapServer = "http://unknown.url.com";
+            ServerCredentials soapCredentials = new()
+            {
+                UserId = userId,
+                Password = "dummypassword",
+                Host = new Uri(soapServer)
+            };
+
+            Mock<IEssentialHeaders> headersMock = new();
+            headersMock.Setup(x => x.GetCookieValue()).Returns(cacheId);
+
+            _basicCredentialsService.CacheCredentials(cacheId, soapCredentials, 1.0, n => n);
+            ServerCredentials etpCredentials = await _basicCredentialsService.GetEtpCredentials(headersMock.Object, soapServer, userId);
+
+            Assert.Null(etpCredentials);
             _basicCredentialsService.RemoveAllCachedCredentials();
         }
 


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #3011 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

Updated CredentialsService with new methods to get the ETP credentials.
All credentials are stored under the SOAP url, so the SOAP url is normally used as input to the methods even for ETP. The ETP and SOAP credentials are the same, so we lookup the ETP url from the database server list and switch out the SOAP url with the corresponding ETP url in the returned credentials.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [ ] New feature (non-breaking change which adds functionality)
* [x] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [x] API
* [ ] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [x] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [x] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


