### PR TITLE
FIX-3026 Add logging of ETP messages

### DIFF
--- a/Src/Witsml/ETP/CoreProtocolHandler.cs
+++ b/Src/Witsml/ETP/CoreProtocolHandler.cs
@@ -120,24 +120,28 @@ internal sealed class CoreProtocolHandler
         }
     }
 
-    public async Task TryHandleAsync(int messageType, BinaryDecoder decoder, CancellationToken cancellationToken)
+    public async Task TryHandleAsync(MessageHeader header, BinaryDecoder decoder, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(header);
+
+        var messageType = header.messageType;
         if (messageType == OpenSessionMessageType)
         {
-            await HandleOpenSessionAsync(decoder, cancellationToken);
+            await HandleOpenSessionAsync(header, decoder, cancellationToken);
             return;
         }
 
         if (messageType == CloseSessionMessageType)
         {
-            await HandleCloseSessionAsync(decoder, cancellationToken);
+            await HandleCloseSessionAsync(header, decoder, cancellationToken);
         }
     }
 
-    private async Task HandleOpenSessionAsync(BinaryDecoder decoder, CancellationToken cancellationToken)
+    private async Task HandleOpenSessionAsync(MessageHeader header, BinaryDecoder decoder, CancellationToken cancellationToken)
     {
         var openSessionReader = new SpecificReader<OpenSession>(OpenSession._SCHEMA, OpenSession._SCHEMA);
         var openSession = openSessionReader.Read(new OpenSession(), decoder);
+        _clientContext.LogReceivedMessage(header, openSession);
         var sessionId = Guid.TryParse(openSession.sessionId, out var parsed) ? parsed : (Guid?)null;
         var capabilities = openSession.ToServerCapabilities(sessionId);
 
@@ -152,10 +156,11 @@ internal sealed class CoreProtocolHandler
         }
     }
 
-    private async Task HandleCloseSessionAsync(BinaryDecoder decoder, CancellationToken cancellationToken)
+    private async Task HandleCloseSessionAsync(MessageHeader header, BinaryDecoder decoder, CancellationToken cancellationToken)
     {
         var closeSessionReader = new SpecificReader<CloseSession>(CloseSession._SCHEMA, CloseSession._SCHEMA);
         var closeSession = closeSessionReader.Read(new CloseSession(), decoder);
+        _clientContext.LogReceivedMessage(header, closeSession);
         var reason = string.IsNullOrWhiteSpace(closeSession.reason)
             ? "The server closed the ETP session."
             : closeSession.reason;

--- a/Src/Witsml/ETP/DiscoveryProtocolHandler.cs
+++ b/Src/Witsml/ETP/DiscoveryProtocolHandler.cs
@@ -7,7 +7,9 @@ using System.Threading.Tasks;
 using Avro.IO;
 using Avro.Specific;
 
+using Energistics.Datatypes;
 using Energistics.Datatypes.Object;
+using Energistics.Protocol.Core;
 using Energistics.Protocol.Discovery;
 
 namespace Witsml.ETP;
@@ -63,21 +65,32 @@ internal sealed class DiscoveryProtocolHandler
         }
     }
 
-    public void TryHandle(int messageType, long correlationId, int messageFlags, BinaryDecoder decoder)
+    public void TryHandle(MessageHeader header, BinaryDecoder decoder)
     {
+        ArgumentNullException.ThrowIfNull(header);
+
+        var messageType = header.messageType;
+        var correlationId = header.correlationId;
+        var messageFlags = header.messageFlags;
+
         if (!_pendingGetResourcesByRequestId.TryGetValue(correlationId, out var pendingRequest))
         {
             return;
         }
 
-        if (EtpMessageHelpers.TryReadProtocolException(messageType, decoder, "Discovery.GetResources", out var protocolException))
+        if (EtpMessageHelpers.TryReadProtocolException(messageType, decoder, "Discovery.GetResources", out var protocolException, out var protocolExceptionBody))
         {
+            _clientContext.LogReceivedMessage(header, protocolExceptionBody);
             pendingRequest.Completion.TrySetException(protocolException);
             return;
         }
 
         if (messageType == EtpMessageHelpers.AcknowledgeMessageType)
         {
+            var ackReader = new SpecificReader<Acknowledge>(Acknowledge._SCHEMA, Acknowledge._SCHEMA);
+            var acknowledge = ackReader.Read(new Acknowledge(), decoder);
+            _clientContext.LogReceivedMessage(header, acknowledge);
+
             if (EtpMessageHelpers.HasMessageFlag(messageFlags, EtpMessageHelpers.NoDataMessageFlag))
             {
                 pendingRequest.Completion.TrySetResult(new List<Resource>());
@@ -110,6 +123,7 @@ internal sealed class DiscoveryProtocolHandler
 
         var responseReader = new SpecificReader<GetResourcesResponse>(GetResourcesResponse._SCHEMA, GetResourcesResponse._SCHEMA);
         var response = responseReader.Read(new GetResourcesResponse(), decoder);
+        _clientContext.LogReceivedMessage(header, response);
         if (response?.resource != null)
         {
             lock (pendingRequest)

--- a/Src/Witsml/ETP/EtpClient.cs
+++ b/Src/Witsml/ETP/EtpClient.cs
@@ -27,6 +27,8 @@ public class EtpClient : EtpWebSocketTransport, IEtpClient, ICoreProtocolHandler
     private readonly CoreProtocolHandler _coreProtocolHandler;
     private readonly DiscoveryProtocolHandler _discoveryProtocolHandler;
     private readonly StoreProtocolHandler _storeProtocolHandler;
+    private readonly Uri _endpoint;
+    private IEtpMessageLogger _messageLogger;
     private EtpServerCapabilities _serverCapabilities;
     private long _messageId;
     private DateTime _lastMessageSentUtc;
@@ -35,9 +37,11 @@ public class EtpClient : EtpWebSocketTransport, IEtpClient, ICoreProtocolHandler
     private EtpClient(EtpSessionOptions sessionOptions, Func<ClientWebSocket> webSocketFactory) : base(webSocketFactory)
     {
         var options = sessionOptions ?? throw new ArgumentNullException(nameof(sessionOptions));
+        _endpoint = options.Endpoint;
         _coreProtocolHandler = new CoreProtocolHandler(this, options);
         _discoveryProtocolHandler = new DiscoveryProtocolHandler(this);
         _storeProtocolHandler = new StoreProtocolHandler(this);
+        SetupMessageLogging(options.LogMessages);
     }
 
     public static async Task<EtpClient> ConnectAsync(EtpSessionOptions sessionOptions, Func<ClientWebSocket> webSocketFactory = null, CancellationToken cancellationToken = default)
@@ -63,6 +67,17 @@ public class EtpClient : EtpWebSocketTransport, IEtpClient, ICoreProtocolHandler
     {
         ThrowIfDisposed();
         return _serverCapabilities;
+    }
+
+    private void SetupMessageLogging(bool logMessages)
+    {
+        if (!logMessages) return;
+        SetMessageLogger(new DefaultEtpMessageLogger());
+    }
+
+    public void SetMessageLogger(IEtpMessageLogger messageLogger)
+    {
+        _messageLogger = messageLogger;
     }
 
     protected override async Task OnDisposingAsync()
@@ -94,15 +109,16 @@ public class EtpClient : EtpWebSocketTransport, IEtpClient, ICoreProtocolHandler
         switch (header.protocol)
         {
             case CoreProtocolHandler.ProtocolId:
-                await _coreProtocolHandler.TryHandleAsync(header.messageType, decoder, cancellationToken);
+                await _coreProtocolHandler.TryHandleAsync(header, decoder, cancellationToken);
                 break;
             case DiscoveryProtocolHandler.ProtocolId:
-                _discoveryProtocolHandler.TryHandle(header.messageType, header.correlationId, header.messageFlags, decoder);
+                _discoveryProtocolHandler.TryHandle(header, decoder);
                 break;
             case StoreProtocolHandler.ProtocolId:
-                _storeProtocolHandler.TryHandle(header.messageType, header.correlationId, header.messageFlags, decoder);
+                _storeProtocolHandler.TryHandle(header, decoder);
                 break;
             default:
+                LogEtpMessage("Received", header, payload.ToArray());
                 break;
         }
     }
@@ -117,6 +133,8 @@ public class EtpClient : EtpWebSocketTransport, IEtpClient, ICoreProtocolHandler
 
     Task IProtocolHandlerContext.SendEtpMessageAsync<TBody>(int protocol, int messageType, TBody body, CancellationToken cancellationToken, long? messageId) => SendEtpMessageAsync(protocol, messageType, body, cancellationToken, messageId);
     long IProtocolHandlerContext.ReserveMessageId() => ReserveMessageId();
+    void IProtocolHandlerContext.LogReceivedMessage(MessageHeader header, object body) =>
+        LogEtpMessage("Received", header, body);
 
     private async Task SendEtpMessageAsync<TBody>(int protocol, int messageType, TBody body, CancellationToken cancellationToken, long? messageId = null) where TBody : ISpecificRecord
     {
@@ -145,8 +163,15 @@ public class EtpClient : EtpWebSocketTransport, IEtpClient, ICoreProtocolHandler
         var bodyWriter = new SpecificWriter<TBody>(body.Schema);
         bodyWriter.Write(body, encoder);
 
+        LogEtpMessage("Sent", header, body);
         await SendMessageAsync(stream.ToArray(), WebSocketMessageType.Binary, cancellationToken);
         _lastMessageSentUtc = DateTime.UtcNow;
+    }
+
+    private void LogEtpMessage(string direction, MessageHeader header, object body = null)
+    {
+        if (_messageLogger == null) return;
+        _messageLogger.LogMessage(direction, _endpoint, header, body);
     }
 
     private long ReserveMessageId()

--- a/Src/Witsml/ETP/EtpMessageHelpers.cs
+++ b/Src/Witsml/ETP/EtpMessageHelpers.cs
@@ -18,9 +18,10 @@ internal static class EtpMessageHelpers
 
     internal static bool HasMessageFlag(int messageFlags, int flag) => (messageFlags & flag) == flag;
 
-    internal static bool TryReadProtocolException(int messageType, BinaryDecoder decoder, string operationName, out Exception exception)
+    internal static bool TryReadProtocolException(int messageType, BinaryDecoder decoder, string operationName, out Exception exception, out ProtocolException protocolException)
     {
         exception = null;
+        protocolException = null;
 
         if (messageType != ProtocolExceptionMessageType)
         {
@@ -28,7 +29,7 @@ internal static class EtpMessageHelpers
         }
 
         var protocolExceptionReader = new SpecificReader<ProtocolException>(ProtocolException._SCHEMA, ProtocolException._SCHEMA);
-        var protocolException = protocolExceptionReader.Read(new ProtocolException(), decoder);
+        protocolException = protocolExceptionReader.Read(new ProtocolException(), decoder);
         var errorCode = protocolException?.errorCode;
         var errorMessage = string.IsNullOrWhiteSpace(protocolException?.errorMessage)
             ? "Unknown protocol error."

--- a/Src/Witsml/ETP/EtpMessageLogger.cs
+++ b/Src/Witsml/ETP/EtpMessageLogger.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Witsml.ETP;
+
+public interface IEtpMessageLogger
+{
+    /// <summary>
+    /// Logs a raw ETP message payload together with basic header metadata when available.
+    /// </summary>
+    /// <param name="direction">Message direction (Sent/Received)</param>
+    /// <param name="endpoint">ETP endpoint URI</param>
+    /// <param name="header">ETP message header</param>
+    /// <param name="body">ETP message body if available</param>
+    void LogMessage(
+        string direction,
+        Uri endpoint,
+        object header,
+        object body);
+}
+
+public class DefaultEtpMessageLogger : IEtpMessageLogger
+{
+    private readonly Logger _logger;
+
+    public DefaultEtpMessageLogger()
+    {
+        _logger = new LoggerConfiguration()
+            .Destructure.With<SchemaOmittingDestructuringPolicy>()
+            .WriteTo.File("etpMessages.log", rollOnFileSizeLimit: true, retainedFileCountLimit: 1, fileSizeLimitBytes: 50000000)
+            .CreateLogger();
+    }
+
+    public void LogMessage(
+        string direction,
+        Uri endpoint,
+        object header,
+        object body)
+    {
+        _logger.Information(
+            "Direction: {Direction}\nEndpoint: {Endpoint}\nHeader:\n{@Header}\nBody:\n{@Body}",
+            direction,
+            endpoint,
+            header,
+            body);
+    }
+}
+
+public class SchemaOmittingDestructuringPolicy : IDestructuringPolicy
+{
+    public bool TryDestructure(
+        object value,
+        ILogEventPropertyValueFactory propertyValueFactory,
+        out LogEventPropertyValue result)
+    {
+        result = null;
+        if (value == null) return false;
+
+        var type = value.GetType();
+        var properties = type.GetProperties();
+
+        var hasSchema = false;
+        foreach (var property in properties)
+        {
+            if (string.Equals(property.Name, "Schema", StringComparison.OrdinalIgnoreCase))
+            {
+                hasSchema = true;
+                break;
+            }
+        }
+
+        if (!hasSchema) return false;
+
+        var structuredProperties = new List<LogEventProperty>();
+        foreach (var property in properties)
+        {
+            if (!property.CanRead) continue;
+            if (property.GetIndexParameters().Length != 0) continue;
+            if (string.Equals(property.Name, "Schema", StringComparison.OrdinalIgnoreCase)) continue;
+
+            object propertyValue;
+            try
+            {
+                propertyValue = property.GetValue(value);
+            }
+            catch
+            {
+                propertyValue = "<unavailable>";
+            }
+
+            structuredProperties.Add(new LogEventProperty(property.Name, propertyValueFactory.CreatePropertyValue(propertyValue, true)));
+        }
+
+        result = new StructureValue(structuredProperties, type.Name);
+        return true;
+    }
+}

--- a/Src/Witsml/ETP/EtpOptions.cs
+++ b/Src/Witsml/ETP/EtpOptions.cs
@@ -10,6 +10,7 @@ public sealed record EtpSessionOptions
     string AppVersion,
     EtpBasicAuthCredentials BasicAuth,
     IReadOnlyList<RequestedProtocol> RequestedProtocols,
+    bool LogMessages = false,
     IReadOnlyDictionary<string, string> HttpHeaders = null
 );
 

--- a/Src/Witsml/ETP/IProtocolHandlerContext.cs
+++ b/Src/Witsml/ETP/IProtocolHandlerContext.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 
 using Avro.Specific;
 
+using Energistics.Datatypes;
+
 namespace Witsml.ETP;
 
 /// <summary>
@@ -12,4 +14,5 @@ internal interface IProtocolHandlerContext
 {
     Task SendEtpMessageAsync<TBody>(int protocol, int messageType, TBody body, CancellationToken cancellationToken, long? messageId = null) where TBody : ISpecificRecord;
     long ReserveMessageId();
+    void LogReceivedMessage(MessageHeader header, object body);
 }

--- a/Src/Witsml/ETP/StoreProtocolHandler.cs
+++ b/Src/Witsml/ETP/StoreProtocolHandler.cs
@@ -12,7 +12,9 @@ using System.Threading.Tasks;
 using Avro.IO;
 using Avro.Specific;
 
+using Energistics.Datatypes;
 using Energistics.Datatypes.Object;
+using Energistics.Protocol.Core;
 using Energistics.Protocol.Store;
 
 using Witsml.Data;
@@ -286,24 +288,31 @@ internal sealed class StoreProtocolHandler
         return outputStream.ToArray();
     }
 
-    public void TryHandle(int messageType, long correlationId, int messageFlags, BinaryDecoder decoder)
+    public void TryHandle(MessageHeader header, BinaryDecoder decoder)
     {
+        ArgumentNullException.ThrowIfNull(header);
+        var correlationId = header.correlationId;
+
         if (_pendingGetObjectByRequestId.TryGetValue(correlationId, out var getObjectRequest))
         {
-            HandleGetObjectResponse(messageType, messageFlags, decoder, getObjectRequest);
+            HandleGetObjectResponse(header, decoder, getObjectRequest, _clientContext);
             return;
         }
 
         if (_pendingAcknowledgeByRequestId.TryGetValue(correlationId, out var ackRequest))
         {
-            HandleAcknowledgeResponse(messageType, decoder, ackRequest);
+            HandleAcknowledgeResponse(header, decoder, ackRequest, _clientContext);
         }
     }
 
-    private static void HandleGetObjectResponse(int messageType, int messageFlags, BinaryDecoder decoder, PendingGetObjectRequest pendingRequest)
+    private static void HandleGetObjectResponse(MessageHeader header, BinaryDecoder decoder, PendingGetObjectRequest pendingRequest, IProtocolHandlerContext clientContext)
     {
-        if (EtpMessageHelpers.TryReadProtocolException(messageType, decoder, "Store.GetObject", out var protocolException))
+        var messageType = header.messageType;
+        var messageFlags = header.messageFlags;
+
+        if (EtpMessageHelpers.TryReadProtocolException(messageType, decoder, "Store.GetObject", out var protocolException, out var protocolExceptionBody))
         {
+            clientContext.LogReceivedMessage(header, protocolExceptionBody);
             pendingRequest.Completion.TrySetException(protocolException);
             return;
         }
@@ -321,6 +330,7 @@ internal sealed class StoreProtocolHandler
 
         var responseReader = new SpecificReader<Energistics.Protocol.Store.Object>(Energistics.Protocol.Store.Object._SCHEMA, Energistics.Protocol.Store.Object._SCHEMA);
         var response = responseReader.Read(new Energistics.Protocol.Store.Object(), decoder);
+        clientContext.LogReceivedMessage(header, response);
         if (response?.dataObject != null)
         {
             lock (pendingRequest)
@@ -351,16 +361,22 @@ internal sealed class StoreProtocolHandler
         pendingRequest.Completion.TrySetResult(result);
     }
 
-    private static void HandleAcknowledgeResponse(int messageType, BinaryDecoder decoder, PendingAcknowledgeRequest pendingRequest)
+    private static void HandleAcknowledgeResponse(MessageHeader header, BinaryDecoder decoder, PendingAcknowledgeRequest pendingRequest, IProtocolHandlerContext clientContext)
     {
-        if (EtpMessageHelpers.TryReadProtocolException(messageType, decoder, "Store", out var protocolException))
+        var messageType = header.messageType;
+
+        if (EtpMessageHelpers.TryReadProtocolException(messageType, decoder, "Store", out var protocolException, out var protocolExceptionBody))
         {
+            clientContext.LogReceivedMessage(header, protocolExceptionBody);
             pendingRequest.Completion.TrySetException(protocolException);
             return;
         }
 
         if (messageType == EtpMessageHelpers.AcknowledgeMessageType)
         {
+            var ackReader = new SpecificReader<Acknowledge>(Acknowledge._SCHEMA, Acknowledge._SCHEMA);
+            var acknowledge = ackReader.Read(new Acknowledge(), decoder);
+            clientContext.LogReceivedMessage(header, acknowledge);
             pendingRequest.Completion.TrySetResult();
         }
     }

--- a/Src/WitsmlExplorer.Api/Services/ETP/EtpSessionManager.cs
+++ b/Src/WitsmlExplorer.Api/Services/ETP/EtpSessionManager.cs
@@ -5,10 +5,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Witsml.ETP;
+
+using WitsmlExplorer.Api.Configuration;
 
 namespace WitsmlExplorer.Api.Services.ETP;
 
@@ -18,16 +21,19 @@ public class EtpSessionManager : IEtpSessionManager, IAsyncDisposable
     private readonly SemaphoreSlim _sessionCreationLock = new(1, 1);
     private readonly SessionManagerOptions _options;
     private readonly ILogger<EtpSessionManager> _logger;
+    private readonly bool _logMessages;
     private readonly Func<EtpSessionOptions, CancellationToken, Task<IEtpClient>> _clientFactory;
     public int SessionCount => _sessions.Count;
 
     public EtpSessionManager(
+        IConfiguration configuration,
         IOptions<SessionManagerOptions> options,
         ILogger<EtpSessionManager> logger,
         Func<EtpSessionOptions, CancellationToken, Task<IEtpClient>> clientFactory = null)
     {
         _options = options.Value;
         _logger = logger;
+        _logMessages = StringHelpers.ToBoolean(configuration[ConfigConstants.LogQueries]);
         _clientFactory = clientFactory ?? DefaultClientFactoryAsync;
     }
 
@@ -62,7 +68,8 @@ public class EtpSessionManager : IEtpSessionManager, IAsyncDisposable
                 _options.AppName,
                 _options.AppVersion,
                 new EtpBasicAuthCredentials(options.Username, options.Password),
-                new List<RequestedProtocol> { RequestedProtocol.Discovery, RequestedProtocol.Store }
+                new List<RequestedProtocol> { RequestedProtocol.Discovery, RequestedProtocol.Store },
+                _logMessages
             );
 
             IEtpClient client;

--- a/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
+++ b/Src/WitsmlExplorer.Api/Services/WitsmlClientProvider.cs
@@ -2,7 +2,6 @@ using System;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Witsml;

--- a/Tests/WitsmlExplorer.Api.Tests/Services/EtpSessionManagerTests.cs
+++ b/Tests/WitsmlExplorer.Api.Tests/Services/EtpSessionManagerTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -10,6 +11,7 @@ using Moq;
 
 using Witsml.ETP;
 
+using WitsmlExplorer.Api.Configuration;
 using WitsmlExplorer.Api.Services.ETP;
 
 using Xunit;
@@ -19,7 +21,13 @@ namespace WitsmlExplorer.Api.Tests.Services;
 public class EtpSessionManagerTests
 {
     private readonly SessionManagerOptions _managerOptions = new() { IdleTimeout = TimeSpan.FromSeconds(1), AppName = "TestApp", AppVersion = "1.0.0" };
+    private readonly Mock<IConfiguration> _configuration = new();
     private readonly Mock<ILogger<EtpSessionManager>> _logger = new();
+
+    public EtpSessionManagerTests()
+    {
+        _configuration.SetupGet(c => c[ConfigConstants.LogQueries]).Returns("false");
+    }
 
     private static SessionKey MakeKey(string userId = "user1", string username = "etpuser", string uri = "wss://etp-server.com") =>
         new(userId, username, new Uri(uri));
@@ -29,7 +37,7 @@ public class EtpSessionManagerTests
 
     private EtpSessionManager CreateManager(Func<EtpSessionOptions, CancellationToken, Task<IEtpClient>> clientFactory = null)
     {
-        return new EtpSessionManager(Options.Create(_managerOptions), _logger.Object, clientFactory);
+        return new EtpSessionManager(_configuration.Object, Options.Create(_managerOptions), _logger.Object, clientFactory);
     }
 
     [Fact]


### PR DESCRIPTION
[//]: # (Request Template Witsml Explorer)

[//]: # (Thank you for contributing to WITSML Explorer! Before submitting this PR, please fill in the following template.)

## Fixes

[//]: # (Write the GitHub issue number starting with #, or, for Equinor only, the Jira issue number starting with WE-)

This pull request fixes #3026 

## Description

[//]: # (Please include a written summary of the changes and which issue is fixed. List any dependencies that are required for this change._)

If the LogQueries option is enabled we will now log ETP messages to file similar to how it's done for SOAP.
Note: The Data field (if relevant for the ETP message) is not fully logged and not in a readable format (example: "data":"1F8B080000000000000A8D57DB6EDB38... (1466 bytes)"). This is primarily for the ETP messages themselves. We might want to change this later if we also need to log the data itself.

## Type of change

[//]: # (Mark any of the types of change that apply.)

* [ ] Bugfix
* [x] New feature (non-breaking change which adds functionality)
* [ ] Enhancement of existing functionality
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Impacted Areas in Application

[//]: # (List general components of the application that this PR will affect)

* [ ] Frontend
* [x] API
* [x] WITSML
* [ ] Desktop
* [ ] Other (please describe)

## Checklist:

[//]: # (Please tick all the boxes or remove the ones that aren't needed and explain why)

*Communication*
* [ ] I have made corresponding changes to the documentation
* [ ] PR affects application security

*Code quality*
* [x] I have self-reviewed my code
* [x] No new warnings are generated

*Test coverage*
* [ ] New code is covered by passing tests

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)


